### PR TITLE
refactor(fuselage): Move margin inline style to inline box at `Modal`

### DIFF
--- a/packages/fuselage/src/components/Modal/Modal.styles.scss
+++ b/packages/fuselage/src/components/Modal/Modal.styles.scss
@@ -107,10 +107,6 @@ $modal-margin: theme('modal-margin', auto);
     }
   }
 
-  &__content-wrapper {
-    margin-inline: $modal-container-margin;
-  }
-
   @include on-breakpoint(sm) {
     max-width: lengths.size(640);
     padding: lengths.padding(16);

--- a/packages/fuselage/src/components/Modal/ModalContent.tsx
+++ b/packages/fuselage/src/components/Modal/ModalContent.tsx
@@ -15,7 +15,7 @@ export const ModalContent = ({
 }: ModalContentProps) => (
   <Scrollable vertical onScrollContent={onScrollContent}>
     <Box rcx-modal__content>
-      <Box rcx-modal__content-wrapper {...props}>
+      <Box rcx-modal__content-wrapper marginInline='x24' {...props}>
         {children}
       </Box>
     </Box>

--- a/packages/fuselage/src/components/Modal/ModalContent.tsx
+++ b/packages/fuselage/src/components/Modal/ModalContent.tsx
@@ -15,7 +15,7 @@ export const ModalContent = ({
 }: ModalContentProps) => (
   <Scrollable vertical onScrollContent={onScrollContent}>
     <Box rcx-modal__content>
-      <Box rcx-modal__content-wrapper marginInline='x24' {...props}>
+      <Box rcx-modal__content-wrapper mi={24} {...props}>
         {children}
       </Box>
     </Box>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 
-->

Right now we don't have fallback styles for `margin-inline` compatible with older browsers.

styles in safari 14:
![Screenshot 2023-02-14 at 11 27 38](https://user-images.githubusercontent.com/9275105/218766932-928891de-1283-44f3-a708-1ece7317b2ae.png)