### PR TITLE
fix(fuselage): add `Callout` missing background-color

### DIFF
--- a/.changeset/quiet-pigs-peel.md
+++ b/.changeset/quiet-pigs-peel.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): add `Callout` missing background-color

--- a/packages/fuselage/src/components/Callout/Callout.styles.scss
+++ b/packages/fuselage/src/components/Callout/Callout.styles.scss
@@ -2,6 +2,10 @@
 @use '../../styles/lengths.scss';
 @use '../../styles/typography.scss';
 
+$callout-background-color: theme(
+  'callout-background-color',
+  colors.surface(light)
+);
 $callout-default-color: theme(
   'callout-default-color',
   colors.font(secondary-info)
@@ -33,6 +37,8 @@ $callout-text-color: theme('callout-text-color', colors.font(default));
   border-color: $callout-default-color;
 
   border-radius: theme('callout-border-radius', lengths.border-radius(medium));
+
+  background-color: $callout-background-color;
 
   &--info {
     border-color: $callout-info-color;

--- a/packages/fuselage/src/components/Callout/Callout.tsx
+++ b/packages/fuselage/src/components/Callout/Callout.tsx
@@ -29,9 +29,7 @@ export const Callout = ({
   return (
     <Box
       is='section'
-      className={[
-        `rcx-callout ${type && `rcx-callout--${type}`} ${className || ''}`,
-      ]
+      className={['rcx-callout', type && `rcx-callout--${type}`, className]
         .filter(Boolean)
         .join(' ')}
       {...props}

--- a/packages/fuselage/src/components/Callout/__snapshots__/Callout.spec.tsx.snap
+++ b/packages/fuselage/src/components/Callout/__snapshots__/Callout.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`[CheckBox Rendering] renders CustomIcon without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout undefined "
+      class="rcx-box rcx-box--full  rcx-callout"
     >
       <i
         aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`[CheckBox Rendering] renders Danger without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout rcx-callout--danger "
+      class="rcx-box rcx-box--full  rcx-callout rcx-callout--danger"
     >
       <i
         aria-hidden="true"
@@ -66,7 +66,7 @@ exports[`[CheckBox Rendering] renders Default without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout undefined "
+      class="rcx-box rcx-box--full  rcx-callout"
     >
       <i
         aria-hidden="true"
@@ -97,7 +97,7 @@ exports[`[CheckBox Rendering] renders Info without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout rcx-callout--info "
+      class="rcx-box rcx-box--full  rcx-callout rcx-callout--info"
     >
       <i
         aria-hidden="true"
@@ -128,7 +128,7 @@ exports[`[CheckBox Rendering] renders Success without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout rcx-callout--success "
+      class="rcx-box rcx-box--full  rcx-callout rcx-callout--success"
     >
       <i
         aria-hidden="true"
@@ -159,7 +159,7 @@ exports[`[CheckBox Rendering] renders Warning without crashing 1`] = `
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout rcx-callout--warning "
+      class="rcx-box rcx-box--full  rcx-callout rcx-callout--warning"
     >
       <i
         aria-hidden="true"
@@ -190,7 +190,7 @@ exports[`[CheckBox Rendering] renders WithDescriptionOnly without crashing 1`] =
 <body>
   <div>
     <section
-      class="rcx-box rcx-box--full  rcx-callout undefined "
+      class="rcx-box rcx-box--full  rcx-callout"
     >
       <i
         aria-hidden="true"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
