### PR TITLE
fix(message-parser): Backtick char in domainChar

### DIFF
--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -381,7 +381,7 @@ domainName
 
 domainNameLabel = $(domainChar+ $("-" domainChar+)*)
 
-domainChar = !"\\" !"/" !"|" !">" !"<" !safe !extra !EndOfLine !Space .
+domainChar = !"\\" !"/" !"|" !">" !"<" !"`" !safe !extra !EndOfLine !Space .
 
 /**
  *

--- a/packages/message-parser/tests/inlineCode.test.ts
+++ b/packages/message-parser/tests/inlineCode.test.ts
@@ -7,6 +7,16 @@ test.each([
     [paragraph([inlineCode(plain('[asd](https://localhost)'))])],
   ],
   [`\`code\``, [paragraph([inlineCode(plain('code'))])]],
+  [
+    `File extension (\`.mov\`)`,
+    [
+      paragraph([
+        plain('File extension ('),
+        inlineCode(plain('.mov')),
+        plain(')'),
+      ]),
+    ],
+  ],
 ])('parses %p', (input, output) => {
   expect(parse(input)).toMatchObject(output);
 });


### PR DESCRIPTION
TC-104

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
**Problem:**
Some combinations of inline code with back-stick was resulting in a plain text, the root cause is because the back-stick was being considered a valid character that should be in the Domain Name of an URL

**Solution:**
Was added a back-stick char into the invalid chars to parse an URL domain name.

**Current behavior**
<img width="319" alt="image" src="https://user-images.githubusercontent.com/20212776/193824099-a418b241-e3c0-4cba-8641-1450464e48ed.png">

**Expected behavior**
![image](https://user-images.githubusercontent.com/20212776/193824304-b17ef190-bf25-4452-b9b7-050b0aae377b.png)


<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
