### PR TITLE
fix(fuselage): `withTitle` prop not working on MultiSelect and PaginatedMultiSelect

### DIFF
--- a/.changeset/gorgeous-ligers-give.md
+++ b/.changeset/gorgeous-ligers-give.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+Fixed `withTitle` property not working on MultiSelect and PaginatedMultiSelect components

--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
@@ -40,6 +40,7 @@ type MultiSelectProps = Omit<
   getLabel?: (params: SelectOption) => SelectOption[1];
   getValue?: (params: SelectOption) => SelectOption[0];
   customEmpty?: string;
+  withTitle?: boolean;
   anchor?:
     | ElementType<MultiSelectAnchorParams>
     | ((params: MultiSelectAnchorParams) => ReactNode);
@@ -69,6 +70,7 @@ export const MultiSelect = forwardRef(
       customEmpty,
       renderSelected: RenderSelected,
       addonIcon,
+      withTitle = false,
       ...props
     }: MultiSelectProps,
     ref: Ref<HTMLInputElement>
@@ -237,6 +239,7 @@ export const MultiSelect = forwardRef(
         <AnimatedVisibility visibility={visible}>
           <Position anchor={containerRef}>
             <_Options
+              withTitle={withTitle}
               width={borderBoxSize.inlineSize}
               onMouseDown={prevent}
               multiple

--- a/packages/fuselage/src/components/Options/Options.tsx
+++ b/packages/fuselage/src/components/Options/Options.tsx
@@ -35,10 +35,11 @@ type OptionsProps = Omit<ComponentProps<typeof Box>, 'onSelect'> & {
   multiple?: boolean;
   options: OptionType[];
   cursor: number;
+  withTitle?: boolean;
+  customEmpty?: string;
   renderItem?: ElementType;
   renderEmpty?: ElementType;
   onSelect: (option: OptionType) => void;
-  customEmpty?: string;
 };
 
 export const Empty = memo(({ customEmpty }: { customEmpty: string }) => (
@@ -56,6 +57,7 @@ export const Options = forwardRef(
       renderItem: OptionComponent = Option,
       onSelect,
       customEmpty,
+      withTitle,
       ...props
     }: OptionsProps,
     ref: Ref<HTMLElement>
@@ -93,6 +95,7 @@ export const Options = forwardRef(
                 <OptionComponent
                   role='option'
                   label={label}
+                  {...(withTitle && { title: label })}
                   onMouseDown={(e: SyntheticEvent) => {
                     if (disabled) {
                       return;

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
@@ -183,6 +183,7 @@ const PaginatedMultiSelect = ({
       <AnimatedVisibility visibility={visible}>
         <Position anchor={containerRef}>
           <OptionsComponent
+            withTitle={withTitle}
             width={borderBoxSize.inlineSize}
             onMouseDown={prevent}
             multiple


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
