### PR TITLE
feat(fuselage): Made index available to OptionsPaginated rendered items

### DIFF
--- a/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
+++ b/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
@@ -66,6 +66,7 @@ export const OptionsPaginated = forwardRef(
       return (
         <OptionComponent
           {...(withTitle && { title: label })}
+          index={index}
           role='option'
           label={label}
           onMouseDown={(e: SyntheticEvent) => {

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.spec.tsx
@@ -1,8 +1,11 @@
 import { composeStories } from '@storybook/react-webpack5';
-import { screen } from '@testing-library/dom';
+import { screen, waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { VirtuosoMockContext } from 'react-virtuoso';
 
 import { render } from '../../testing';
+import Option from '../Option';
 
 import { PaginatedSelectFiltered } from './PaginatedSelectFiltered';
 import * as stories from './PaginatedSelectFiltered.stories';
@@ -63,5 +66,67 @@ describe('[PaginatedSelectFiltered Component]', () => {
 
     // Necessary due to styles not being properly computed in the test environment
     expect(screen.getByRole('textbox').parentElement).toHaveClass(hiddenClass);
+  });
+
+  test('should render custom option when renderItem is provided', async () => {
+    const renderItem = jest.fn(({ label, value, index, ...props }) => (
+      <Option {...props}>
+        Label: {label}; Value: {value}; Index: {index}
+      </Option>
+    ));
+    const defaultProps = {
+      setFilter: jest.fn(),
+      onChange: jest.fn(),
+      options: [
+        { value: 'item1', label: 'Item 1' },
+        { value: 'item2', label: 'Item 2' },
+      ],
+      placeholder: 'Select an option...',
+      renderItem,
+    };
+
+    render(<PaginatedSelectFiltered {...defaultProps} />, {
+      wrapper: ({ children }) => (
+        <VirtuosoMockContext.Provider
+          value={{ viewportHeight: 300, itemHeight: 30 }}
+        >
+          {children}
+        </VirtuosoMockContext.Provider>
+      ),
+    });
+
+    await userEvent.click(screen.getByPlaceholderText('Select an option...'));
+
+    await waitFor(() =>
+      expect(screen.getByRole('listbox')).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Label: Item 1; Value: item1; Index: 0',
+      }),
+    ).toBeInTheDocument();
+
+    expect(renderItem.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        label: 'Item 1',
+        value: 'item1',
+        index: 0,
+      }),
+    );
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Label: Item 2; Value: item2; Index: 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(renderItem.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        label: 'Item 2',
+        value: 'item2',
+        index: 1,
+      }),
+    );
   });
 });

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.stories.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.stories.tsx
@@ -1,5 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/react-webpack5';
 
+import Option, { OptionDescription } from '../Option';
+
 import { PaginatedSelectFiltered } from './PaginatedSelectFiltered';
 
 export default {
@@ -33,4 +35,15 @@ Errored.args = {
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
+};
+
+export const WithRenderItem = Template.bind({});
+WithRenderItem.args = {
+  renderItem: ({ label, value, index, ...props }) => (
+    <Option {...props} label={<strong>{label}</strong>}>
+      <OptionDescription>
+        (Value: {value}, Index: {index})
+      </OptionDescription>
+    </Option>
+  ),
 };

--- a/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
+++ b/packages/fuselage/src/components/PaginatedSelect/__snapshots__/PaginatedSelectFiltered.spec.tsx.snap
@@ -94,3 +94,34 @@ exports[`[PaginatedSelectFiltered Component] renders Normal without crashing 1`]
   </div>
 </body>
 `;
+
+exports[`[PaginatedSelectFiltered Component] renders WithRenderItem without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-select rcx-css-5gkzmp"
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-select__wrapper rcx-css-bpb89k"
+      >
+        <input
+          aria-haspopup="listbox"
+          class="rcx-box rcx-box--full rcx-box--animated rcx-input-box--undecorated rcx-input-box rcx-select__focus rcx-css-1l0s473"
+          placeholder="Placeholder here..."
+          value=""
+        />
+        <div
+          class="rcx-box rcx-box--full rcx-select__addon rcx-css-x7bl3q rcx-css-6bg1ps"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-chevron-down rcx-icon rcx-css-4pvxx3"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR enhances the `OptionsPaginated` component by exposing the index of each item being rendered through a prop `index`. This is especially useful when customizing option rendering via the `renderItem` prop, allowing developers to implement index-based logic or styling.

Components that use `OptionsPaginated` internally, such as `PaginatedSelect` and `PaginatedSelectMultiple`, will automatically benefit from this improvement.

## Issue(s)
[CTZ-244](https://rocketchat.atlassian.net/browse/CTZ-244)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
