### PR TITLE
chore: change font weight on FormPageLayout according to figma

### DIFF
--- a/packages/layout/src/FormPageLayout/FormPageLayout.styles.tsx
+++ b/packages/layout/src/FormPageLayout/FormPageLayout.styles.tsx
@@ -67,7 +67,7 @@ export const Title = styled('div')`
   padding-block-end: 24px;
   font-size: ${String(40 / 16)}rem;
   font-family: ${sans};
-  font-weight: 500;
+  font-weight: 800;
   line-height: ${String(42 / 16)}rem;
   text-align: center;
 


### PR DESCRIPTION
Change font weight on FormPageLayout according to Figma.

## Proposed changes

<!-- CHANGELOG -->
![image](https://user-images.githubusercontent.com/72958726/189209812-15a8b7e6-c5f1-477a-aa06-9200581ff54d.png)

![image](https://user-images.githubusercontent.com/72958726/189209862-035532d7-f144-464c-8109-31831dcf56eb.png)


<!-- END CHANGELOG -->

## Issue(s)
[https://rocketchat.atlassian.net/browse/CS-64](https://rocketchat.atlassian.net/browse/CS-64)

