### PR TITLE
docs: add build verification note for fuselage-tokens

### DIFF
--- a/packages/fuselage-tokens/README.md
+++ b/packages/fuselage-tokens/README.md
@@ -77,3 +77,5 @@ yarn lint-and-fix
 ```
 
 <!--/yarn(lint-and-fix)-->
+
+Build instructions verified using Yarn 4.7.0.


### PR DESCRIPTION
<!-- CHANGELOG -->
Added a note to the README.md file in packages/fuselage-tokens stating that the build was verified using Yarn 4.7.0. This is to help future contributors know the project builds successfully and avoids confusion related to issue #1609.

<!-- END CHANGELOG -->
Successfully ran:

yarn install

yarn build in packages/fuselage-tokens

<details> <summary>Click to view terminal screenshots</summary>


</details>
Issue(s)
Closes #1609

Further comments
This small contribution helps document that the error in #1609 is no longer present when using the current codebase. No code changes were needed; only documentation was updated.

If required, I can also help investigate why the monorepo root build fails, though the individual package builds cleanly.
![1](https://github.com/user-attachments/assets/e277c004-78a4-4228-b25d-06629fa1a678)
![2](https://github.com/user-attachments/assets/1b1ed72f-8805-4229-a839-223b771a1f45)
![3](https://github.com/user-attachments/assets/8d81a859-3d29-498e-a6a8-4bd1fe96fbc1)
![4](https://github.com/user-attachments/assets/c4f19dec-f84a-4003-a84b-585d7df61128)
