### PR TITLE
[New] `MediumMultilineInput` and `LargeMultilineInput` Elements

### DIFF
--- a/packages/fuselage-ui-kit/src/elements/PlainTextInputElement.tsx
+++ b/packages/fuselage-ui-kit/src/elements/PlainTextInputElement.tsx
@@ -16,7 +16,7 @@ const PlainTextInputElement = ({
 }: PlainTextInputElementProps): ReactElement => {
   const [{ loading, value, error }, action] = useUiKitState(block, context);
 
-  if (block.multilineLarge) {
+  if (block.multiline && block.multilineSize === 'large') {
     return (
       <TextAreaInput
         disabled={loading}
@@ -35,7 +35,7 @@ const PlainTextInputElement = ({
     );
   }
 
-  if (block.multilineMedium) {
+  if (block.multiline && block.multilineSize === 'medium') {
     return (
       <TextAreaInput
         disabled={loading}
@@ -54,7 +54,7 @@ const PlainTextInputElement = ({
     );
   }
 
-  if (block.multiline || block.multilineSmall) {
+  if (block.multiline || (block.multiline && block.multilineSize === 'small')) {
     return (
       <TextAreaInput
         disabled={loading}

--- a/packages/fuselage-ui-kit/src/elements/PlainTextInputElement.tsx
+++ b/packages/fuselage-ui-kit/src/elements/PlainTextInputElement.tsx
@@ -16,7 +16,45 @@ const PlainTextInputElement = ({
 }: PlainTextInputElementProps): ReactElement => {
   const [{ loading, value, error }, action] = useUiKitState(block, context);
 
-  if (block.multiline) {
+  if (block.multilineLarge) {
+    return (
+      <TextAreaInput
+        disabled={loading}
+        id={block.actionId}
+        name={block.actionId}
+        rows={30}
+        error={error}
+        value={value}
+        onChange={action}
+        placeholder={
+          block.placeholder
+            ? fromTextObjectToString(surfaceRenderer, block.placeholder, 0)
+            : undefined
+        }
+      />
+    );
+  }
+
+  if (block.multilineMedium) {
+    return (
+      <TextAreaInput
+        disabled={loading}
+        id={block.actionId}
+        name={block.actionId}
+        rows={15}
+        error={error}
+        value={value}
+        onChange={action}
+        placeholder={
+          block.placeholder
+            ? fromTextObjectToString(surfaceRenderer, block.placeholder, 0)
+            : undefined
+        }
+      />
+    );
+  }
+
+  if (block.multiline || block.multilineSmall) {
     return (
       <TextAreaInput
         disabled={loading}

--- a/packages/fuselage-ui-kit/src/stories/Banner.stories.tsx
+++ b/packages/fuselage-ui-kit/src/stories/Banner.stories.tsx
@@ -121,6 +121,20 @@ export const InputWithMultilinePlainTextInput = createStory(
   }
 );
 
+export const InputWithMediumMultilinePlainTextInput = createStory(
+  payloads.inputWithMediumMultilinePlainTextInput,
+  {
+    'input-0': 'Error',
+  }
+);
+
+export const InputWithLargeMultilinePlainTextInput = createStory(
+  payloads.inputWithLargeMultilinePlainTextInput,
+  {
+    'input-0': 'Error',
+  }
+);
+
 export const InputWithPlainTextInput = createStory(
   payloads.inputWithPlainTextInput,
   {

--- a/packages/fuselage-ui-kit/src/stories/Modal.stories.tsx
+++ b/packages/fuselage-ui-kit/src/stories/Modal.stories.tsx
@@ -162,6 +162,20 @@ export const InputWithMultilinePlainTextInput = createStory(
   }
 );
 
+export const InputWithMediumMultilinePlainTextInput = createStory(
+  payloads.inputWithMediumMultilinePlainTextInput,
+  {
+    'input-0': 'Error',
+  }
+);
+
+export const InputWithLargeMultilinePlainTextInput = createStory(
+  payloads.inputWithLargeMultilinePlainTextInput,
+  {
+    'input-0': 'Error',
+  }
+);
+
 export const InputWithPlainTextInput = createStory(
   payloads.inputWithPlainTextInput,
   {

--- a/packages/fuselage-ui-kit/src/stories/payloads/input.ts
+++ b/packages/fuselage-ui-kit/src/stories/payloads/input.ts
@@ -8,6 +8,7 @@ export const inputWithMultilinePlainTextInput: readonly UiKit.LayoutBlock[] = [
       blockId: 'dummy-block-id',
       type: 'plain_text_input',
       multiline: true,
+      multilineSize: 'small',
       actionId: 'input-0',
     },
     label: {
@@ -26,7 +27,8 @@ export const inputWithMediumMultilinePlainTextInput: readonly UiKit.LayoutBlock[
         appId: 'dummy-app-id',
         blockId: 'dummy-block-id',
         type: 'plain_text_input',
-        multilineMedium: true,
+        multiline: true,
+        multilineSize: 'medium',
         actionId: 'input-0',
       },
       label: {
@@ -45,7 +47,8 @@ export const inputWithLargeMultilinePlainTextInput: readonly UiKit.LayoutBlock[]
         appId: 'dummy-app-id',
         blockId: 'dummy-block-id',
         type: 'plain_text_input',
-        multilineLarge: true,
+        multiline: true,
+        multilineSize: 'large',
         actionId: 'input-0',
       },
       label: {

--- a/packages/fuselage-ui-kit/src/stories/payloads/input.ts
+++ b/packages/fuselage-ui-kit/src/stories/payloads/input.ts
@@ -18,6 +18,44 @@ export const inputWithMultilinePlainTextInput: readonly UiKit.LayoutBlock[] = [
   },
 ] as const;
 
+export const inputWithMediumMultilinePlainTextInput: readonly UiKit.LayoutBlock[] =
+  [
+    {
+      type: 'input',
+      element: {
+        appId: 'dummy-app-id',
+        blockId: 'dummy-block-id',
+        type: 'plain_text_input',
+        multilineMedium: true,
+        actionId: 'input-0',
+      },
+      label: {
+        type: 'plain_text',
+        text: 'Label',
+        emoji: true,
+      },
+    },
+  ] as const;
+
+export const inputWithLargeMultilinePlainTextInput: readonly UiKit.LayoutBlock[] =
+  [
+    {
+      type: 'input',
+      element: {
+        appId: 'dummy-app-id',
+        blockId: 'dummy-block-id',
+        type: 'plain_text_input',
+        multilineLarge: true,
+        actionId: 'input-0',
+      },
+      label: {
+        type: 'plain_text',
+        text: 'Label',
+        emoji: true,
+      },
+    },
+  ] as const;
+
 export const inputWithPlainTextInput: readonly UiKit.LayoutBlock[] = [
   {
     type: 'input',

--- a/packages/ui-kit/src/blocks/elements/PlainTextInputElement.ts
+++ b/packages/ui-kit/src/blocks/elements/PlainTextInputElement.ts
@@ -8,4 +8,7 @@ export type PlainTextInputElement = Actionable<{
   multiline?: boolean;
   minLength?: number;
   maxLength?: number;
+  multilineLarge?: boolean;
+  multilineMedium?: boolean;
+  multilineSmall?: boolean;
 }>;

--- a/packages/ui-kit/src/blocks/elements/PlainTextInputElement.ts
+++ b/packages/ui-kit/src/blocks/elements/PlainTextInputElement.ts
@@ -8,7 +8,5 @@ export type PlainTextInputElement = Actionable<{
   multiline?: boolean;
   minLength?: number;
   maxLength?: number;
-  multilineLarge?: boolean;
-  multilineMedium?: boolean;
-  multilineSmall?: boolean;
+  multilineSize?: 'large' | 'medium' | 'small';
 }>;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->


  feat: New `MediumMultilineInput` and `LargeMultilineInput` Elements


- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules

## Why Do We need this ?


- Larger Multiline Input Elements will open new possibilities for Rocket.Chat App Developers. 
- Larger input components can be used in future apps which include a Code Editing App where the developers pair program inside Rocket.Chat.
- Or a Journal App/Notes App where journal Entries or more extensive notes can be made in RC
- Or a Future GitLab integrations where a code Review and Edit feature will be desirable.
- Larger can even be used in the main chat input component to edit and send a larger message to the Rocket.Chat channel, which may not be possible with the current input component.  
- Our use case and motivation to add this component to fuselage was to enable users display and merge PRs right from RocketChat channels through the [GitHub App](https://github.com/RocketChat/Apps.Github22). **This will be an exclusive feature which is not available in any `GitHub x Messaging` app intigration.**
- We currently use the `SectionBlock` as the `InputBlock` is too small, but the `SectionBlock` looses the indentation. 
- https://user-images.githubusercontent.com/70485812/179247571-7c9001e6-ba40-4edc-9030-e1307818a79b.mp4

- **A Larger Input component can help us take fix this as it preserves indentation. This would improve community collaboration over Rocket.Chat and push `Messaging x Developer Collaboration` to the limits**
- The Same component can also be extended to add new Issues to GitHub or A Rocket.Chat app which parses and display markdown. The possibilities can be endless.
- https://github.com/RocketChat/fuselage/discussions/744



## Proposed changes (including videos or screenshots)

- Added New `MediumMultilineInput` and `LargeMultilineInput` elements to [fuselage-ui-kit](https://github.com/RocketChat/fuselage/tree/develop/packages/fuselage-ui-kit).
- Added the new elements to the storybook.

- Input With Medium Multiline Plane Text Input

  - Banner

https://user-images.githubusercontent.com/70485812/178167410-3837a459-824c-4be3-b14f-93be3f66814f.mp4

   - Modal

https://user-images.githubusercontent.com/70485812/178167421-04e53647-4466-4408-8b45-55038c7885d2.mp4

- Input With Large Multiline Plane Text Input

  - Banner 

https://user-images.githubusercontent.com/70485812/178167501-4a9b1c3a-bff4-4d68-8283-43f3f0f72696.mp4


   - Modal

https://user-images.githubusercontent.com/70485812/178167504-5d57ea78-39f1-4ad9-a9c8-bf0f907f7a3a.mp4


<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

closes #765 

