### PR TITLE
fix(fuselage): Adding heading tag styles to messages

### DIFF
--- a/packages/fuselage/src/components/Message/Messages.stories.tsx
+++ b/packages/fuselage/src/components/Message/Messages.stories.tsx
@@ -67,7 +67,7 @@ export const Default: ComponentStory<typeof Message> = () => (
   </Box>
 );
 
-export const WithSequential = () => (
+export const WithSequential: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' clickable>
@@ -182,7 +182,7 @@ export const WithSequential = () => (
   </Box>
 );
 
-export const MessageWithThread = () => (
+export const MessageWithThread: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider unreadLabel='Unread'>May, 24, 2020</MessageDivider>
     <Message className='customclass' clickable>
@@ -300,7 +300,7 @@ export const MessageWithThread = () => (
   </Box>
 );
 
-export const MessageSelected = () => {
+export const MessageSelected: ComponentStory<typeof Message> = () => {
   const [selected, setSelected] = useState(true);
   return (
     <Box>
@@ -359,7 +359,7 @@ export const MessageSelected = () => {
   );
 };
 
-export const MessageEditing = () => (
+export const MessageEditing: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' clickable>
@@ -443,7 +443,7 @@ export const MessageEditing = () => (
   </Box>
 );
 
-export const MessageUnorderedList = () => (
+export const MessageUnorderedList: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' clickable>
@@ -489,7 +489,7 @@ export const MessageUnorderedList = () => (
   </Box>
 );
 
-export const MessageOrderedList = () => (
+export const MessageOrderedList: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' clickable>
@@ -535,7 +535,7 @@ export const MessageOrderedList = () => (
   </Box>
 );
 
-export const MessageHighlighted = () => (
+export const MessageHighlighted: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' highlight>
@@ -619,7 +619,7 @@ export const MessageHighlighted = () => (
   </Box>
 );
 
-export const MessagePending = () => (
+export const MessagePending: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
     <Message className='customclass' isPending>
@@ -696,6 +696,7 @@ export const MessagePending = () => (
     </Message>
   </Box>
 );
+
 export const MessageWithMetrics: ComponentStory<typeof Message> = () => (
   <Box>
     <MessageDivider>May, 24, 2020</MessageDivider>
@@ -737,6 +738,54 @@ export const MessageWithMetrics: ComponentStory<typeof Message> = () => (
             <MessageMetrics.Following name='bell' />
           </MessageMetrics>
         </Message.Block>
+      </Message.Container>
+      <MessageToolbox.Wrapper>
+        <MessageToolbox>
+          <MessageToolbox.Item icon='quote' />
+          <MessageToolbox.Item icon='clock' />
+          <MessageToolbox.Item icon='thread' />
+        </MessageToolbox>
+      </MessageToolbox.Wrapper>
+    </Message>
+  </Box>
+);
+
+export const MessageWithHeadings: ComponentStory<typeof Message> = () => (
+  <Box>
+    <MessageDivider>May, 24, 2020</MessageDivider>
+    <Message className='customclass' clickable>
+      <Message.LeftContainer>
+        <Avatar url={avatarUrl} size={'x36'} />
+      </Message.LeftContainer>
+      <Message.Container>
+        <Message.Header>
+          <Message.NameContainer>
+            <Message.Name>Haylie George</Message.Name>{' '}
+            <Message.Username>@haylie.george</Message.Username>
+          </Message.NameContainer>
+          <Message.Roles>
+            <Message.Role>Admin</Message.Role>
+            <Message.Role>User</Message.Role>
+            <Message.Role>Owner</Message.Role>
+          </Message.Roles>
+          <Message.Timestamp>12:00 PM</Message.Timestamp>
+        </Message.Header>
+        <Message.Body>
+          <h1 style={{ marginTop: 0 }}>Heading 1</h1>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+          <h2>Heading 2</h2>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          <h3>Heading 3</h3>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          <h4>Heading 4</h4>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        </Message.Body>
       </Message.Container>
       <MessageToolbox.Wrapper>
         <MessageToolbox>

--- a/packages/fuselage/src/components/Message/Messages.styles.scss
+++ b/packages/fuselage/src/components/Message/Messages.styles.scss
@@ -178,6 +178,22 @@ $message-background-color-highlight: functions.theme(
 
     color: colors.font(default);
 
+    & h1 {
+      @include typography.use-font-scale(h1);
+    }
+
+    & h2 {
+      @include typography.use-font-scale(h2);
+    }
+
+    & h3 {
+      @include typography.use-font-scale(h3);
+    }
+
+    & h4 {
+      @include typography.use-font-scale(h4);
+    }
+
     & ul,
     ol {
       margin: 0;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Today the message heading are displayed as normal texts, with the same size, and style. 
To fix this behavior and make to behave as the previous message parser we added the typography tokens from `fuselage-tokens` to the scss file responsible for message styles.

### [OLD] As it was before this change:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/20212776/202536651-a696839d-8afc-49df-9832-15391f0ae162.png">

### [NEW] As it is NOW:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/20212776/202536808-8c3c6646-4e66-4de3-97b0-00562d494977.png">


<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

TC-273
