### PR TITLE
chore: Broken dark mode in Storybook docs and canvasses

### DIFF
--- a/packages/fuselage-toastbar/.storybook/DocsContainer.tsx
+++ b/packages/fuselage-toastbar/.storybook/DocsContainer.tsx
@@ -1,0 +1,25 @@
+import { DocsContainer as BaseContainer } from '@storybook/blocks';
+import { addons } from '@storybook/preview-api';
+import { themes } from '@storybook/theming';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useEffect, useState } from 'react';
+import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
+
+const channel = addons.getChannel();
+
+const DocsContainer = (
+  props: ComponentPropsWithoutRef<typeof BaseContainer>
+) => {
+  const [isDark, setDark] = useState(false);
+
+  useEffect(() => {
+    channel.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
+  }, [setDark]);
+
+  return (
+    <BaseContainer {...props} theme={isDark ? themes.dark : themes.light} />
+  );
+};
+
+export default DocsContainer;

--- a/packages/fuselage-toastbar/.storybook/preview.tsx
+++ b/packages/fuselage-toastbar/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import surface from '@rocket.chat/fuselage-tokens/dist/surface.json';
 import { DarkModeProvider } from '@rocket.chat/layout';
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
@@ -6,6 +7,7 @@ import { useDarkMode } from 'storybook-dark-mode';
 
 import manifest from '../package.json';
 import ToastBarProvider from '../src/ToastBarProvider';
+import DocsContainer from './DocsContainer';
 import logo from './logo.svg';
 
 import '@rocket.chat/fuselage/dist/fuselage.css';
@@ -21,6 +23,9 @@ export default {
         opacity: 0.5,
       },
     },
+    docs: {
+      container: DocsContainer,
+    },
     options: {
       storySort: {
         method: 'alphabetical',
@@ -29,12 +34,17 @@ export default {
     darkMode: {
       dark: {
         ...themes.dark,
+        appBg: surface.surface.dark.sidebar,
+        appContentBg: surface.surface.dark.light,
+        appPreviewBg: 'transparent',
+        barBg: surface.surface.dark.light,
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,
       },
       light: {
         ...themes.normal,
+        appPreviewBg: 'transparent',
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,

--- a/packages/fuselage-toastbar/package.json
+++ b/packages/fuselage-toastbar/package.json
@@ -49,6 +49,7 @@
     "@rocket.chat/eslint-config-alt": "workspace:~",
     "@rocket.chat/fuselage": "workspace:~",
     "@rocket.chat/fuselage-hooks": "workspace:~",
+    "@rocket.chat/fuselage-tokens": "workspace:~",
     "@rocket.chat/layout": "workspace:~",
     "@rocket.chat/prettier-config": "workspace:~",
     "@rocket.chat/styled": "workspace:~",

--- a/packages/fuselage/.storybook/DocsContainer.tsx
+++ b/packages/fuselage/.storybook/DocsContainer.tsx
@@ -1,0 +1,25 @@
+import { DocsContainer as BaseContainer } from '@storybook/blocks';
+import { addons } from '@storybook/preview-api';
+import { themes } from '@storybook/theming';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useEffect, useState } from 'react';
+import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
+
+const channel = addons.getChannel();
+
+const DocsContainer = (
+  props: ComponentPropsWithoutRef<typeof BaseContainer>
+) => {
+  const [isDark, setDark] = useState(false);
+
+  useEffect(() => {
+    channel.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
+  }, [setDark]);
+
+  return (
+    <BaseContainer {...props} theme={isDark ? themes.dark : themes.light} />
+  );
+};
+
+export default DocsContainer;

--- a/packages/fuselage/.storybook/preview.tsx
+++ b/packages/fuselage/.storybook/preview.tsx
@@ -1,11 +1,12 @@
 import breakpointTokens from '@rocket.chat/fuselage-tokens/breakpoints.json';
+import surface from '@rocket.chat/fuselage-tokens/dist/surface.json';
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
 import { useDarkMode } from 'storybook-dark-mode';
 
 import manifest from '../package.json';
 import { PaletteStyleTag } from '../src';
-import { surface } from './helpers';
+import DocsContainer from './DocsContainer';
 import logo from './logo.svg';
 
 import 'normalize.css/normalize.css';
@@ -20,6 +21,9 @@ export default {
         cellAmount: 4,
         opacity: 0.5,
       },
+    },
+    docs: {
+      container: DocsContainer,
     },
     options: {
       storySort: {
@@ -54,15 +58,17 @@ export default {
     darkMode: {
       dark: {
         ...themes.dark,
-        appBg: surface.sidebar,
-        appContentBg: surface.main,
-        barBg: surface.main,
+        appBg: surface.surface.dark.sidebar,
+        appContentBg: surface.surface.dark.light,
+        appPreviewBg: 'transparent',
+        barBg: surface.surface.dark.light,
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,
       },
       light: {
         ...themes.normal,
+        appPreviewBg: 'transparent',
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,

--- a/packages/layout/.storybook/DocsContainer.tsx
+++ b/packages/layout/.storybook/DocsContainer.tsx
@@ -1,0 +1,25 @@
+import { DocsContainer as BaseContainer } from '@storybook/blocks';
+import { addons } from '@storybook/preview-api';
+import { themes } from '@storybook/theming';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useEffect, useState } from 'react';
+import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
+
+const channel = addons.getChannel();
+
+const DocsContainer = (
+  props: ComponentPropsWithoutRef<typeof BaseContainer>
+) => {
+  const [isDark, setDark] = useState(false);
+
+  useEffect(() => {
+    channel.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
+  }, [setDark]);
+
+  return (
+    <BaseContainer {...props} theme={isDark ? themes.dark : themes.light} />
+  );
+};
+
+export default DocsContainer;

--- a/packages/layout/.storybook/preview.tsx
+++ b/packages/layout/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import surface from '@rocket.chat/fuselage-tokens/dist/surface.json';
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
 import { Suspense } from 'react';
@@ -5,6 +6,7 @@ import { useDarkMode } from 'storybook-dark-mode';
 
 import manifest from '../package.json';
 import DarkModeProvider from '../src/DarkModeProvider';
+import DocsContainer from './DocsContainer';
 import logo from './logo.svg';
 
 import '@rocket.chat/fuselage/dist/fuselage.css';
@@ -20,6 +22,9 @@ export default {
         opacity: 0.5,
       },
     },
+    docs: {
+      container: DocsContainer,
+    },
     options: {
       storySort: {
         method: 'alphabetical',
@@ -29,12 +34,17 @@ export default {
     darkMode: {
       dark: {
         ...themes.dark,
+        appBg: surface.surface.dark.sidebar,
+        appContentBg: surface.surface.dark.light,
+        appPreviewBg: 'transparent',
+        barBg: surface.surface.dark.light,
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,
       },
       light: {
         ...themes.normal,
+        appPreviewBg: 'transparent',
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@rocket.chat/eslint-config-alt": "workspace:~",
     "@rocket.chat/fuselage": "workspace:~",
+    "@rocket.chat/fuselage-tokens": "workspace:~",
     "@rocket.chat/prettier-config": "workspace:~",
     "@storybook/addon-essentials": "~8.2.7",
     "@storybook/addon-webpack5-compiler-swc": "~1.0.5",

--- a/packages/onboarding-ui/.storybook/DocsContainer.tsx
+++ b/packages/onboarding-ui/.storybook/DocsContainer.tsx
@@ -1,0 +1,25 @@
+import { DocsContainer as BaseContainer } from '@storybook/blocks';
+import { addons } from '@storybook/preview-api';
+import { themes } from '@storybook/theming';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useEffect, useState } from 'react';
+import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
+
+const channel = addons.getChannel();
+
+const DocsContainer = (
+  props: ComponentPropsWithoutRef<typeof BaseContainer>
+) => {
+  const [isDark, setDark] = useState(false);
+
+  useEffect(() => {
+    channel.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
+  }, [setDark]);
+
+  return (
+    <BaseContainer {...props} theme={isDark ? themes.dark : themes.light} />
+  );
+};
+
+export default DocsContainer;

--- a/packages/onboarding-ui/.storybook/preview.tsx
+++ b/packages/onboarding-ui/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import surface from '@rocket.chat/fuselage-tokens/dist/surface.json';
 import { DarkModeProvider } from '@rocket.chat/layout';
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
@@ -7,6 +8,7 @@ import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { useDarkMode } from 'storybook-dark-mode';
 
 import manifest from '../package.json';
+import DocsContainer from './DocsContainer';
 import logo from './logo.svg';
 
 import '@rocket.chat/fuselage/dist/fuselage.css';
@@ -40,6 +42,9 @@ export default {
         opacity: 0.5,
       },
     },
+    docs: {
+      container: DocsContainer,
+    },
     options: {
       storySort: {
         method: 'alphabetical',
@@ -48,12 +53,17 @@ export default {
     darkMode: {
       dark: {
         ...themes.dark,
+        appBg: surface.surface.dark.sidebar,
+        appContentBg: surface.surface.dark.light,
+        appPreviewBg: 'transparent',
+        barBg: surface.surface.dark.light,
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,
       },
       light: {
         ...themes.normal,
+        appPreviewBg: 'transparent',
         brandTitle: manifest.name,
         brandImage: logo,
         brandUrl: manifest.homepage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,7 @@ __metadata:
     "@rocket.chat/eslint-config-alt": "workspace:~"
     "@rocket.chat/fuselage": "workspace:~"
     "@rocket.chat/fuselage-hooks": "workspace:~"
+    "@rocket.chat/fuselage-tokens": "workspace:~"
     "@rocket.chat/layout": "workspace:~"
     "@rocket.chat/prettier-config": "workspace:~"
     "@rocket.chat/styled": "workspace:~"
@@ -4758,6 +4759,7 @@ __metadata:
   dependencies:
     "@rocket.chat/eslint-config-alt": "workspace:~"
     "@rocket.chat/fuselage": "workspace:~"
+    "@rocket.chat/fuselage-tokens": "workspace:~"
     "@rocket.chat/prettier-config": "workspace:~"
     "@storybook/addon-essentials": "npm:~8.2.7"
     "@storybook/addon-webpack5-compiler-swc": "npm:~1.0.5"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
It fixes dark mode theming in Storybook Docs pages and in canvasses backgrounds.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
To do: move the common configuration to a single and unified configuration package. 