### PR TITLE
fix(fuselage): FieldLabel required prop ignored when 'is' prop is set

### DIFF
--- a/.changeset/gold-dolls-burn.md
+++ b/.changeset/gold-dolls-burn.md
@@ -1,5 +1,7 @@
 ---
-"@rocket.chat/fuselage": patch
+'@rocket.chat/onboarding-ui': patch
+'@rocket.chat/fuselage': patch
+'@rocket.chat/layout': patch
 ---
 
 fix(fuselage): FieldLabel required prop ignored when 'is' prop is set

--- a/.changeset/gold-dolls-burn.md
+++ b/.changeset/gold-dolls-burn.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): FieldLabel required prop ignored when 'is' prop is set

--- a/packages/fuselage/src/components/Field/FieldLabel.spec.tsx
+++ b/packages/fuselage/src/components/Field/FieldLabel.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+
+import { FieldLabel } from './FieldLabel';
+
+describe('[FieldLabel Component]', () => {
+  it('should render required asterisk when required prop is true', () => {
+    render(
+      <FieldLabel required htmlFor='test-field'>
+        Test Label
+      </FieldLabel>,
+    );
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('should render required asterisk when using custom element', () => {
+    render(
+      <FieldLabel required htmlFor='test-field'>
+        Test Label
+      </FieldLabel>,
+    );
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('should not render required asterisk when required prop is false', () => {
+    render(<FieldLabel htmlFor='test-field'>Test Label</FieldLabel>);
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+});

--- a/packages/fuselage/src/components/Field/FieldLabel.spec.tsx
+++ b/packages/fuselage/src/components/Field/FieldLabel.spec.tsx
@@ -15,7 +15,7 @@ describe('[FieldLabel Component]', () => {
 
   it('should render required asterisk when using custom element', () => {
     render(
-      <FieldLabel required htmlFor='test-field'>
+      <FieldLabel is='span' id='test-field' required>
         Test Label
       </FieldLabel>,
     );

--- a/packages/fuselage/src/components/Field/FieldLabel.tsx
+++ b/packages/fuselage/src/components/Field/FieldLabel.tsx
@@ -1,7 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 
 import WithErrorWrapper from '../../helpers/WithErrorWrapper';
-import Box from '../Box';
 import { Label } from '../Label';
 
 import { FieldContext } from './Field';
@@ -9,7 +8,7 @@ import { FieldContext } from './Field';
 type FieldLabelProps = ComponentPropsWithoutRef<typeof Label>;
 
 export const FieldLabel = (props: FieldLabelProps) => {
-  const component = <Box is={Label} rcx-field__label {...props} />;
+  const component = <Label rcx-field__label {...props} />;
 
   if (process.env.NODE_ENV === 'development') {
     return (

--- a/packages/fuselage/src/components/Field/__snapshots__/Field.spec.tsx.snap
+++ b/packages/fuselage/src/components/Field/__snapshots__/Field.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`[Field Component] renders WithCheckbox without crashing 1`] = `
 <body>
@@ -10,7 +10,7 @@ exports[`[Field Component] renders WithCheckbox without crashing 1`] = `
         class="rcx-box rcx-box--full rcx-field__row"
       >
         <label
-          class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+          class="rcx-box rcx-box--full rcx-field__label rcx-label"
           for="fieldWithCheckbox"
         >
           Label
@@ -94,7 +94,7 @@ exports[`[Field Component] renders WithRadioButton without crashing 1`] = `
         class="rcx-box rcx-box--full rcx-field__row"
       >
         <label
-          class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+          class="rcx-box rcx-box--full rcx-field__label rcx-label"
           for="fieldWithRadio"
         >
           Label
@@ -175,7 +175,7 @@ exports[`[Field Component] renders WithTextArea without crashing 1`] = `
       class="rcx-box rcx-box--full rcx-field"
     >
       <label
-        class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+        class="rcx-box rcx-box--full rcx-field__label rcx-label"
         for="fieldWithTextArea"
       >
         Label
@@ -252,7 +252,7 @@ exports[`[Field Component] renders WithTextInput without crashing 1`] = `
       class="rcx-box rcx-box--full rcx-field"
     >
       <label
-        class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+        class="rcx-box rcx-box--full rcx-field__label rcx-label"
         for="fieldWithText"
       >
         Label
@@ -332,7 +332,7 @@ exports[`[Field Component] renders WithToggleSwitch without crashing 1`] = `
         class="rcx-box rcx-box--full rcx-field__row"
       >
         <label
-          class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+          class="rcx-box rcx-box--full rcx-field__label rcx-label"
           for="fieldWithToggle"
         >
           Label

--- a/packages/fuselage/src/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/fuselage/src/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`[Modal Component] _WithAnnotation should match the snapshot 1`] = `
 <body>
@@ -143,7 +143,7 @@ exports[`[Modal Component] _WithForm should match the snapshot 1`] = `
                 class="rcx-box rcx-box--full rcx-field rcx-field-group__item"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>

--- a/packages/layout/src/layouts/HorizontalWizardLayout/__snapshots__/HorizontalWizardLayout.spec.tsx.snap
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/__snapshots__/HorizontalWizardLayout.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders Default without crashing 1`] = `
 <body>
@@ -140,7 +140,7 @@ exports[`renders Default without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -313,7 +313,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -348,7 +348,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -383,7 +383,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -418,7 +418,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -453,7 +453,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -488,7 +488,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -523,7 +523,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -558,7 +558,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -593,7 +593,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -628,7 +628,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -663,7 +663,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -698,7 +698,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>

--- a/packages/layout/src/layouts/VerticalWizardLayout/__snapshots__/VerticalWizardLayout.spec.tsx.snap
+++ b/packages/layout/src/layouts/VerticalWizardLayout/__snapshots__/VerticalWizardLayout.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders Default without crashing 1`] = `
 <body>
@@ -108,7 +108,7 @@ exports[`renders Default without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -266,7 +266,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -302,7 +302,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -338,7 +338,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -374,7 +374,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -410,7 +410,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -446,7 +446,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -482,7 +482,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -518,7 +518,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -554,7 +554,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -590,7 +590,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -626,7 +626,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -662,7 +662,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>
@@ -698,7 +698,7 @@ exports[`renders WithScroll without crashing 1`] = `
                 class="rcx-box rcx-box--full rcx-field"
               >
                 <label
-                  class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label"
+                  class="rcx-box rcx-box--full rcx-field__label rcx-label"
                 >
                   Label
                 </label>

--- a/packages/onboarding-ui/src/forms/RegisterServerForm/__snapshots__/RegisterServerForm.spec.tsx.snap
+++ b/packages/onboarding-ui/src/forms/RegisterServerForm/__snapshots__/RegisterServerForm.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders _RegisterServerForm without crashing 1`] = `
 <body>
@@ -35,7 +35,7 @@ exports[`renders _RegisterServerForm without crashing 1`] = `
             class="rcx-box rcx-box--full rcx-field rcx-field-group__item"
           >
             <label
-              class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label rcx-css-127j9mz"
+              class="rcx-box rcx-box--full rcx-field__label rcx-label rcx-css-127j9mz"
               for=":r1:"
             >
               Admin email
@@ -87,7 +87,7 @@ exports[`renders _RegisterServerForm without crashing 1`] = `
                 />
               </label>
               <label
-                class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-box--with-block-elements rcx-box--with-inline-elements rcx-field__label rcx-css-1nlo49l"
+                class="rcx-box rcx-box--full rcx-box--with-block-elements rcx-box--with-inline-elements rcx-field__label rcx-label rcx-css-1nlo49l"
                 for=":r2:"
               >
                 I agree with 
@@ -208,7 +208,7 @@ exports[`renders _RegisterServerFormOffline without crashing 1`] = `
             class="rcx-box rcx-box--full rcx-field rcx-field-group__item"
           >
             <label
-              class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-field__label rcx-css-127j9mz"
+              class="rcx-box rcx-box--full rcx-field__label rcx-label rcx-css-127j9mz"
               for=":r4:"
             >
               Admin email
@@ -260,7 +260,7 @@ exports[`renders _RegisterServerFormOffline without crashing 1`] = `
                 />
               </label>
               <label
-                class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-box--with-block-elements rcx-box--with-inline-elements rcx-field__label rcx-css-1nlo49l"
+                class="rcx-box rcx-box--full rcx-box--with-block-elements rcx-box--with-inline-elements rcx-field__label rcx-label rcx-css-1nlo49l"
                 for=":r5:"
               >
                 I agree with 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a bug where the required `*` indicator was not displayed next to the label text when the `is` prop was provided. This occurred because the is prop was overriding the default `Label` component, which caused its built-in behaviors to be bypassed.

The issue was resolved by removing the intermediate `Box` wrapper and passing all props directly to the `Label` component, which natively supports the `is` prop and preserves the expected functionality.

## Issue(s)
[CTZ-244](https://rocketchat.atlassian.net/browse/CTZ-244)

## Further comments
This fix is especially useful in cases where using the `htmlFor` attribute is not appropriate, such as when the form field is labeled via ARIA attributes instead. In these scenarios, ensuring HTML compliance may require using a different tag for the label, for example:

```jsx
<FieldLabel is="span" id="test-label" required>
  Test Label
</FieldLabel>
```
With this fix, the required `*` indicator will now display correctly even when a custom element is used via the is prop.


[CTZ-244]: https://rocketchat.atlassian.net/browse/CTZ-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ