### PR TITLE
fix(fuselage): Placeholder not being displayed in PaginatedSelectFiltered

### DIFF
--- a/.changeset/twenty-bobcats-cover.md
+++ b/.changeset/twenty-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): Placeholder not being displayed in PaginatedSelectFiltered

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.spec.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.spec.tsx
@@ -1,0 +1,20 @@
+import { screen } from '@testing-library/dom';
+import { render } from '@testing-library/react';
+
+import { PaginatedSelect } from './PaginatedSelect';
+
+describe('[PaginatedSelect Component]', () => {
+  test('should render placeholder when provided', () => {
+    const placeholder = 'Select an option...';
+    const defaultProps = {
+      filter: '',
+      setFilter: jest.fn(),
+      onChange: jest.fn(),
+      options: [{ value: 'item1', label: `Item #1` }],
+    };
+
+    render(<PaginatedSelect {...defaultProps} placeholder={placeholder} />);
+
+    expect(screen.getByPlaceholderText(placeholder)).toBeVisible();
+  });
+});

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.spec.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.spec.tsx
@@ -15,6 +15,6 @@ describe('[PaginatedSelect Component]', () => {
 
     render(<PaginatedSelect {...defaultProps} placeholder={placeholder} />);
 
-    expect(screen.getByPlaceholderText(placeholder)).toBeVisible();
+    expect(screen.getByText(placeholder)).toBeVisible();
   });
 });

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelect.tsx
@@ -38,7 +38,7 @@ export const PaginatedSelect = ({
   options = [],
   anchor: Anchor = SelectFocus,
   onChange = () => {},
-  placeholder = '',
+  placeholder,
   renderOptions: _Options = OptionsPaginated,
   renderItem = Option,
   endReached,
@@ -64,9 +64,12 @@ export const PaginatedSelect = ({
 
   const valueLabel = option?.label;
 
-  const visibleText =
-    (filter === undefined || visible === AnimatedVisibility.HIDDEN) &&
-    (valueLabel || placeholder || typeof placeholder === 'string');
+  const isUnfilteredOrHidden =
+    filter === undefined || visible === AnimatedVisibility.HIDDEN;
+
+  const visibleText = isUnfilteredOrHidden
+    ? valueLabel || placeholder
+    : undefined;
 
   const handleClick = useEffectEvent(() => {
     if (visible === AnimatedVisibility.VISIBLE) {

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
@@ -12,7 +12,7 @@ const testCases = Object.values(composeStories(stories)).map((Story) => [
   Story,
 ]);
 
-describe('[Bubble Rendering]', () => {
+describe('[PaginatedSelectFiltered Component]', () => {
   test.each(testCases)(
     `renders %s without crashing`,
     async (_storyname, Story) => {

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
@@ -1,0 +1,67 @@
+import { composeStories } from '@storybook/react-webpack5';
+import { screen } from '@testing-library/dom';
+import { axe } from 'jest-axe';
+
+import { render } from '../../testing';
+
+import { PaginatedSelectFiltered } from './PaginatedSelectFiltered';
+import * as stories from './PaginatedSelectFiltered.stories';
+
+const testCases = Object.values(composeStories(stories)).map((Story) => [
+  Story.storyName || 'Story',
+  Story,
+]);
+
+describe('[Bubble Rendering]', () => {
+  test.each(testCases)(
+    `renders %s without crashing`,
+    async (_storyname, Story) => {
+      const tree = render(<Story />);
+      expect(tree.baseElement).toMatchSnapshot();
+    },
+  );
+
+  test.each(testCases)(
+    '%s should have no a11y violations',
+    async (_storyname, Story) => {
+      const { container } = render(<Story />);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    },
+  );
+
+  test('should render placeholder when provided', async () => {
+    const hiddenClass = 'rcx-select__wrapper--hidden';
+    const placeholder = 'Select an option...';
+    const defaultProps = {
+      setFilter: jest.fn(),
+      onChange: jest.fn(),
+      options: [{ value: 'item1', label: `Item #1` }],
+    };
+
+    const { rerender } = render(
+      <PaginatedSelectFiltered {...defaultProps} placeholder={placeholder} />,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'placeholder',
+      placeholder,
+    );
+
+    // Necessary due to styles not being properly computed in the test environment
+    expect(screen.getByRole('textbox').parentElement).not.toHaveClass(
+      hiddenClass,
+    );
+
+    rerender(<PaginatedSelectFiltered {...defaultProps} value='item1' />);
+
+    expect(screen.getByRole('textbox')).not.toHaveAttribute(
+      'placeholder',
+      placeholder,
+    );
+
+    // Necessary due to styles not being properly computed in the test environment
+    expect(screen.getByRole('textbox').parentElement).toHaveClass(hiddenClass);
+  });
+});

--- a/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
+++ b/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`[Bubble Rendering] renders Disabled without crashing 1`] = `
+exports[`[PaginatedSelectFiltered Component] renders Disabled without crashing 1`] = `
 <body>
   <div>
     <div
@@ -33,7 +33,7 @@ exports[`[Bubble Rendering] renders Disabled without crashing 1`] = `
 </body>
 `;
 
-exports[`[Bubble Rendering] renders Errored without crashing 1`] = `
+exports[`[PaginatedSelectFiltered Component] renders Errored without crashing 1`] = `
 <body>
   <div>
     <div
@@ -64,7 +64,7 @@ exports[`[Bubble Rendering] renders Errored without crashing 1`] = `
 </body>
 `;
 
-exports[`[Bubble Rendering] renders Normal without crashing 1`] = `
+exports[`[PaginatedSelectFiltered Component] renders Normal without crashing 1`] = `
 <body>
   <div>
     <div

--- a/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
+++ b/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`[Bubble Rendering] renders Disabled without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-select disabled rcx-css-5gkzmp"
+      disabled=""
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-select__wrapper rcx-css-bpb89k"
+      >
+        <input
+          aria-haspopup="listbox"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-select__focus rcx-css-1l0s473"
+          disabled=""
+          placeholder="Placeholder here..."
+          value=""
+        />
+        <div
+          class="rcx-box rcx-box--full rcx-select__addon rcx-css-x7bl3q rcx-css-6bg1ps"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-4pvxx3"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`[Bubble Rendering] renders Errored without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-select invalid rcx-css-5gkzmp"
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-select__wrapper rcx-css-bpb89k"
+      >
+        <input
+          aria-haspopup="listbox"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-select__focus rcx-css-1l0s473"
+          placeholder="Placeholder here..."
+          value=""
+        />
+        <div
+          class="rcx-box rcx-box--full rcx-select__addon rcx-css-x7bl3q rcx-css-6bg1ps"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-4pvxx3"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`[Bubble Rendering] renders Normal without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-select rcx-css-5gkzmp"
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-select__wrapper rcx-css-bpb89k"
+      >
+        <input
+          aria-haspopup="listbox"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-select__focus rcx-css-1l0s473"
+          placeholder="Placeholder here..."
+          value=""
+        />
+        <div
+          class="rcx-box rcx-box--full rcx-select__addon rcx-css-x7bl3q rcx-css-6bg1ps"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-4pvxx3"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a bug in the `PaginatedSelect` that was affecting only `PaginatedSelectFiltered`. The bug prevented the placeholder from being displayed in the `PaginatedSelectFiltered` due incorrect visible text check, causing the anchor to be hidden when not focused. The issue was fixed by adjusting the visibility check. Unit tests were also added to prevent this issue from happening again.

Note: classNames were used in the tests due to the select styles not being properly computed in the `PaginatedSelectFiltered` unit tests.

This PR fixes a bug in `PaginatedSelect` that was affecting `PaginatedSelectFiltered`, where the placeholder was not displayed due to an incorrect visible text check. As a result, the anchor element was hidden when the select was not focused. The issue has been resolved by adjusting the visibility check logic.

**Before:** 
<img width="270" alt="Screenshot 2025-07-07 at 20 01 10" src="https://github.com/user-attachments/assets/b3d43816-2b83-4697-b0c1-4a25e7b9a104" />

**After**
<img width="270" alt="Screenshot 2025-07-07 at 19 54 39" src="https://github.com/user-attachments/assets/1272e77f-0eea-486d-9594-ee3add1a4efa" />

## Issue(s)
[CTZ-244](https://rocketchat.atlassian.net/browse/CTZ-244)

## Further comments

Unit tests have been added to prevent regressions.
Note: Class names were used in the tests because styles from the `Select` component don't seem to be fully computed in the `PaginatedSelectFiltered` unit tests. 🤔 

[CTZ-244]: https://rocketchat.atlassian.net/browse/CTZ-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ