### PR TITLE
fix: banner breaking ui when the title is not a string

### DIFF
--- a/.changeset/little-trains-applaud.md
+++ b/.changeset/little-trains-applaud.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+Fixes banner breaking ui when the `title` prop is not a string

--- a/packages/fuselage/src/components/Banner/Banner.tsx
+++ b/packages/fuselage/src/components/Banner/Banner.tsx
@@ -96,7 +96,7 @@ const Banner = ({
         </div>
       )}
       <div className={cx('rcx-banner__content')({ inline })}>
-        {title && (
+        {title && typeof title === 'string' && (
           <h6 className={cx('rcx-banner__title')({ inline })}>{title}</h6>
         )}
         {children}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[SUP-634](https://rocketchat.atlassian.net/browse/SUP-634)
<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This fixes the UI crashing when the title passed to the banner component is an empty object or non string type
This is just patching the issue, we will have to check how we are validating prop data on the ui kit 

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Fixes banner component crashing the ui when the `title` is not a string
<!-- END CHANGELOG -->

## Issue(s)
closes https://github.com/RocketChat/Rocket.Chat/issues/33263

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[SUP-634]: https://rocketchat.atlassian.net/browse/SUP-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ