### PR TITLE
fix(fuselage-tokens): incorrect color tokens on Button's success variant 

### DIFF
--- a/.changeset/stupid-eagles-destroy.md
+++ b/.changeset/stupid-eagles-destroy.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage-tokens": patch
+---
+
+Fixes Button's success variant, which was using incorrect color tokens.

--- a/packages/fuselage-tokens/src/button/base.json
+++ b/packages/fuselage-tokens/src/button/base.json
@@ -37,13 +37,13 @@
       "fontOnDanger": { "value": "{colors.white}" },
       "fontOnDangerDisabled": { "value": "{colors.white}" },
 
-      "backgroundSuccessDefault": { "value": "{colors.g500}" },
-      "backgroundSuccessHover": { "value": "{colors.g600}" },
-      "backgroundSuccessPress": { "value": "{colors.g700}" },
-      "backgroundSuccessFocus": { "value": "{colors.g500}" },
-      "backgroundSuccessKeyfocus": { "value": "{colors.g500}" },
+      "backgroundSuccessDefault": { "value": "{colors.g800}" },
+      "backgroundSuccessHover": { "value": "{colors.g900}" },
+      "backgroundSuccessPress": { "value": "{colors.g1000}" },
+      "backgroundSuccessFocus": { "value": "{colors.g800}" },
+      "backgroundSuccessKeyfocus": { "value": "{colors.g800}" },
       "backgroundSuccessDisabled": { "value": "{colors.g200}" },
-      "fontOnSuccess": { "value": "{colors.n900}" },
+      "fontOnSuccess": { "value": "{colors.white}" },
       "fontOnSuccessDisabled": { "value": "{colors.white}" }
     },
     "high-contrast": {


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
This PR fixes Button's success variant, which was using the incorrect color tokens. This was affecting the light theme in particular.

**Before:**
![Screenshot 2024-10-23 at 16 32 05](https://github.com/user-attachments/assets/c21405e5-aa16-4434-ae1d-9974a5c9810d)

**After:**
![Screenshot 2024-10-23 at 16 33 07](https://github.com/user-attachments/assets/51a69652-5742-4048-8799-c84df88f7ea3)

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
