### PR TITLE
fix(fuselage): Missing track on `Slider` component

### DIFF
--- a/.changeset/grumpy-mice-draw.md
+++ b/.changeset/grumpy-mice-draw.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+Fixes the missing track on the Slider component to ensure proper visual representation and functionality.

--- a/.changeset/grumpy-mice-draw.md
+++ b/.changeset/grumpy-mice-draw.md
@@ -2,4 +2,4 @@
 "@rocket.chat/fuselage": patch
 ---
 
-Fixes the missing track on the Slider component to ensure proper visual representation and functionality.
+fix(fuselage): Missing track on `Slider` component

--- a/packages/fuselage/src/components/Slider/SliderTrack.tsx
+++ b/packages/fuselage/src/components/Slider/SliderTrack.tsx
@@ -75,7 +75,7 @@ export const SliderTrack = ({
       &::before {
         position: absolute;
         display: block;
-        content: attr(x);
+        content: '';
 
         background: linear-gradient(${getTrackGradient()});
         transform: translateX(-50%);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
There was a rendering issue with the SliderTrack component in Chromium-based browsers. The component was using the CSS attr() function with an invalid attribute but without specifying fallback values or attribute types. While this edge case should return an empty string according to the CSS specification, Chromium browsers weren't handling it correctly, causing the track to fail to render. This has been fixed by explicitly setting an empty string ('') instead of relying on attr().

Before:
![before_attr_bug](https://github.com/user-attachments/assets/0d813a16-f900-42b9-aba2-a1e88159d42f)

After:
![after_attr_bug](https://github.com/user-attachments/assets/d1adef30-eb9c-4b57-a93c-f478549b5d5c)

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
