### PR TITLE
fix(message-parser): Link are not clickable if local environment

### DIFF
--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -85,13 +85,21 @@ export const link = (src: string, label?: Markup[]): Link => ({
 });
 
 export const autoLink = (src: string) => {
+  const validHosts = ['localhost', 'local'];
   const { isIcann, isIp, isPrivate, domain } = tldParse(src, {
     detectIp: false,
     allowPrivateDomains: true,
-    validHosts: ['localhost'],
+    validHosts,
   });
 
-  if (!(isIcann || isIp || isPrivate || domain === 'localhost')) {
+  if (
+    !(
+      isIcann ||
+      isIp ||
+      isPrivate ||
+      (domain !== null && validHosts.indexOf(domain) !== -1)
+    )
+  ) {
     return plain(src);
   }
 

--- a/packages/message-parser/tests/link.test.ts
+++ b/packages/message-parser/tests/link.test.ts
@@ -65,6 +65,10 @@ test.each([
     [paragraph([link('http://localhost', [plain('title')])])],
   ],
   [
+    '[title](http://gitlab.local)',
+    [paragraph([link('http://gitlab.local', [plain('title')])])],
+  ],
+  [
     '[title](http://localhost?testing=true)',
     [paragraph([link('http://localhost?testing=true', [plain('title')])])],
   ],
@@ -226,6 +230,7 @@ test.each([
     'www.google.com',
     [paragraph([link('//www.google.com', [plain('www.google.com')])])],
   ],
+  ['gitlab.local', [paragraph([link('//gitlab.local', [plain('gitlab.local')])])]],
   ['rocket.chat:8080', [paragraph([link('rocket.chat:8080')])]],
   ['ShouldNotBeALink', [paragraph([plain('ShouldNotBeALink')])]],
   [


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

### Before
![image](https://user-images.githubusercontent.com/78360471/225653521-bdcbc4f1-9acf-464c-974c-0300dacbcc7b.png)

### Now
![image](https://user-images.githubusercontent.com/78360471/225653299-a5df895e-cdbf-4156-a885-7a564cc6c1c9.png)


## Issue(s)
closes https://github.com/RocketChat/Rocket.Chat/issues/28427

## Further comments
- I have utilized an array to store approved local URL suffixes that may facilitate any future extensions.
- Thanks for @dudanogueira 's help lol