### PR TITLE
fix: drop down close issue of multiselect component

### DIFF
--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
@@ -10,6 +10,8 @@ import type {
   ElementType,
   Ref,
   ReactNode,
+  FocusEventHandler,
+  MouseEventHandler,
 } from 'react';
 import React, { useState, useRef, useEffect, forwardRef } from 'react';
 
@@ -142,12 +144,21 @@ export const MultiSelect = forwardRef(
     };
 
     const handleClick = useEffectEvent(() => {
-      if (visible === AnimatedVisibility.VISIBLE) {
-        return hide();
-      }
       innerRef.current?.focus();
-      return show();
     });
+
+    const handleBlur: FocusEventHandler = useEffectEvent(() => {
+      visible === AnimatedVisibility.VISIBLE && hide();
+    });
+
+    const handleOnMouseDown = useEffectEvent((e) => {
+      const isClickOnChip = e.target.closest('.rcx-chip');
+      if (!isClickOnChip) {
+        visible === AnimatedVisibility.VISIBLE ? hide() : show();
+      }
+    });
+
+    const handleAnchorClick: MouseEventHandler = useEffectEvent(() => {});
 
     return (
       <Box
@@ -155,6 +166,7 @@ export const MultiSelect = forwardRef(
         rcx-select
         className={[error && 'invalid', disabled && 'disabled']}
         ref={containerRef}
+        onMouseDown={handleOnMouseDown}
         onClick={handleClick}
         disabled={disabled}
         {...props}
@@ -176,8 +188,8 @@ export const MultiSelect = forwardRef(
                       ref: anchorRef,
                       children: internalValue.length === 0 ? placeholder : null,
                       disabled: disabled ?? false,
-                      onClick: show,
-                      onBlur: hide,
+                      onClick: handleAnchorClick,
+                      onBlur: handleBlur,
                       onKeyDown: handleKeyDown,
                       onKeyUp: handleKeyUp,
                     })}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
I've created a handleOnMouseDown function to control the visibility of the dropdown menu.

In the Anchor component, the onClick prop has been assigned an empty function since it's already being managed by the handleMouseDown function provided as a prop on the Box component. Additionally, a custom function called handleBlur has been introduced and is now assigned to the onBlur prop of the anchor component. This function is responsible for hiding the dropdown only when necessary. The handleClick function has also been modified to only work in creating focus within the box.

The sequence of actions is as follows: onMouseDown first, followed by onBlur, and finally onClick.


https://github.com/RocketChat/fuselage/assets/78961432/08bfd266-4702-4ad4-b20c-f2be5002b434



<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

Closes #1305

## Further comments

The issue occurred because the onBlur event, responsible for hiding the dropdown when clicking outside, executed before the onClick event. Therefore, clicking inside the box, such as on the arrow icon, triggered the onBlur event to hide the dropdown, and then the onClick event mistakenly thought it was hidden and displayed it again. To address this, I employed the onMouseDown event to better manage these scenarios.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
