### PR TITLE
fix(fuselage): AutoComplete's disabled property not working

### DIFF
--- a/.changeset/fluffy-rats-film.md
+++ b/.changeset/fluffy-rats-film.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): AutoComplete's disabled property not working

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.spec.tsx
@@ -1,9 +1,11 @@
 import { composeStories } from '@storybook/react-webpack5';
+import { screen } from '@testing-library/dom';
 import { axe } from 'jest-axe';
 import { withResizeObserverMock } from 'testing-utils/mocks/withResizeObserverMock';
 
 import { render } from '../../testing';
 
+import { AutoComplete } from './AutoComplete';
 import * as stories from './AutoComplete.stories';
 
 const testCases = Object.values(composeStories(stories)).map((Story) => [
@@ -31,4 +33,22 @@ describe('[AutoComplete Rendering]', () => {
       expect(results).toHaveNoViolations();
     },
   );
+});
+
+describe('[Autocomplete functionality]', () => {
+  it('should disabled the input when disabled prop is true', () => {
+    render(
+      <AutoComplete
+        value='1'
+        filter='test'
+        setFilter={() => {}}
+        options={[{ value: '1', label: 'test1' }]}
+        onChange={() => {}}
+        disabled
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
 });

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.stories.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.stories.tsx
@@ -95,3 +95,8 @@ export const WithPlaceholder = Template.bind({});
 WithPlaceholder.args = {
   placeholder: 'Search...',
 };
+
+export const Disabled = Template.bind({});
+WithPlaceholder.args = {
+  disabled: true,
+};

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.stories.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.stories.tsx
@@ -97,6 +97,6 @@ WithPlaceholder.args = {
 };
 
 export const Disabled = Template.bind({});
-WithPlaceholder.args = {
+Disabled.args = {
   disabled: true,
 };

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -164,6 +164,7 @@ export function AutoComplete({
             order={1}
             rcx-input-box--undecorated
             value={filter}
+            disabled={disabled}
             {...props}
           />
           {selected?.length > 0 &&

--- a/packages/fuselage/src/components/AutoComplete/__snapshots__/AutoComplete.spec.tsx.snap
+++ b/packages/fuselage/src/components/AutoComplete/__snapshots__/AutoComplete.spec.tsx.snap
@@ -165,7 +165,7 @@ exports[`[AutoComplete Rendering] renders Disabled without crashing 1`] = `
 <body>
   <div>
     <div
-      class="rcx-box rcx-box--full rcx-autocomplete rcx-css-t3n91h"
+      class="rcx-box rcx-box--full rcx-autocomplete disabled rcx-css-t3n91h"
     >
       <div
         class="rcx-box rcx-box--full rcx-css-6d871f"
@@ -174,6 +174,7 @@ exports[`[AutoComplete Rendering] renders Disabled without crashing 1`] = `
         <input
           aria-label="Decorator Label"
           class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-css-trljwa rcx-css-rcil7k"
+          disabled=""
           value=""
         />
       </div>
@@ -462,7 +463,7 @@ exports[`[AutoComplete Rendering] renders WithPlaceholder without crashing 1`] =
 <body>
   <div>
     <div
-      class="rcx-box rcx-box--full rcx-autocomplete disabled rcx-css-t3n91h"
+      class="rcx-box rcx-box--full rcx-autocomplete rcx-css-t3n91h"
     >
       <div
         class="rcx-box rcx-box--full rcx-css-6d871f"
@@ -471,7 +472,7 @@ exports[`[AutoComplete Rendering] renders WithPlaceholder without crashing 1`] =
         <input
           aria-label="Decorator Label"
           class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-css-trljwa rcx-css-rcil7k"
-          disabled=""
+          placeholder="Search..."
           value=""
         />
       </div>

--- a/packages/fuselage/src/components/AutoComplete/__snapshots__/AutoComplete.spec.tsx.snap
+++ b/packages/fuselage/src/components/AutoComplete/__snapshots__/AutoComplete.spec.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`[AutoComplete Rendering] renders CustomItem without crashing 1`] = `
 <body>
@@ -131,6 +131,37 @@ v/L21v8BT/ZVoe1UItsAAAAASUVORK5CYII="
 `;
 
 exports[`[AutoComplete Rendering] renders Default without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-autocomplete rcx-css-t3n91h"
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-css-6d871f"
+        role="group"
+      >
+        <input
+          aria-label="Decorator Label"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-css-trljwa rcx-css-rcil7k"
+          value=""
+        />
+      </div>
+      <div
+        class="rcx-box rcx-box--full rcx-autocomplete__addon"
+      >
+        <i
+          aria-hidden="true"
+          class="rcx-box rcx-box--full rcx-icon--name-magnifier rcx-icon rcx-css-6vi44e"
+        >
+          
+        </i>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`[AutoComplete Rendering] renders Disabled without crashing 1`] = `
 <body>
   <div>
     <div
@@ -431,7 +462,7 @@ exports[`[AutoComplete Rendering] renders WithPlaceholder without crashing 1`] =
 <body>
   <div>
     <div
-      class="rcx-box rcx-box--full rcx-autocomplete rcx-css-t3n91h"
+      class="rcx-box rcx-box--full rcx-autocomplete disabled rcx-css-t3n91h"
     >
       <div
         class="rcx-box rcx-box--full rcx-css-6d871f"
@@ -440,7 +471,7 @@ exports[`[AutoComplete Rendering] renders WithPlaceholder without crashing 1`] =
         <input
           aria-label="Decorator Label"
           class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-css-trljwa rcx-css-rcil7k"
-          placeholder="Search..."
+          disabled=""
           value=""
         />
       </div>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes an issue where the `AutoComplete` component did not respect the `disabled` prop when it was set to `true`. This happened because the `disabled` attribute was not being forwarded to the internal `InputBox.Input` component.

The issue was resolved by explicitly passing the `disabled` prop to the `InputBox.Input`, ensuring the input is properly disabled.

## Issue(s)
[CTZ-244](https://rocketchat.atlassian.net/browse/CTZ-244)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-244]: https://rocketchat.atlassian.net/browse/CTZ-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ