### PR TITLE
fix(emitter): `off()` ignoring handler check when one listener remains

### DIFF
--- a/packages/emitter/src/emitter.spec.ts
+++ b/packages/emitter/src/emitter.spec.ts
@@ -5,87 +5,98 @@ const times = (n: number, fn: () => void): number => {
   return n;
 };
 
-describe('Emitter function', () => {
-  let handler: () => void;
-  let emitter: Emitter;
+let handler: () => void;
+let emitter: Emitter;
 
-  beforeEach(() => {
-    handler = jest.fn();
-    emitter = new Emitter();
+beforeEach(() => {
+  handler = jest.fn();
+  emitter = new Emitter();
+});
+
+describe('`on` method', () => {
+  it('should call `test` handler 5 times - with only one listener', () => {
+    emitter.on('test', handler);
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(5);
   });
 
-  describe('`on` method', () => {
-    it('It should call `test` handler 5 times - with only one listener', () => {
-      emitter.on('test', handler);
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(5);
-    });
+  it('should call `test2` handler 0 times - with multiple listeners', () => {
+    emitter.on('test', () => null);
+    emitter.on('test2', handler);
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
+});
 
-    it('It should call `test2` handler 0 times - with multiple listeners', () => {
-      emitter.on('test', () => null);
-      emitter.on('test2', handler);
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(0);
-    });
+describe('`once` method', () => {
+  it('should call `test` handler only once', () => {
+    emitter.once('test', handler);
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  describe('`once` method', () => {
-    it('It should call `test` handler only once', () => {
-      emitter.once('test', handler);
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
-
-    it('It should call `test` handler only once - with multiple events and same handler', () => {
-      emitter.once('test', handler);
-      emitter.once('test2', handler);
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
-
-    it('It should call `test` handler 5 times afert `once + remove + on` same event', () => {
-      emitter.once('test', handler);
-      emitter.off('test', handler);
-      emitter.on('test', handler);
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(5);
-    });
-
-    it('It should call `test` handler once after add multiple `once` and remove n-1', () => {
-      emitter.once('test', handler);
-      emitter.once('test', handler)();
-      emitter.once('test', handler)();
-      emitter.once('test', handler)();
-      emitter.once('test', handler)();
-      emitter.once('test', handler)();
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
-
-    it('It should call `test` handler once after add same handler with different `once` events and remove n-1', () => {
-      emitter.once('test', handler);
-      emitter.once('test2', handler)();
-      times(5, () => emitter.emit('test'));
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
+  it('should call `test` handler only once - with multiple events and same handler', () => {
+    emitter.once('test', handler);
+    emitter.once('test2', handler);
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  describe('`off` method', () => {
-    it('It should have no `test` handler after removal', () => {
-      emitter.on('test', handler);
-      emitter.off('test', handler);
-      expect(emitter.has('test')).toBe(false);
-    });
+  it('should call `test` handler 5 times afert `once + remove + on` same event', () => {
+    emitter.once('test', handler);
+    emitter.off('test', handler);
+    emitter.on('test', handler);
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(5);
+  });
 
-    it('It should have no `test` handler after use stop callback', () => {
-      emitter.on('test', handler)();
-      expect(emitter.has('test')).toBe(false);
-    });
+  it('should call `test` handler once after add multiple `once` and remove n-1', () => {
+    emitter.once('test', handler);
+    emitter.once('test', handler)();
+    emitter.once('test', handler)();
+    emitter.once('test', handler)();
+    emitter.once('test', handler)();
+    emitter.once('test', handler)();
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
 
-    it('It should have no `test` handler after emit once', () => {
-      emitter.once('test', handler);
-      emitter.emit('test');
-      expect(emitter.has('test')).toBe(false);
-    });
+  it('should call `test` handler once after add same handler with different `once` events and remove n-1', () => {
+    emitter.once('test', handler);
+    emitter.once('test2', handler)();
+    times(5, () => emitter.emit('test'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('`off` method', () => {
+  it('should have no `test` handler after removal', () => {
+    emitter.on('test', handler);
+    emitter.off('test', handler);
+    expect(emitter.has('test')).toBe(false);
+  });
+
+  it('should have no `test` handler after use stop callback', () => {
+    emitter.on('test', handler)();
+    expect(emitter.has('test')).toBe(false);
+  });
+
+  it('should have no `test` handler after emit once', () => {
+    emitter.once('test', handler);
+    emitter.emit('test');
+    expect(emitter.has('test')).toBe(false);
+  });
+
+  it('should remove only the specified handler', () => {
+    const handler = jest.fn();
+    const unusedHandler = jest.fn();
+
+    emitter.on('test', handler);
+    emitter.off('test', unusedHandler);
+
+    emitter.emit('test');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(unusedHandler).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/emitter/src/index.ts
+++ b/packages/emitter/src/index.ts
@@ -167,14 +167,14 @@ export class Emitter<EventMap extends DefaultEventMap = DefaultEventMap>
       this[once].delete(handler);
     }
 
-    if (handlers.length === 1) {
-      this[evts].delete(type);
-      return;
-    }
     handlers.splice(
       handlers.findIndex((callback) => callback === handler) >>> 0,
       1
     );
+
+    if (handlers.length === 0) {
+      this[evts].delete(type);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
For any `Emitter` instance, if there is only one event handler attached to some event `x`, calling `emitter.off('x', handler)` will wipe that handler regardless of `handler` being the one.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
```ts
it('should remove only the specified handler', () => {
    const handler = jest.fn();
    const unusedHandler = jest.fn();

    emitter.on('test', handler);
    emitter.off('test', unusedHandler);

    emitter.emit('test');

    expect(handler).toHaveBeenCalledTimes(1); // Actual: 0
    expect(unusedHandler).toHaveBeenCalledTimes(0);
  });
```