### PR TITLE
fix(fuselage): AutoComplete selected items not being updated when value changes

### DIFF
--- a/.changeset/green-walls-kick.md
+++ b/.changeset/green-walls-kick.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix: AutoComplete selected items not being updated when value changes

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.spec.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.spec.tsx
@@ -93,4 +93,35 @@ describe('[Autocomplete functionality]', () => {
 
     expect(onChange).toHaveBeenCalledWith('');
   });
+
+  it('should update selected items based on the value prop', () => {
+    const { rerender } = render(
+      <AutoComplete
+        value={['1']}
+        filter='test'
+        setFilter={() => {}}
+        options={[{ value: '1', label: 'test1' }]}
+        onChange={() => {}}
+        multiple
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'test1' })).toBeInTheDocument();
+
+    rerender(
+      <AutoComplete
+        value={[]}
+        filter='test'
+        setFilter={() => {}}
+        options={[
+          { value: '1', label: 'test1' },
+          { value: '2', label: 'test2' },
+        ]}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: 'test1' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -60,6 +60,17 @@ const getSelected = (
     : options?.filter((option) => value.includes(option.value));
 };
 
+const isSelectedValid =
+  (value: string | string[] | undefined) => (selected: AutoCompleteOption) => {
+    if (!value) {
+      return false;
+    }
+
+    return typeof value === 'string'
+      ? selected.value === value
+      : value.includes(selected.value);
+  };
+
 /**
  * An input for selection of options.
  */
@@ -86,8 +97,17 @@ export function AutoComplete({
     () => getSelected(value, options) || [],
   );
 
+  useEffect(() => {
+    // Validates if selected items are still valid after value changes
+    setSelected((selected) => {
+      return !selected.every(isSelectedValid(value))
+        ? selected.filter(isSelectedValid(value))
+        : selected;
+    });
+  }, [value]);
+
   const handleSelect = useEffectEvent(([newValue]: OptionType) => {
-    if (selected?.some((item) => item.value === newValue)) {
+    if (selected.some((item) => item.value === newValue)) {
       hide();
       return;
     }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Previously, selected items in the AutoComplete component could remain visible even when the current value no longer contained them. This PR adds a validation step to ensure consistency between the value and the selected items, removing any invalid ones.

## Issue(s)
[CTZ-336](https://rocketchat.atlassian.net/browse/CTZ-336)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-336]: https://rocketchat.atlassian.net/browse/CTZ-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ