### PR TITLE
feat: add export to darkMode provider

### DIFF
--- a/packages/onboarding-ui/src/index.ts
+++ b/packages/onboarding-ui/src/index.ts
@@ -10,3 +10,4 @@ export { default as MagicLinkEmailPage } from './pages/MagicLinkEmailPage';
 export { default as OrganizationInfoPage } from './pages/OrganizationInfoPage';
 export { default as RegisterServerPage } from './pages/RegisterServerPage';
 export { default as RequestTrialPage } from './pages/RequestTrialPage';
+export { default as DarkModeProvider } from './common/DarkModeProvider';


### PR DESCRIPTION
add export to darkModeProvider (to be able to use dark mode in the projects where this is a dependency)