### PR TITLE
fix(fuselage): `MenuItem` onPointerUp event behavior

### DIFF
--- a/.changeset/late-glasses-accept.md
+++ b/.changeset/late-glasses-accept.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): `MenuItem` onPointerUp event behavior

--- a/packages/fuselage/src/components/Menu/V2/MenuItem.tsx
+++ b/packages/fuselage/src/components/Menu/V2/MenuItem.tsx
@@ -24,6 +24,9 @@ function MenuItem({ item, state }: MenuItemProps) {
     isDisabled,
   } = useMenuItem({ key: item.key }, state, ref);
 
+  // There's an issue caused by conflicting event handlers. The popover opens on onPointerDown and the selection event for both, the menu (listbox), happens on onPointerUp.
+  // As a workaround, we are overwriting `onPointerDown` event with `onPointerUp`
+
   return (
     <MenuOption
       {...mergeProps(menuItemProps, { onPointerDown: onPointerUp })}

--- a/packages/fuselage/src/components/Menu/V2/MenuItem.tsx
+++ b/packages/fuselage/src/components/Menu/V2/MenuItem.tsx
@@ -1,7 +1,7 @@
 import type { Node } from '@react-types/shared';
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
-import { useMenuItem } from 'react-aria';
+import { mergeProps, useMenuItem } from 'react-aria';
 import type { TreeState } from 'react-stately';
 
 import { MenuItemDescription } from '.';
@@ -18,15 +18,15 @@ type MenuItemProps = {
 
 function MenuItem({ item, state }: MenuItemProps) {
   const ref = useRef(null);
-  const { menuItemProps, isFocused, isDisabled } = useMenuItem(
-    { key: item.key },
-    state,
-    ref
-  );
+  const {
+    menuItemProps: { onPointerUp, ...menuItemProps },
+    isFocused,
+    isDisabled,
+  } = useMenuItem({ key: item.key }, state, ref);
 
   return (
     <MenuOption
-      {...menuItemProps}
+      {...mergeProps(menuItemProps, { onPointerDown: onPointerUp })}
       ref={ref}
       focus={isFocused}
       disabled={isDisabled}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

Fixes Menu triggering pointerUp event immediately when Popover overlaps its Trigger button.
This solution is a workaround suggested on [this issue](https://github.com/adobe/react-spectrum/issues/3864) on react-spectrum
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
