### PR TITLE
feat(fuselage)!: Lighter `Accordion` and `AccordionItem` components

### DIFF
--- a/.changeset/soft-islands-decide.md
+++ b/.changeset/soft-islands-decide.md
@@ -1,0 +1,13 @@
+---
+"@rocket.chat/fuselage": minor
+---
+
+Simplifies `Accordion` and `AccordionItem`
+
+It removes an obsolete and not accessible toggle switch in `AccordionItem` and eases the internal usage of `Box` to
+improve rendering performance.
+
+Additionally, it adds a new `StylingBox` component that can be used as a wrapper for components that accept styling
+props but don't need the weight of the `Box` component prop handling internally.
+
+Also, it adds a new `cx` and `cxx` helpers to compose class names.

--- a/packages/fuselage/jest-setup.ts
+++ b/packages/fuselage/jest-setup.ts
@@ -48,3 +48,9 @@ window.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+let uniqueIdCounter = 0;
+jest.mock('@rocket.chat/fuselage-hooks', () => ({
+  ...jest.requireActual('@rocket.chat/fuselage-hooks'),
+  useUniqueId: () => `unique-id-${uniqueIdCounter++}`,
+}));

--- a/packages/fuselage/src/components/Accordion/Accordion.spec.tsx
+++ b/packages/fuselage/src/components/Accordion/Accordion.spec.tsx
@@ -4,17 +4,25 @@ import { axe } from 'jest-axe';
 import { render } from '../../testing';
 import * as stories from './Accordion.stories';
 
-const { Default } = composeStories(stories);
+const testCases = Object.values(composeStories(stories)).map((Story) => [
+  Story.storyName || 'Story',
+  Story,
+]);
 
-describe('[Accordion Component]', () => {
-  it('renders without crashing', () => {
-    render(<Default />);
-  });
+test.each(testCases)(
+  `renders %s without crashing`,
+  async (_storyname, Story) => {
+    const tree = render(<Story />);
+    expect(tree.baseElement).toMatchSnapshot();
+  }
+);
 
-  it('should have no a11y violations', async () => {
-    const { container } = render(<Default />);
+test.each(testCases)(
+  '%s should have no a11y violations',
+  async (_storyname, Story) => {
+    const { container } = render(<Story />);
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-  });
-});
+  }
+);

--- a/packages/fuselage/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/fuselage/src/components/Accordion/Accordion.stories.tsx
@@ -2,36 +2,66 @@ import type { StoryFn, Meta } from '@storybook/react';
 import type { ComponentType } from 'react';
 
 import Box from '../Box';
-import { Accordion } from './Accordion';
-import { AccordionItem } from './AccordionItem';
+import Accordion from './Accordion';
+import AccordionItem from './AccordionItem';
 
 export default {
   title: 'Containers/Accordion',
   component: Accordion,
   subcomponents: {
-    'Accordion.Item': Accordion.Item as ComponentType<any>,
-    'AccordionItem': AccordionItem as ComponentType<any>,
+    AccordionItem: AccordionItem as ComponentType<any>,
   },
 } satisfies Meta<typeof Accordion>;
 
-const Template: StoryFn<typeof Accordion> = () => (
+export const Default: StoryFn<typeof Accordion> = () => (
   <Accordion>
-    <Accordion.Item title='Item #1' defaultExpanded>
+    <AccordionItem title='Item #1'>
       <Box color='default' fontScale='p2' marginBlockEnd={16}>
         Content #1
       </Box>
-    </Accordion.Item>
-    <Accordion.Item title='Item #2'>
+    </AccordionItem>
+    <AccordionItem title='Item #2'>
       <Box color='default' fontScale='p2' marginBlockEnd={16}>
         Content #2
       </Box>
-    </Accordion.Item>
-    <Accordion.Item title='Item #3'>
+    </AccordionItem>
+    <AccordionItem title='Item #3'>
       <Box color='default' fontScale='p2' marginBlockEnd={16}>
         Content #3
       </Box>
-    </Accordion.Item>
+    </AccordionItem>
   </Accordion>
 );
 
-export const Default: StoryFn<typeof Accordion> = Template.bind({});
+const ItemTemplate: StoryFn<typeof AccordionItem> = ({
+  title = 'Item #2',
+  ...args
+}) => (
+  <Accordion>
+    <AccordionItem title='Item #1'>
+      <Box color='default' fontScale='p2' marginBlockEnd={16}>
+        Content #1
+      </Box>
+    </AccordionItem>
+    <AccordionItem title={title} {...args}>
+      <Box color='default' fontScale='p2' marginBlockEnd={16}>
+        Content #2
+      </Box>
+    </AccordionItem>
+    <AccordionItem title='Item #3'>
+      <Box color='default' fontScale='p2' marginBlockEnd={16}>
+        Content #3
+      </Box>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const ExpandedItemByDefault = ItemTemplate.bind({});
+ExpandedItemByDefault.args = {
+  defaultExpanded: true,
+};
+
+export const DisabledItem = ItemTemplate.bind({});
+DisabledItem.args = {
+  disabled: true,
+};

--- a/packages/fuselage/src/components/Accordion/Accordion.styles.scss
+++ b/packages/fuselage/src/components/Accordion/Accordion.styles.scss
@@ -6,7 +6,6 @@
   display: flex;
   flex-flow: column nowrap;
   border-block-end-color: colors.stroke(extra-light);
-
   border-block-end-width: lengths.border-width(default);
 }
 
@@ -62,14 +61,6 @@
   white-space: nowrap;
 
   @include typography.use-font-scale(h4);
-}
-
-.rcx-accordion-item__toggle-switch {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-
-  margin: lengths.margin(none) lengths.margin(24);
 }
 
 .rcx-accordion-item__panel {

--- a/packages/fuselage/src/components/Accordion/Accordion.tsx
+++ b/packages/fuselage/src/components/Accordion/Accordion.tsx
@@ -1,21 +1,22 @@
-import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
-import Box from '../Box';
-import { AccordionItem } from './AccordionItem';
+import { cx, cxx } from '../../helpers/composeClassNames';
+import { StylingBox } from '../Box';
+import { StylingProps } from '../Box/stylingProps';
 
-type AccordionProps = ComponentProps<typeof Box> & {
-  animated?: boolean;
+export type AccordionProps = {
   children: ReactNode;
-};
+} & Partial<StylingProps>;
 
 /**
  * An `Accordion` allows users to toggle the display of sections of content.
  */
-export function Accordion(props: AccordionProps): ReactElement<AccordionProps> {
-  return <Box animated rcx-accordion {...props} />;
-}
+const Accordion = ({ children, ...props }: AccordionProps) => (
+  <StylingBox {...props}>
+    <div className={cx(cxx('rcx-box')('full', 'animated'), 'rcx-accordion')}>
+      {children}
+    </div>
+  </StylingBox>
+);
 
-/**
- * @deprecated use named import instead
- */
-Accordion.Item = AccordionItem;
+export default Accordion;

--- a/packages/fuselage/src/components/Accordion/AccordionItem.tsx
+++ b/packages/fuselage/src/components/Accordion/AccordionItem.tsx
@@ -1,11 +1,11 @@
 import { useToggle, useUniqueId } from '@rocket.chat/fuselage-hooks';
-import type { FormEvent, KeyboardEvent, MouseEvent, ReactNode } from 'react';
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
-import Box from '../Box';
+import { cx, cxx } from '../../helpers/composeClassNames';
+import { StylingBox } from '../Box';
 import { Chevron } from '../Chevron';
-import { ToggleSwitch } from '../ToggleSwitch';
 
-type AccordionItemProps = {
+export type AccordionItemProps = {
   children?: ReactNode;
   className?: string;
   defaultExpanded?: boolean;
@@ -14,33 +14,20 @@ type AccordionItemProps = {
   tabIndex?: number;
   title: ReactNode;
   noncollapsible?: boolean;
-  onToggle?: (e: MouseEvent | KeyboardEvent) => void;
-  onToggleEnabled?: (e: FormEvent) => void;
 };
 
-export const AccordionItem = function Item({
+const AccordionItem = ({
   children,
-  className,
   defaultExpanded,
-  disabled,
+  disabled = false,
   expanded: propExpanded,
   tabIndex = 0,
   title,
   noncollapsible = !title,
-  onToggle,
-  onToggleEnabled,
   ...props
-}: AccordionItemProps) {
+}: AccordionItemProps) => {
   const [stateExpanded, toggleStateExpanded] = useToggle(defaultExpanded);
   const expanded = propExpanded || stateExpanded;
-  const toggleExpanded = (event: MouseEvent | KeyboardEvent) => {
-    if (onToggle) {
-      onToggle.call(event.currentTarget, event);
-      return;
-    }
-
-    toggleStateExpanded();
-  };
 
   const panelExpanded = noncollapsible || expanded;
 
@@ -52,7 +39,7 @@ export const AccordionItem = function Item({
       return;
     }
     e.currentTarget?.blur();
-    toggleExpanded(e);
+    toggleStateExpanded();
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -60,19 +47,17 @@ export const AccordionItem = function Item({
       return;
     }
 
-    if ([13, 32].includes(event.keyCode)) {
-      event.preventDefault();
-
-      if (event.repeat) {
-        return;
-      }
-
-      toggleExpanded(event);
+    if (![' ', 'Enter'].includes(event.key)) {
+      return;
     }
-  };
 
-  const handleToggleClick = (event: MouseEvent) => {
-    event.stopPropagation();
+    event.preventDefault();
+
+    if (event.repeat) {
+      return;
+    }
+
+    toggleStateExpanded();
   };
 
   const collapsibleProps = {
@@ -92,42 +77,41 @@ export const AccordionItem = function Item({
   const barProps = noncollapsible ? nonCollapsibleProps : collapsibleProps;
 
   return (
-    <Box is='section' rcx-accordion-item className={className} {...props}>
-      {title && (
-        <Box
-          role='button'
-          animated
-          rcx-accordion-item__bar
-          rcx-accordion-item__bar--disabled={disabled}
-          {...barProps}
-        >
-          <Box is='h2' rcx-accordion-item__title id={titleId}>
-            {title}
-          </Box>
-          {!noncollapsible && (
-            <>
-              {(disabled || onToggleEnabled) && (
-                <Box rcx-accordion-item__toggle-switch>
-                  <ToggleSwitch
-                    checked={!disabled}
-                    onClick={handleToggleClick}
-                    onChange={onToggleEnabled}
-                  />
-                </Box>
+    <StylingBox {...props}>
+      <section className={cx(cxx('rcx-box')('full'), 'rcx-accordion-item')}>
+        {title && (
+          <div
+            role='button'
+            className={cx(
+              cxx('rcx-box')('full', 'animated'),
+              cxx('rcx-accordion-item__bar')({ disabled })
+            )}
+            {...barProps}
+          >
+            <h2
+              className={cx(
+                cxx('rcx-box')('full'),
+                'rcx-accordion-item__title'
               )}
-              <Chevron size='x24' up={expanded} />
-            </>
+              id={titleId}
+            >
+              {title}
+            </h2>
+            {!noncollapsible && <Chevron size='x24' up={expanded} />}
+          </div>
+        )}
+        <div
+          className={cx(
+            cxx('rcx-box')('full', 'animated'),
+            cxx('rcx-accordion-item__panel')({ expanded: panelExpanded })
           )}
-        </Box>
-      )}
-      <Box
-        animated
-        rcx-accordion-item__panel
-        rcx-accordion-item__panel--expanded={panelExpanded}
-        id={panelId}
-      >
-        {children}
-      </Box>
-    </Box>
+          id={panelId}
+        >
+          {children}
+        </div>
+      </section>
+    </StylingBox>
   );
 };
+
+export default AccordionItem;

--- a/packages/fuselage/src/components/Accordion/__snapshots__/Accordion.spec.tsx.snap
+++ b/packages/fuselage/src/components/Accordion/__snapshots__/Accordion.spec.tsx.snap
@@ -1,0 +1,375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders Default without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-box--animated rcx-accordion"
+    >
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-1"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-0"
+          >
+            Item #1
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-1"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #1
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-3"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-2"
+          >
+            Item #2
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-3"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #2
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-5"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-4"
+          >
+            Item #3
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-5"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #3
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders DisabledItem without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-box--animated rcx-accordion"
+    >
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-13"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-12"
+          >
+            Item #1
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-13"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #1
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-15"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar rcx-accordion-item__bar--disabled"
+          role="button"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-14"
+          >
+            Item #2
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-15"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #2
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-17"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-16"
+          >
+            Item #3
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-17"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #3
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders ExpandedItemByDefault without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-box--animated rcx-accordion"
+    >
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-7"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-6"
+          >
+            Item #1
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-7"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #1
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-9"
+          aria-expanded="true"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-8"
+          >
+            Item #2
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron--up rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel rcx-accordion-item__panel--expanded"
+          id="unique-id-9"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #2
+          </div>
+        </div>
+      </section>
+      <section
+        class="rcx-box rcx-box--full rcx-accordion-item"
+      >
+        <div
+          aria-controls="unique-id-11"
+          aria-expanded="false"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__bar"
+          role="button"
+          tabindex="0"
+        >
+          <h2
+            class="rcx-box rcx-box--full rcx-accordion-item__title"
+            id="unique-id-10"
+          >
+            Item #3
+          </h2>
+          <span
+            class="rcx-box rcx-box--full rcx-chevron"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-f8dsuo"
+            >
+              
+            </i>
+          </span>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-box--animated rcx-accordion-item__panel"
+          id="unique-id-11"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-xuk1lb"
+          >
+            Content #3
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/fuselage/src/components/Accordion/index.ts
+++ b/packages/fuselage/src/components/Accordion/index.ts
@@ -1,2 +1,5 @@
-export * from './Accordion';
-export * from './AccordionItem';
+export { default as Accordion, type AccordionProps } from './Accordion';
+export {
+  default as AccordionItem,
+  type AccordionItemProps,
+} from './AccordionItem';

--- a/packages/fuselage/src/components/Box/StylingBox.tsx
+++ b/packages/fuselage/src/components/Box/StylingBox.tsx
@@ -1,0 +1,34 @@
+import type { cssFn } from '@rocket.chat/css-in-js';
+import { cloneElement } from 'react';
+import type { ReactElement } from 'react';
+
+import { useArrayLikeClassNameProp } from '../../hooks/useArrayLikeClassNameProp';
+import type { Falsy } from '../../types/Falsy';
+import type { StylingProps } from './stylingProps';
+import { useStylingProps } from './useStylingProps';
+
+export type StylingBoxProps = {
+  children: ReactElement<{ className?: string }>;
+  className?: string | cssFn | (string | cssFn | Falsy)[];
+} & Partial<StylingProps>;
+
+/**
+ * Merges its `StylingProps` props into a `className` prop passed to a child element.
+ *
+ * This is intended to be used as a wrapper for components that accept styling props but don't need the weight of the
+ * `Box` component prop handling internally.
+ */
+export const StylingBox = ({ children, ...props }: StylingBoxProps) => {
+  const propsWithStringClassName = useArrayLikeClassNameProp(props);
+  propsWithStringClassName.className = [
+    children.props.className,
+    propsWithStringClassName.className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const propsWithoutStylingProps = useStylingProps(propsWithStringClassName);
+
+  return cloneElement(children, propsWithoutStylingProps);
+};
+
+export default StylingBox;

--- a/packages/fuselage/src/components/Box/index.ts
+++ b/packages/fuselage/src/components/Box/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Box';
+export { default as StylingBox, type StylingBoxProps } from './StylingBox';

--- a/packages/fuselage/src/components/Box/index.tsx
+++ b/packages/fuselage/src/components/Box/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Box';

--- a/packages/fuselage/src/helpers/composeClassNames.ts
+++ b/packages/fuselage/src/helpers/composeClassNames.ts
@@ -1,3 +1,6 @@
+import { Falsy } from '../types/Falsy';
+import { exhaustiveCheck } from './exhaustiveCheck';
+
 const withPrefix = (prefix?: string) => (modifier: string) =>
   prefix ? `${prefix}--${modifier}` : modifier;
 
@@ -44,4 +47,96 @@ export const composeClassNames =
       .join(' ');
 
     return [prefix, classNames].filter(Boolean).join(' ');
+  };
+
+type CxArg =
+  | Falsy
+  | string
+  | { [className: string]: boolean | string | number };
+
+/**
+ * Composes class names into a single string based on flags.
+ *
+ * Any falsy value passed as an argument will be ignored.
+ *
+ * If a string is passed, it will be used as a class name.
+ *
+ * If a dictionary object is passed, its keys will be used as class names and its values will be used as modifiers --
+ * unless the value is a boolean, in which case the key will be used as a class name if the value is `true`.
+ *
+ * @example
+ * ```ts
+ * cx('a', false, 'b', null, { c: true, d: false, e: 'f', f: 1 }); // 'a b c e-f f-1'
+ * ```
+ *
+ * @param args a sequence of falsy values, strings and dictionary objects containing the class names
+ * @returns a space-separated string of class names
+ */
+export const cx = (...args: CxArg[]): string =>
+  args
+    .flatMap((arg) => {
+      if (!arg) {
+        return [];
+      }
+
+      if (typeof arg === 'string') {
+        return arg;
+      }
+
+      if (typeof arg === 'object') {
+        return Object.entries(arg).flatMap(([className, value]) => {
+          if (typeof value === 'boolean') {
+            return value ? className : [];
+          }
+
+          return `${className}-${value}`;
+        });
+      }
+
+      return exhaustiveCheck(arg);
+    })
+    .join(' ');
+
+/**
+ * Composes class name modifiers under a class name into a single class names' string based on flags.
+ *
+ * This function returns a function similar to `cx`, with the difference it handles the arguments as class name
+ * modifiers (based on BEM CSS conventions). However, it's recommended to use `cxx` as a curried function.
+ *
+ * @example
+ * ```ts
+ * cxx('z')('a', false, 'b', null, { c: true, d: false, e: 'f', f: 1 }); // 'z z--a z--b z--c z--e-f z--f-1'
+ * ```
+ * @param className the class name
+ * @param args a sequence of falsy values, strings and dictionary objects containing the modifiers
+ * @returns a space-separated string of class names
+ */
+export const cxx =
+  (className: string) =>
+  (...args: CxArg[]): string => {
+    const classNames = args.flatMap((arg) => {
+      if (!arg) {
+        return [];
+      }
+
+      if (typeof arg === 'string') {
+        return `${className}--${arg}`;
+      }
+
+      if (typeof arg === 'object') {
+        return Object.entries(arg).flatMap(([modifier, value]) => {
+          if (typeof value === 'boolean') {
+            return value ? `${className}--${modifier}` : [];
+          }
+
+          return `${className}--${modifier}-${value}`;
+        });
+      }
+
+      return exhaustiveCheck(arg);
+    });
+
+    classNames.unshift(className);
+
+    return classNames.join(' ');
   };

--- a/packages/fuselage/src/helpers/exhaustiveCheck.ts
+++ b/packages/fuselage/src/helpers/exhaustiveCheck.ts
@@ -1,0 +1,30 @@
+/**
+ * Utility function to check exhaustiveness of a switch statement or if-else statements.
+ *
+ * In TypeScript, variables going through a sequence of conditionals, like cases in switch statements or if-else
+ * statements, the variable type is incrementally narrowed as the conditionals are evaluated until it reaches the
+ * `never` type, meaning all possible cases have been covered. This function is used to check, at compilation time, that
+ * all possible cases have been covered (i.e. if the conditional checks were exhaustive) and should only be called in
+ * unreachable blocks of code.
+ *
+ * @example
+ * ```ts
+ * declare const value: 'foo' | 'bar';
+ * switch (value) {
+ *   case 'foo':
+ *     // ...
+ *     break;
+ *   case 'bar':
+ *     // ...
+ *     break;
+ *   default: // should be unreachable
+ *     exhaustiveCheck(value); // `value` type should be `never`, otherwise the compilation fails
+ * }
+ * ```
+ *
+ * @param _ the value which type should be `never`
+ * @throws {Error} will always throw an error if it's reached
+ */
+export const exhaustiveCheck = (_: never): never => {
+  throw new Error('Exhaustive check failed');
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
It removes an obsolete and not accessible toggle switch in `AccordionItem` and eases the internal usage of `Box` to
improve rendering performance.

Additionally, it adds a new `StylingBox` component that can be used as a wrapper for components that accept styling
props but don't need the weight of the `Box` component prop handling internally.

Also, it adds a new `cx` and `cxx` helpers to compose class names.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments
An important tweak was made in Jest's setup, mocking `useUniqueId` calls to return deterministic IDs, allowing snapshot matching.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
