### PR TITLE
fix(fuselage): border color on accordion component

### DIFF
--- a/.changeset/sour-pumpkins-repeat.md
+++ b/.changeset/sour-pumpkins-repeat.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+Change border color on Accordion component that was affecting dark mode, requested by design. 

--- a/packages/fuselage/src/components/Accordion/Accordion.styles.scss
+++ b/packages/fuselage/src/components/Accordion/Accordion.styles.scss
@@ -28,7 +28,7 @@
   color: colors.font(default);
 
   border-width: lengths.border-width(default);
-  border-color: colors.neutral(300) transparent transparent;
+  border-color: colors.stroke(extra-light) transparent transparent;
 
   &[tabindex] {
     @include clickable;


### PR DESCRIPTION
Change token color affecting dark mode for the accordion component, requested by design. 
It doesn't affect light mode.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
Before:
<img width="958" alt="image" src="https://github.com/RocketChat/fuselage/assets/72958726/c1ef3564-d3de-48f8-b02a-bcca1d1d380a">

After: 
<img width="968" alt="image" src="https://github.com/RocketChat/fuselage/assets/72958726/78f2d8b1-04c9-4e29-8058-c119e9161e7d">


<!-- END CHANGELOG -->

## Issue(s)
[https://rocketchat.atlassian.net/browse/CORE-36](https://rocketchat.atlassian.net/browse/CORE-36)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
