### PR TITLE
fix(fuselage): `OptionIcon` not receiving proper icon props

### DIFF
--- a/.changeset/tall-rabbits-do.md
+++ b/.changeset/tall-rabbits-do.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+fix: `OptionIcon` not receiving proper icon props

--- a/packages/fuselage/src/components/Menu/V2/Menu.stories.tsx
+++ b/packages/fuselage/src/components/Menu/V2/Menu.stories.tsx
@@ -56,7 +56,7 @@ export const Complex: StoryFn<typeof Menu> = (args) => (
       <MenuItemContent>Chats</MenuItemContent>
     </MenuItem>
     <MenuItem key='settings'>
-      <MenuItemIcon name='cog' />
+      <MenuItemIcon name='cog' color='font-info' />
       <MenuItemContent>Settings</MenuItemContent>
     </MenuItem>
   </Menu>

--- a/packages/fuselage/src/components/Option/OptionIcon.tsx
+++ b/packages/fuselage/src/components/Option/OptionIcon.tsx
@@ -4,13 +4,11 @@ import { Icon } from '../Icon';
 
 import OptionColumn from './OptionColumn';
 
-type OptionIconProps = {
-  name: ComponentProps<typeof Icon>['name'];
-};
+type OptionIconProps = ComponentProps<typeof Icon>;
 
-const OptionIcon = ({ name }: OptionIconProps) => (
+const OptionIcon = (props: OptionIconProps) => (
   <OptionColumn>
-    <Icon size='x20' rcx-option__icon name={name} />
+    <Icon size='x20' rcx-option__icon {...props} />
   </OptionColumn>
 );
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
