### PR TITLE
fix(fuselage): `ToastBar` remove close button from content alert

### DIFF
--- a/.changeset/clever-socks-double.md
+++ b/.changeset/clever-socks-double.md
@@ -2,4 +2,4 @@
 "@rocket.chat/fuselage": patch
 ---
 
-fix(fuselage): `ToastBar` considering close button as content when alerting
+fix(fuselage): `ToastBar` remove close button from content alert

--- a/.changeset/clever-socks-double.md
+++ b/.changeset/clever-socks-double.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): `ToastBar` considering close button as content when alerting

--- a/packages/fuselage/src/components/ToastBar/ToastBar.tsx
+++ b/packages/fuselage/src/components/ToastBar/ToastBar.tsx
@@ -24,7 +24,6 @@ export function ToastBar({
   time = 5,
   id,
   onClose,
-  buttonLabel = 'Close',
   ...props
 }: ToastBarProps) {
   const iconName =
@@ -74,6 +73,7 @@ export function ToastBar({
       elevation='2nb'
       borderRadius='x4'
       role='alert'
+      aria-labelledby={toastId}
       {...props}
     >
       <div className='rcx-toastbar_inner'>
@@ -91,7 +91,8 @@ export function ToastBar({
               tiny
               onClick={() => onClose(toastId)}
               icon='cross'
-              aria-label={buttonLabel}
+              tabIndex={-1}
+              aria-hidden
             />
           </div>
         )}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
