### PR TITLE
fix: handling visibility of options in multiselect

### DIFF
--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
@@ -117,6 +117,8 @@ export const MultiSelect = forwardRef(
     const [cursor, handleKeyDown, handleKeyUp, reset, [visible, hide, show]] =
       useCursor(index, filteredOptions, internalChanged);
 
+    const [visibility, setVisibility] = useState(visible);
+
     useEffect(reset, [filter]);
 
     const innerRef = useRef<HTMLElement>(null);
@@ -145,9 +147,11 @@ export const MultiSelect = forwardRef(
         className={[error && 'invalid', disabled && 'disabled']}
         ref={containerRef}
         onClick={useMutableCallback(() => {
-          if (visible === AnimatedVisibility.VISIBLE) {
+          if (visibility === AnimatedVisibility.VISIBLE) {
+            setVisibility('hidden');
             return hide();
           }
+          setVisibility('visible');
           innerRef.current?.focus();
           return show();
         })}
@@ -217,7 +221,7 @@ export const MultiSelect = forwardRef(
               children={
                 <Icon
                   name={
-                    visible === AnimatedVisibility.VISIBLE
+                    visibility === AnimatedVisibility.VISIBLE
                       ? 'cross'
                       : addonIcon || 'chevron-down'
                   }
@@ -227,7 +231,7 @@ export const MultiSelect = forwardRef(
             />
           </Margins>
         </Flex.Item>
-        <AnimatedVisibility visibility={visible}>
+        <AnimatedVisibility visibility={visibility}>
           <Position anchor={containerRef}>
             <_Options
               width={borderBoxSize.inlineSize}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
The multiselect component had an outer `Box` which handled the visibility of the `AnimatedVisibility` when clicked. So, this was getting overlapped with the actual anchorSelect's onClick. So when we press a click outside of the anchorSelect, it responds to us by going from -> hidden -> visible in one click.

![multiselect-visibility](https://user-images.githubusercontent.com/73601258/163398679-5e1899ee-74ca-4b68-bf58-db3a27f0128b.png)

So, with this change we handle the visibility in a state keeping track of the "click to the outer box" and changing it to hidden/visible correctly.
```javascript
if (visibility === AnimatedVisibility.VISIBLE) {
       setVisibility('hidden');
       return hide();
 }
      setVisibility('visible'); // here "visible" was coming out to be hidden, so when we click on cross we again come here
      innerRef.current?.focus();
      return show();
```
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
## Before

https://user-images.githubusercontent.com/73601258/163399659-e93c6c6e-8426-4f53-9c35-039ff84bbc50.mp4



## After

https://user-images.githubusercontent.com/73601258/163399695-152ad71c-30b3-4e96-8b99-c3d6baea7ee7.mp4




<!-- END CHANGELOG -->

## Issue(s)
fixes #696
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
