### PR TITLE
fixed autocompelete issue

### DIFF
--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -77,14 +77,14 @@ export function AutoComplete({
   );
 
   const handleSelect = useEffectEvent(([currentValue]) => {
-    if (selected?.some((item) => item.value === currentValue)) {
-      hide();
-      return;
-    }
+    if (!currentValue) return; // Exit early if no value is selected
 
     if (multiple) {
+      const newValue = Array.isArray(value)
+        ? [...value, currentValue]
+        : [currentValue];
       setSelected([...selected, ...getSelected(currentValue, options)]);
-      onChange([...value, currentValue]);
+      onChange(newValue);
     } else {
       setSelected(getSelected(currentValue, options));
       onChange(currentValue);
@@ -98,13 +98,12 @@ export function AutoComplete({
     event.stopPropagation();
     event.preventDefault();
 
-    const filtered = selected.filter(
-      (item) => item.value !== event.currentTarget.value
-    );
+    const removedValue = event.currentTarget.value;
 
-    const filteredValue = value.filter(
-      (item) => item !== event.currentTarget.value
-    );
+    const filtered = selected.filter((item) => item.value !== removedValue);
+    const filteredValue = Array.isArray(value)
+      ? value.filter((item) => item !== removedValue)
+      : [];
 
     setSelected(filtered);
     onChange(filteredValue);


### PR DESCRIPTION
Made minor changes in handleSelect and handleRemove to fix Autocompelete issue

changes made : 

Changes in handleSelect:
1. Added a check to ensure that currentValue is truthy before proceeding.
2. Modified the logic to handle multiple selections and correctly update the value state based on whether it's an array or a single value.

Changes in handleRemove:
1. Added a removedValue variable to store the value of the removed item.
2. Utilized event.currentTarget.value to obtain the value of the removed item.
4. Updated the filtering logic to remove the item with the corresponding value from both the selected list and the value state.

issue: #1298 