### PR TITLE
fix(fuselage): `IconButton` with badge click-animation

### DIFF
--- a/packages/fuselage/src/components/Button/Button.styles.scss
+++ b/packages/fuselage/src/components/Button/Button.styles.scss
@@ -35,12 +35,7 @@
 
   @mixin click-animation() {
     @include on-active {
-      > * {
-        transform: translateY(1px);
-      }
-    }
-    @include on-pressed {
-      > * {
+      > *:not(div[role='status']) {
         transform: translateY(1px);
       }
     }

--- a/packages/fuselage/src/components/Button/IconButton.stories.tsx
+++ b/packages/fuselage/src/components/Button/IconButton.stories.tsx
@@ -1,3 +1,4 @@
+import { css } from '@rocket.chat/css-in-js';
 import {
   Title,
   Subtitle,
@@ -11,6 +12,8 @@ import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import React from 'react';
 
 import { PropsVariationSection } from '../../../.storybook/helpers';
+import { Badge } from '../Badge';
+import Box from '../Box/Box';
 import { ButtonGroup } from '../ButtonGroup';
 import { IconButton } from './IconButton';
 
@@ -212,3 +215,21 @@ export const _IconButtonDanger: ComponentStory<typeof IconButton> = () => (
 export const _IconButtonSecondaryDanger: ComponentStory<
   typeof IconButton
 > = () => <IconButton icon='balloon' aria-label='balloon' secondary danger />;
+
+export const _IconButtonWithBadge: ComponentStory<typeof IconButton> = () => (
+  <ButtonGroup>
+    <IconButton icon='balloon' small position='relative' overflow='visible'>
+      <Box
+        position='absolute'
+        role='status'
+        className={css`
+          top: 0;
+          right: 0;
+          transform: translate(30%, -30%);
+        `}
+      >
+        <Badge variant='danger'>2</Badge>
+      </Box>
+    </IconButton>
+  </ButtonGroup>
+);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

- adjust mixin `click-animation` selector to ignore status badges
![Kapture 2023-09-04 at 14 36 52](https://github.com/RocketChat/fuselage/assets/60678893/f1e4192f-5910-4eef-860b-a6693172d16a)

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
