### PR TITLE
fix(message-parser): Added ChannelMention in the markup

### DIFF
--- a/.changeset/cyan-pots-care.md
+++ b/.changeset/cyan-pots-care.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Added ChannelMention in the markup inside message-parser

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -83,7 +83,7 @@ export type Quote = {
   value: Paragraph[];
 };
 
-export type Markup = Italic | Strike | Bold | Plain;
+export type Markup = Italic | Strike | Bold | Plain | ChannelMention;
 export type MarkupExcluding<T extends Markup> = Exclude<Markup, T>;
 
 export type Bold = {


### PR DESCRIPTION
# fix(markup-problem): 

Added ChannelMention in the type Markup

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)

Initially, the bold, strike, and italic markup was not working on the mobile while mentioning the channel name in the message box.
![Screenshot from 2023-11-06 16-53-18](https://github.com/RocketChat/fuselage/assets/107868772/55424a81-e18b-4288-a758-fab65f2450aa)

I have made the necessary changes in the React Native repo but there is a specific change that is required in the fuselage repo as well for that change to work. We need to add ChannelMention in the type Markup for this change to work. I have made these changes and raising the PR for the same.

After adding the changes, we would be able to see the Channel in the message box.
![WhatsApp Image 2023-11-06 at 17 04 13](https://github.com/RocketChat/fuselage/assets/107868772/e6804422-e9f1-4e02-af8a-b55233ac103d)

## Issue(s)

https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/5305


