### PR TITLE
feat: replace `useLayoutEffect` in favor of `useInsertionEffect`

### DIFF
--- a/.changeset/ninety-cherries-pull.md
+++ b/.changeset/ninety-cherries-pull.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/fuselage': minor
+'@rocket.chat/styled': minor
+---
+
+feat: replace `useLayoutEffect` in favor of `useInsertionEffect`

--- a/packages/fuselage/src/hooks/useStyle.ts
+++ b/packages/fuselage/src/hooks/useStyle.ts
@@ -5,7 +5,7 @@ import {
   transpile,
   attachRules,
 } from '@rocket.chat/css-in-js';
-import { useDebugValue, useLayoutEffect, useMemo } from 'react';
+import { useDebugValue, useInsertionEffect, useMemo } from 'react';
 
 export const useStyle = (cssFn: cssFn | undefined, arg: unknown) => {
   const content = useMemo(() => (cssFn ? cssFn(arg) : undefined), [arg, cssFn]);
@@ -20,7 +20,7 @@ export const useStyle = (cssFn: cssFn | undefined, arg: unknown) => {
 
   useDebugValue(className);
 
-  useLayoutEffect(() => {
+  useInsertionEffect(() => {
     if (!content || !className) {
       return;
     }

--- a/packages/styled/src/styled.ts
+++ b/packages/styled/src/styled.ts
@@ -19,7 +19,7 @@ import {
   forwardRef,
   Fragment,
   useDebugValue,
-  useLayoutEffect,
+  useInsertionEffect,
 } from 'react';
 
 export const attachClassName = <P extends { className?: string }>(
@@ -85,7 +85,7 @@ const styled =
 
           useDebugValue(computedClassName);
 
-          useLayoutEffect(() => {
+          useInsertionEffect(() => {
             const escapedClassName = escapeName(computedClassName);
             const transpiledContent = transpile(
               `.${escapedClassName}`,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

> useInsertionEffect allows inserting elements into the DOM before any layout Effects fire.
It's indicated for inserting styles before any Effects fire that may need to read layout.

ref: https://react.dev/reference/react/useInsertionEffect

This PR replaces `useLayoutEffect` in favor of `useInsertionEffect` in Box component's `useStyle` hook and in `styled` package.

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
