### PR TITLE
refactor(fuselage-hooks): `useSafeRefCallback` reimplemented callback/cleanup order

### DIFF
--- a/packages/fuselage-hooks/src/useSafeRefCallback/useSafeRefCallback.spec.tsx
+++ b/packages/fuselage-hooks/src/useSafeRefCallback/useSafeRefCallback.spec.tsx
@@ -28,14 +28,12 @@ describe('useSafeRefCallback', () => {
 
     rerender(<TestComponent callback={callback} renderSpan />);
 
-    expect(callback).toHaveBeenCalledTimes(3);
-    expect(callback.mock.calls[1][0]).toBe(null);
-    expect(callback.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
 
     unmount();
 
-    expect(callback).toHaveBeenCalledTimes(4);
-    expect(callback.mock.calls[3][0]).toBe(null);
+    expect(callback).toHaveBeenCalledTimes(2);
   });
 
   it('should run again when callback reference changes', () => {
@@ -50,23 +48,58 @@ describe('useSafeRefCallback', () => {
 
     rerender(<TestComponent callback={callback2} />);
 
-    // Ensure first callback has been properly unmounted
-    expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback.mock.calls[1][0]).toBe(null);
+    expect(callback).toHaveBeenCalledTimes(1);
 
     expect(callback2).toHaveBeenCalledTimes(1);
     expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
 
     rerender(<TestComponent callback={callback2} renderSpan />);
 
-    expect(callback2).toHaveBeenCalledTimes(3);
-    expect(callback2.mock.calls[1][0]).toBe(null);
-    expect(callback2.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+    expect(callback2).toHaveBeenCalledTimes(2);
+    expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
 
     unmount();
 
-    expect(callback2).toHaveBeenCalledTimes(4);
-    expect(callback2.mock.calls[3][0]).toBe(null);
+    expect(callback2).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call cleanup if callback changes', () => {
+    const cleanup = jest.fn();
+    const callback = jest.fn<() => void, any>(() => cleanup);
+
+    const { rerender, unmount } = render(<TestComponent callback={callback} />);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    const cleanup2 = jest.fn();
+    const callback2 = jest.fn<() => void, any>(() => cleanup2);
+
+    rerender(<TestComponent callback={callback2} />);
+
+    // Ensure first callback has been properly unmounted
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+    expect(cleanup2).not.toHaveBeenCalled();
+
+    rerender(<TestComponent callback={callback2} renderSpan />);
+
+    expect(callback2).toHaveBeenCalledTimes(2);
+    expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
+
+    expect(cleanup2).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(callback2).toHaveBeenCalledTimes(2);
+
+    expect(cleanup2).toHaveBeenCalledTimes(2);
   });
 
   it('should call cleanup with previous value on rerender', () => {
@@ -82,23 +115,18 @@ describe('useSafeRefCallback', () => {
 
     rerender(<TestComponent callback={callback} renderSpan />);
 
-    expect(callback).toHaveBeenCalledTimes(3);
-    expect(callback.mock.calls[1][0]).toBe(null);
-    expect(callback.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
 
-    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(cleanup).toHaveBeenCalledTimes(1);
 
     const cleanup2 = jest.fn();
     const callback2 = jest.fn<() => void, any>(() => cleanup2);
 
     rerender(<TestComponent callback={callback2} renderSpan />);
 
-    // Ensure first callback has been properly unmounted
-    expect(callback).toHaveBeenCalledTimes(4);
-    expect(callback.mock.calls[3][0]).toBe(null);
-
-    console.log(cleanup.mock.calls);
-    expect(cleanup).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(cleanup).toHaveBeenCalledTimes(2);
 
     expect(callback2).toHaveBeenCalledTimes(1);
     expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
@@ -107,17 +135,14 @@ describe('useSafeRefCallback', () => {
 
     rerender(<TestComponent callback={callback2} />);
 
-    expect(callback2).toHaveBeenCalledTimes(3);
-    expect(callback2.mock.calls[1][0]).toBe(null);
-    expect(callback2.mock.calls[2][0]).toBeInstanceOf(HTMLDivElement);
+    expect(callback2).toHaveBeenCalledTimes(2);
+    expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
 
-    expect(cleanup2).toHaveBeenCalledTimes(2);
+    expect(cleanup2).toHaveBeenCalledTimes(1);
 
     unmount();
 
-    expect(callback2).toHaveBeenCalledTimes(4);
-    expect(callback2.mock.calls[3][0]).toBe(null);
-
-    expect(cleanup2).toHaveBeenCalledTimes(3);
+    expect(callback2).toHaveBeenCalledTimes(2);
+    expect(cleanup2).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This fixes an issue where if the passed callback reference were to change, the cleanup function would be lost.

Additionaly, the callback calling order was refactored. Now when the component unmounts/rerender, the main callback won't be called - instead, the cleanup function will be called in it's place.

Previously, the cleanup function would be called everytime before the callbackRef was called, even if `node` was null. This is the default behaviour for refCallbacks, and serves the purpose of communicating that that node stopped existing. Since we now have a cleanup function, this "extra call" with a `null` node doesn't need to happen anymore, since the cleanup function will be called at this time.
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
