### PR TITLE
fix(fuselage): Handle `onBlur` prop on AutoComplete

### DIFF
--- a/.changeset/sharp-planets-type.md
+++ b/.changeset/sharp-planets-type.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+Handle `onBlur` prop on AutoComplete

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn update-readme
-yarn lint-staged
+yarn lint-staged --allow-empty

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -69,6 +69,7 @@ export function AutoComplete({
   error,
   disabled,
   multiple,
+  onBlur: onBlurAction = () => {},
   ...props
 }: AutoCompleteProps): ReactElement {
   const ref = useRef();
@@ -121,6 +122,11 @@ export function AutoComplete({
   const [cursor, handleKeyDown, , reset, [optionsAreVisible, hide, show]] =
     useCursor(value, memoizedOptions, handleSelect);
 
+  const onBlur = useMutableCallback((event) => {
+    hide();
+    onBlurAction(event);
+  });
+
   useEffect(reset, [filter]);
 
   return (
@@ -148,7 +154,7 @@ export function AutoComplete({
             onChange={useMutableCallback((e) =>
               setFilter(e.currentTarget.value)
             )}
-            onBlur={hide}
+            onBlur={onBlur}
             onFocus={show}
             onKeyDown={handleKeyDown}
             placeholder={

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -69,7 +69,7 @@ export function AutoComplete({
   error,
   disabled,
   multiple,
-  onBlur: handleOnBlur = () => {},
+  onBlur: onBlurAction = () => {},
   ...props
 }: AutoCompleteProps): ReactElement {
   const ref = useRef();
@@ -124,7 +124,7 @@ export function AutoComplete({
 
   const onBlur = useMutableCallback((event) => {
     hide();
-    handleOnBlur(event);
+    onBlurAction(event);
   });
 
   useEffect(reset, [filter]);

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -69,7 +69,7 @@ export function AutoComplete({
   error,
   disabled,
   multiple,
-  onBlur: onBlurAction = () => {},
+  onBlur: handleOnBlur = () => {},
   ...props
 }: AutoCompleteProps): ReactElement {
   const ref = useRef();
@@ -124,7 +124,7 @@ export function AutoComplete({
 
   const onBlur = useMutableCallback((event) => {
     hide();
-    onBlurAction(event);
+    handleOnBlur(event);
   });
 
   useEffect(reset, [filter]);

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -122,7 +122,7 @@ export function AutoComplete({
   const [cursor, handleKeyDown, , reset, [optionsAreVisible, hide, show]] =
     useCursor(value, memoizedOptions, handleSelect);
 
-  const onBlur = useMutableCallback((event) => {
+  const handleOnBlur = useMutableCallback((event) => {
     hide();
     onBlurAction(event);
   });
@@ -154,7 +154,7 @@ export function AutoComplete({
             onChange={useMutableCallback((e) =>
               setFilter(e.currentTarget.value)
             )}
-            onBlur={onBlur}
+            onBlur={handleOnBlur}
             onFocus={show}
             onKeyDown={handleKeyDown}
             placeholder={


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Sometimes we need to send the `onBlur` event as prop to the `AutoComplete` component which overrides the already implemented `onBlur` event which is used to hide the suggestions box, due to which the suggestions are not hiding after moving away from the component.
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
TC-1030