### PR TITLE
chore(fuselage): Correctly render colors and layouts `Box` stories

### DIFF
--- a/packages/fuselage/src/components/Box/colors.stories.tsx
+++ b/packages/fuselage/src/components/Box/colors.stories.tsx
@@ -32,7 +32,7 @@ export const SurfaceColors: StoryFn<typeof Box> = () => (
   </>
 );
 SurfaceColors.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -68,7 +68,7 @@ export const StatusColors: StoryFn<typeof Box> = () => (
   </>
 );
 StatusColors.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center' overflow='hidden'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -105,7 +105,7 @@ export const StrokeColors: StoryFn<typeof Box> = () => (
   </>
 );
 StrokeColors.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center' overflow='hidden'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -144,7 +144,7 @@ export const FontColors: StoryFn<typeof Box> = () => (
   </>
 );
 FontColors.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box
       display='flex'
       alignItems='flex-start'

--- a/packages/fuselage/src/components/Box/layout.stories.tsx
+++ b/packages/fuselage/src/components/Box/layout.stories.tsx
@@ -51,7 +51,7 @@ export const Borders: StoryFn<typeof Box> = () => (
   </>
 );
 Borders.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -75,7 +75,7 @@ export const BorderRadii: StoryFn<typeof Box> = () => (
   </>
 );
 BorderRadii.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -100,7 +100,7 @@ export const Display: StoryFn<typeof Box> = () => (
   </>
 );
 Display.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box color='default'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -126,7 +126,7 @@ export const Elevation: StoryFn<typeof Box> = () => (
   </>
 );
 Elevation.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -149,7 +149,7 @@ export const Heights: StoryFn<typeof Box> = () => (
   </>
 );
 Heights.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(context.originalStoryFn(context.args, context)).map(
         (child: any) =>
@@ -176,7 +176,7 @@ export const Insets: StoryFn<typeof Box> = () => (
   </>
 );
 Insets.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -222,7 +222,7 @@ export const Margins: StoryFn<typeof Box> = () => (
   </>
 );
 Margins.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -271,7 +271,7 @@ export const Paddings: StoryFn<typeof Box> = () => (
   </>
 );
 Paddings.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -297,7 +297,7 @@ export const Position: StoryFn<typeof Box> = () => (
   </>
 );
 Position.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -321,7 +321,7 @@ export const Widths: StoryFn<typeof Box> = () => (
   </>
 );
 Widths.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -340,7 +340,7 @@ export const Sizes: StoryFn<typeof Box> = () => (
   </>
 );
 Sizes.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -374,7 +374,7 @@ export const VerticalAlign: StoryFn<typeof Box> = () => (
   </>
 );
 VerticalAlign.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,
@@ -403,7 +403,7 @@ export const ZIndex: StoryFn<typeof Box> = () => (
   </>
 );
 ZIndex.decorators = [
-  (_: any, context: StoryContext) => (
+  (_: StoryFn, context: StoryContext) => (
     <Box display='flex' flexWrap='wrap' alignItems='center'>
       {flattenChildren(
         context.originalStoryFn(context.args, context).props.children,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
- Fixed the rendering of various color variants (`bg='light'`, `bg='tint'`, etc.) in the Box stories.
- Ensured layout-related props like padding, margin, border, and size are visually represented.
- Wrapped the stories in a flex container to showcase variants side-by-side.

Video proof of issue fix-

https://github.com/user-attachments/assets/e1d101de-dc2c-4f0b-8165-666da926dd2f



<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
Closes #1695 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments
Used `SurfaceContext.Provider` to ensure background color tokens are interpreted correctly when rendering `Box` variants. Considered alternatives like hardcoded background colors but chose context to align with design token usage across Fuselage.


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
