### PR TITLE
fix(message-parser): Phone pattern 

### DIFF
--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -28,6 +28,7 @@
     task,
     tasks,
     unorderedList,
+    phoneChecker,
   } = require('./utils');
 }
 
@@ -297,7 +298,10 @@ unicode
       return String.fromCharCode(parseInt(digits, 16));
     }
 
-AutolinkedPhone = p:Phone { return link('tel:' + p.number, plain(p.text)); }
+AutolinkedPhone
+  = p:Phone (EndOfLine / Space / !anyText) {
+      return phoneChecker(p.text, p.number);
+    }
 
 AutolinkedURL = u:URL { return link(u); }
 
@@ -368,6 +372,9 @@ Phone = "+" p:phoneNumber { return { text: '+' + p.text, number: p.number }; }
 phoneNumber
   = p:phonePrefix "-" d:digits {
       return { text: p.text + '-' + d, number: p.number + d };
+    }
+  / p:phonePrefix d1:digits "-" d2:digits {
+      return { text: p.text + d1 + '-' + d2, number: p.number + d1 + d2 };
     }
   / p:phonePrefix d:digits {
       return { text: p.text + d, number: p.number + d };

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -298,10 +298,7 @@ unicode
       return String.fromCharCode(parseInt(digits, 16));
     }
 
-AutolinkedPhone
-  = p:Phone (EndOfLine / Space / !anyText) {
-      return phoneChecker(p.text, p.number);
-    }
+AutolinkedPhone = p:Phone { return phoneChecker(p.text, p.number); }
 
 AutolinkedURL = u:URL { return link(u); }
 

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -152,7 +152,7 @@ Whitespace = w:$" "+ { return plain(w); }
 
 Escaped = "\\" t:$("*" / "_" / "~" / "`" / "#" / ".") { return plain(t); }
 
-Any = !EndOfLine t:$. u:$URL? { return plain(t + u); }
+Any = !EndOfLine t:$. p:$AutolinkedPhone? u:$URL? { return plain(t + p + u); }
 
 // = Line
 

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -193,3 +193,11 @@ export const inlineKatex = (content: string): InlineKaTeX => ({
   type: 'INLINE_KATEX',
   value: content,
 });
+
+export const phoneChecker = (text: string, number: string) => {
+  if (number.length < 5) {
+    return plain(text);
+  }
+
+  return link(`tel:${number}`, plain(text));
+};

--- a/packages/message-parser/tests/phoneNumber.test.ts
+++ b/packages/message-parser/tests/phoneNumber.test.ts
@@ -26,6 +26,22 @@ test.each([
     '[**here**](+(075)63546725)',
     [paragraph([link('tel:07563546725', bold([plain('here')]))])],
   ],
+  [
+    '[**here**](+(075)63546725)',
+    [paragraph([link('tel:07563546725', bold([plain('here')]))])],
+  ],
+  [
+    '+(11)99999-9999',
+    [paragraph([link('tel:11999999999', plain('+(11)99999-9999'))])],
+  ],
+  ['+(12)3-45', [paragraph([link('tel:12345', plain('+(12)3-45'))])]],
+  ['1+1=2', [paragraph([plain('1+1=2')])]],
+  ['1+1=2 text', [paragraph([plain('1+1=2 text')])]],
+  ['+1000,00', [paragraph([plain('+1000,00')])]],
+  ['+ 1199999999', [paragraph([plain('+ 1199999999')])]],
+  ['+1234', [paragraph([plain('+1234')])]],
+  ['+(12)3-4', [paragraph([plain('+(12)3-4')])]],
+  ['+123-4', [paragraph([plain('+123-4')])]],
 ])('parses %p', (input, output) => {
   expect(parse(input)).toMatchObject(output);
 });

--- a/packages/message-parser/tests/phoneNumber.test.ts
+++ b/packages/message-parser/tests/phoneNumber.test.ts
@@ -35,6 +35,7 @@ test.each([
     [paragraph([link('tel:11999999999', plain('+(11)99999-9999'))])],
   ],
   ['+(12)3-45', [paragraph([link('tel:12345', plain('+(12)3-45'))])]],
+  ['+1.599123', [paragraph([plain('+1.599123')])]],
   ['1+1=2', [paragraph([plain('1+1=2')])]],
   ['1+1=2 text', [paragraph([plain('1+1=2 text')])]],
   ['+1000,00', [paragraph([plain('+1000,00')])]],

--- a/packages/message-parser/tests/phoneNumber.test.ts
+++ b/packages/message-parser/tests/phoneNumber.test.ts
@@ -34,6 +34,11 @@ test.each([
     '+(11)99999-9999',
     [paragraph([link('tel:11999999999', plain('+(11)99999-9999'))])],
   ],
+  ['5 +51231', [paragraph([plain('5 '), link('tel:51231', plain('+51231'))])]],
+  [
+    '5 +51231 5',
+    [paragraph([plain('5 '), link('tel:51231', plain('+51231')), plain(' 5')])],
+  ],
   ['+(12)3-45', [paragraph([link('tel:12345', plain('+(12)3-45'))])]],
   ['+1.599123', [paragraph([plain('+1.599123')])]],
   ['1+1=2', [paragraph([plain('1+1=2')])]],
@@ -43,6 +48,7 @@ test.each([
   ['+1234', [paragraph([plain('+1234')])]],
   ['+(12)3-4', [paragraph([plain('+(12)3-4')])]],
   ['+123-4', [paragraph([plain('+123-4')])]],
+  ['5+51231', [paragraph([plain('5+51231')])]],
 ])('parses %p', (input, output) => {
   expect(parse(input)).toMatchObject(output);
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
The  Phone code matches any plus sign (+) followed by one or more digits, regardless of whether it is a valid phone number.
To fix this behavior we are now checking if the phone number has any other characters other than `(`, `)` and `-` and at least 5 numbers 
### Steps to reproduce:
In a chat, enter the text 1+1=2

### Expected behavior:
The chat message should not contain any hyperlinks

other e.g:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/20212776/201656696-8b16b2cc-9f4f-4f09-b32d-5ff2d4db99be.png">


### Actual behavior:
The +1 is hyperlinked to tel:1 even though it is not a valid phone number.

Other e.g:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/20212776/201656828-542e3d58-499d-40ff-a614-feb0e090e8e7.png">


## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
https://github.com/RocketChat/Rocket.Chat/issues/27141

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

TC-250
