### PR TITLE
fix(fuselage): message link color

### DIFF
--- a/packages/fuselage/src/components/Message/Messages.styles.scss
+++ b/packages/fuselage/src/components/Message/Messages.styles.scss
@@ -50,6 +50,8 @@ $message-background-color-highlight: functions.theme(
   colors.status-background(warning-2)
 );
 
+$message-link-color: functions.theme('message-link-color', colors.font(info));
+
 .rcx-message {
   @include mixins.container();
   position: relative;
@@ -190,6 +192,10 @@ $message-background-color-highlight: functions.theme(
     opacity: 1;
 
     color: colors.font(default);
+
+    & a {
+      color: $message-link-color;
+    }
 
     & h1 {
       @include typography.use-font-scale(h1);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
- set link's color inside messages with the correct token: `font-info`
- not all message links were using the correct token, inheriting the default color for `<a>` (e.g on threads list)

from:
<img width="453" alt="image" src="https://user-images.githubusercontent.com/60678893/234413128-d43ca96d-4304-4986-84f3-38e0e3591c6f.png">

to:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/60678893/234413238-13470286-1be8-4aa4-9600-df2d5ee4de39.png">

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
