### PR TITLE
fix: Don't embed the icon font

### DIFF
--- a/packages/fuselage/.storybook/config.js
+++ b/packages/fuselage/.storybook/config.js
@@ -34,6 +34,7 @@ addParameters({
 addDecorator(withTests({ results }));
 
 configure(() => {
+  require('@rocket.chat/icons/dist/font/RocketChat.minimal.css');
   const requireStories = require.context('../src', true, /stories(\/index)?\.js$/);
   requireStories.keys().forEach(requireStories);
 }, module);

--- a/packages/fuselage/src/components/Icon/index.js
+++ b/packages/fuselage/src/components/Icon/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as characters from '@rocket.chat/icons/dist/font/characters';
 import * as names from '@rocket.chat/icons/dist/font/index';
-import '@rocket.chat/icons/dist/font/RocketChat.minimal.css';
 
 import { useStyle } from '../../hooks/styles';
 import styles from './styles.scss';


### PR DESCRIPTION
Assets, like images and fonts, must be manually embedded to compatible to any build system.