### PR TITLE
feat(fuselage): Add optional description prop to `PaginatedSelect` and `PaginatedMultiSelect` options

### DIFF
--- a/.changeset/flat-bees-drum.md
+++ b/.changeset/flat-bees-drum.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": minor
+---
+
+feat(fuselage): Add optional description prop to `PaginatedSelect` and `PaginatedMultiSelect` options

--- a/packages/fuselage/src/components/Option/Option.spec.tsx
+++ b/packages/fuselage/src/components/Option/Option.spec.tsx
@@ -42,4 +42,19 @@ describe('Option', () => {
     expect(click).toHaveBeenCalledTimes(0);
     expect(prevent).toHaveBeenCalledTimes(1);
   });
+
+  it('should render description when passed', () => {
+    const { getByText } = render(
+      <Option label='Option label' description='Option description' />,
+    );
+
+    expect(getByText('Option label')).toBeInTheDocument();
+    expect(getByText('Option description')).toBeInTheDocument();
+  });
+
+  it('should not render description when description is passed but label is not', () => {
+    const { queryByText } = render(<Option description='Option description' />);
+
+    expect(queryByText('Option description')).not.toBeInTheDocument();
+  });
 });

--- a/packages/fuselage/src/components/Option/Option.tsx
+++ b/packages/fuselage/src/components/Option/Option.tsx
@@ -8,7 +8,7 @@ import type {
 import { forwardRef, memo } from 'react';
 
 import type { Icon } from '../..';
-import { OptionColumn } from '../..';
+import { OptionColumn, OptionDescription } from '../..';
 import { prevent } from '../../helpers/prevent';
 import type Box from '../Box';
 
@@ -99,7 +99,15 @@ const Option = memo(
           {avatar && <OptionAvatar>{avatar}</OptionAvatar>}
           {icon && <OptionIcon name={icon} />}
           {gap && <OptionColumn />}
-          {label && <OptionContent>{label}</OptionContent>}
+          {label && (
+            <OptionContent>
+              {label}
+
+              {description && (
+                <OptionDescription>{description}</OptionDescription>
+              )}
+            </OptionContent>
+          )}
           {label !== children && children}
         </div>
       </Tag>

--- a/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
+++ b/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
@@ -12,7 +12,12 @@ import Tile from '../Tile';
 
 type OptionsPaginatedProps = Omit<ComponentProps<typeof Box>, 'onSelect'> & {
   multiple?: boolean;
-  options: { value: unknown; label: string; selected?: boolean }[];
+  options: {
+    value: unknown;
+    label: string;
+    selected?: boolean;
+    description?: string;
+  }[];
   cursor: number;
   withTitle?: boolean;
   renderItem?: ElementType;
@@ -62,7 +67,7 @@ export const OptionsPaginated = forwardRef(
       index: number;
       data: OptionsPaginatedProps['options'][0];
     }) => {
-      const { value, label, selected } = data;
+      const { value, label, description, selected } = data;
       return (
         <OptionComponent
           {...(withTitle && { title: label })}
@@ -74,6 +79,7 @@ export const OptionsPaginated = forwardRef(
             return false;
           }}
           key={value}
+          description={description}
           value={value}
           selected={selected || (multiple !== true && null)}
           focus={cursor === index || null}

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
@@ -18,6 +18,7 @@ import SelectFocus from '../Select/SelectFocus';
 export type PaginatedMultiSelectOption = {
   value: string | number;
   label: string;
+  description?: string;
 };
 
 type PaginatedMultiSelectProps = Omit<

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelectFiltered.stories.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelectFiltered.stories.tsx
@@ -43,3 +43,12 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
 };
+
+export const WithDescription = Template.bind({});
+WithDescription.args = {
+  options: Array.from({ length: 10 }, (_, i) => ({
+    value: i,
+    label: `Item #${i}`,
+    description: `Description #${i}`,
+  })),
+};

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
@@ -19,6 +19,7 @@ import PaginatedSelectWrapper from './PaginatedSelectWrapper';
 type PaginatedOptionType = {
   value: string | number;
   label: string;
+  description?: string;
 };
 export type PaginatedSelectProps = Omit<SelectProps, 'options'> & {
   anchor?: ElementType;
@@ -64,9 +65,12 @@ export const PaginatedSelect = ({
 
   const valueLabel = option?.label;
 
-  const visibleText =
-    (filter === undefined || visible === AnimatedVisibility.HIDDEN) &&
-    (valueLabel || placeholder || typeof placeholder === 'string');
+  const isUnfilteredOrHidden =
+    filter === undefined || visible === AnimatedVisibility.HIDDEN;
+
+  const visibleText = isUnfilteredOrHidden
+    ? valueLabel || placeholder
+    : undefined;
 
   const handleClick = useEffectEvent(() => {
     if (visible === AnimatedVisibility.VISIBLE) {

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
@@ -65,12 +65,9 @@ export const PaginatedSelect = ({
 
   const valueLabel = option?.label;
 
-  const isUnfilteredOrHidden =
-    filter === undefined || visible === AnimatedVisibility.HIDDEN;
-
-  const visibleText = isUnfilteredOrHidden
-    ? valueLabel || placeholder
-    : undefined;
+  const visibleText =
+    (filter === undefined || visible === AnimatedVisibility.HIDDEN) &&
+    (valueLabel || placeholder || typeof placeholder === 'string');
 
   const handleClick = useEffectEvent(() => {
     if (visible === AnimatedVisibility.VISIBLE) {

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.stories.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.stories.tsx
@@ -34,3 +34,12 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
 };
+
+export const WithDescription = Template.bind({});
+WithDescription.args = {
+  options: Array.from({ length: 10 }, (_, i) => ({
+    value: i,
+    label: `Item #${i}`,
+    description: `Description #${i}`,
+  })),
+};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR adds an optional description prop to the following components:
- `PaginatedSelect`
- `PaginatedSelectFiltered`
- `PaginatedMultiSelect`
- `PaginatedMultiSelectFiltered`

While the `Option` component previously accepted a `description` prop, it didn’t render anything. It now renders an `OptionDescription` internally when a description is provided.

**Note:** The description is rendered only if the option has a label; otherwise, the option’s children take precedence.

## Issue(s)
[CTZ-244](https://rocketchat.atlassian.net/browse/CTZ-244)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-244]: https://rocketchat.atlassian.net/browse/CTZ-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ