### PR TITLE
fix(stories): update Box stories to correctly render colors and layouts

### DIFF
--- a/packages/fuselage/src/components/Box/colors.stories.tsx
+++ b/packages/fuselage/src/components/Box/colors.stories.tsx
@@ -32,25 +32,26 @@ export const SurfaceColors: StoryFn<typeof Box> = () => (
   </>
 );
 SurfaceColors.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(story().props.children).map((child: any) =>
-        cloneElement(
-          child,
-          {
-            m: 'x4',
-            size: 'x122',
-            color: 'annotation',
-            border: '2px solid',
-            borderColor: 'stroke light',
-            borderRadius: 4,
-            textAlign: 'center',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-          child.props.bg,
-        ),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(
+            child,
+            {
+              m: 'x4',
+              size: 'x122',
+              color: 'annotation',
+              border: '2px solid',
+              borderColor: 'stroke light',
+              borderRadius: 4,
+              textAlign: 'center',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            child.props.bg,
+          ),
       )}
     </Box>
   ),
@@ -67,23 +68,24 @@ export const StatusColors: StoryFn<typeof Box> = () => (
   </>
 );
 StatusColors.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center' overflow='hidden'>
-      {flattenChildren(story().props.children).map((child: any) =>
-        cloneElement(
-          child,
-          {
-            m: 'x4',
-            size: 'x122',
-            border: '2px solid',
-            borderRadius: 4,
-            textAlign: 'center',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-          child.props.bg.replace('status-background-', ''),
-        ),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(
+            child,
+            {
+              m: 'x4',
+              size: 'x122',
+              border: '2px solid',
+              borderRadius: 4,
+              textAlign: 'center',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            child.props.bg.replace('status-background-', ''),
+          ),
       )}
     </Box>
   ),
@@ -103,25 +105,26 @@ export const StrokeColors: StoryFn<typeof Box> = () => (
   </>
 );
 StrokeColors.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center' overflow='hidden'>
-      {flattenChildren(story().props.children).map((child: any) =>
-        cloneElement(
-          child,
-          {
-            m: 'x4',
-            textAlign: 'center',
-            size: 'x122',
-            color: 'default',
-            borderWidth: 'x8',
-            borderRadius: 4,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            p: 8,
-          },
-          child.props.borderColor,
-        ),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(
+            child,
+            {
+              m: 'x4',
+              textAlign: 'center',
+              size: 'x122',
+              color: 'default',
+              borderWidth: 'x8',
+              borderRadius: 4,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              p: 8,
+            },
+            child.props.borderColor,
+          ),
       )}
     </Box>
   ),
@@ -141,15 +144,16 @@ export const FontColors: StoryFn<typeof Box> = () => (
   </>
 );
 FontColors.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box
       display='flex'
       alignItems='flex-start'
       overflow='hidden'
       flexDirection='column'
     >
-      {flattenChildren(story().props.children).map((child: any) =>
-        cloneElement(child, { m: 'x4', p: 'x4' }, child.props.color),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, { m: 'x4', p: 'x4' }, child.props.color),
       )}
     </Box>
   ),

--- a/packages/fuselage/src/components/Box/layout.stories.tsx
+++ b/packages/fuselage/src/components/Box/layout.stories.tsx
@@ -51,14 +51,15 @@ export const Borders: StoryFn<typeof Box> = () => (
   </>
 );
 Borders.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, {
-          size: 'x32',
-          m: 'x16',
-          borderColor: 'stroke-dark',
-        }),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, {
+            size: 'x32',
+            m: 'x16',
+            borderColor: 'stroke-dark',
+          }),
       )}
     </Box>
   ),
@@ -74,14 +75,15 @@ export const BorderRadii: StoryFn<typeof Box> = () => (
   </>
 );
 BorderRadii.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, {
-          bg: 'dark',
-          size: 'x32',
-          m: 'x16',
-        }),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, {
+            bg: 'dark',
+            size: 'x32',
+            m: 'x16',
+          }),
       )}
     </Box>
   ),
@@ -98,16 +100,17 @@ export const Display: StoryFn<typeof Box> = () => (
   </>
 );
 Display.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box color='default'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, {
-          children: child.props.display,
-          border: '1px solid',
-          borderColor: 'stroke-light',
-          m: 'x4',
-          p: 'x4',
-        }),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, {
+            children: child.props.display,
+            border: '1px solid',
+            borderColor: 'stroke-light',
+            m: 'x4',
+            p: 'x4',
+          }),
       )}
     </Box>
   ),
@@ -123,14 +126,15 @@ export const Elevation: StoryFn<typeof Box> = () => (
   </>
 );
 Elevation.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, {
-          bg: 'light',
-          size: 'x32',
-          m: 'x16',
-        }),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, {
+            bg: 'light',
+            size: 'x32',
+            m: 'x16',
+          }),
       )}
     </Box>
   ),
@@ -145,10 +149,11 @@ export const Heights: StoryFn<typeof Box> = () => (
   </>
 );
 Heights.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, { bg: 'neutral', w: 'x32', m: 'x4' }),
+      {flattenChildren(context.originalStoryFn(context.args)).map(
+        (child: any) =>
+          cloneElement(child, { bg: 'neutral', w: 'x32', m: 'x4' }),
       )}
     </Box>
   ),
@@ -171,9 +176,11 @@ export const Insets: StoryFn<typeof Box> = () => (
   </>
 );
 Insets.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) => (
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) => (
         <Box
           key={child.key}
           position='relative'
@@ -215,9 +222,11 @@ export const Margins: StoryFn<typeof Box> = () => (
   </>
 );
 Margins.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(story().props.children).map((child: any, i) => (
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any, i) => (
         <Box key={i} bg='neutral-200' m={16}>
           {cloneElement(
             child,
@@ -262,9 +271,11 @@ export const Paddings: StoryFn<typeof Box> = () => (
   </>
 );
 Paddings.decorators = [
-  (story: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(story().props.children).map((child: any, i) => (
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any, i) => (
         <Box key={i} bg='neutral-200' m={16}>
           {cloneElement(
             child,
@@ -286,9 +297,11 @@ export const Position: StoryFn<typeof Box> = () => (
   </>
 );
 Position.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) =>
         cloneElement(child, {
           bg: 'neutral',
           size: 'x32',
@@ -308,9 +321,11 @@ export const Widths: StoryFn<typeof Box> = () => (
   </>
 );
 Widths.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) =>
         cloneElement(child, { bg: 'neutral', h: 'x32', m: 'x4' }),
       )}
     </Box>
@@ -325,11 +340,11 @@ export const Sizes: StoryFn<typeof Box> = () => (
   </>
 );
 Sizes.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
-        cloneElement(child, { bg: 'neutral', m: 'x4' }),
-      )}
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) => cloneElement(child, { bg: 'neutral', m: 'x4' }))}
     </Box>
   ),
 ];
@@ -359,9 +374,11 @@ export const VerticalAlign: StoryFn<typeof Box> = () => (
   </>
 );
 VerticalAlign.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box>
-      {flattenChildren(fn().props.children).map((child: any) =>
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) =>
         cloneElement(child, {
           display: 'inline',
           children: child.props.verticalAlign,
@@ -386,9 +403,11 @@ export const ZIndex: StoryFn<typeof Box> = () => (
   </>
 );
 ZIndex.decorators = [
-  (fn: any) => (
+  (_: any, context: any) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
-      {flattenChildren(fn().props.children).map((child: any) =>
+      {flattenChildren(
+        context.originalStoryFn(context.args).props.children,
+      ).map((child: any) =>
         cloneElement(child, {
           bg: 'neutral',
           borderWidth: 'x4',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
- Fixed the rendering of various color variants (`bg='light'`, `bg='tint'`, etc.) in the Box stories.
- Ensured layout-related props like padding, margin, border, and size are visually represented.
- Wrapped the stories in a flex container to showcase variants side-by-side.

Video proof of issue fix-

https://github.com/user-attachments/assets/e1d101de-dc2c-4f0b-8165-666da926dd2f



<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
Closes #1695 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments
Used `SurfaceContext.Provider` to ensure background color tokens are interpreted correctly when rendering `Box` variants. Considered alternatives like hardcoded background colors but chose context to align with design token usage across Fuselage.


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
