### PR TITLE
fix(mp3-encoder): Suppress assertion

### DIFF
--- a/.changeset/ninety-monkeys-notice.md
+++ b/.changeset/ninety-monkeys-notice.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/mp3-encoder': patch
+---
+
+Suppressed assertions at the LAME encoding due to unknown `NaN` values

--- a/packages/mp3-encoder/src/lame/assert.ts
+++ b/packages/mp3-encoder/src/lame/assert.ts
@@ -1,8 +1,11 @@
 export function assert(
   condition: boolean,
-  message?: string,
+  _message?: string,
 ): asserts condition {
   if (!condition) {
-    throw new Error(message);
+    // TODO: There is a condition generating multiple NaN values that was never
+    //       addressed in the original code and is not clear how to handle it.
+    //       Originally this assertion was commented out, probably because of it.
+    // throw new Error(message);
   }
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
It suppresses assertions at the LAME encoding due to unknown `NaN` values.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is the original `assert` function: https://github.com/zhuker/lamejs/blob/090eaa9b7e90abb81939145f13be2bdcd06ac5e6/src/js/common.js#L148-L150

During investigation, the input buffers showed a small segment of `NaN` values instead of the expected typed Float32 numbers. It couldn't be determined where they are allocated, because they seen to exist prior to the `flush` call. Since there is no `async` function or callbacks at play (as the original code was transpiled from single-threaded Java code), the hypothesis of `message` events out of sync at the worker thread can be disregarded. One interesting thing to note is that when using a external microphone instead of Macbook's built-in microphone did **not** generated the `NaN` values; it might indicate a bug with the channel enumeration.