### PR TITLE
fix: (4.1.3) Added aria-live polite

### DIFF
--- a/packages/fuselage/src/components/Callout/Callout.tsx
+++ b/packages/fuselage/src/components/Callout/Callout.tsx
@@ -41,6 +41,7 @@ export const Callout = ({
     <Box
       ref={ref}
       is='section'
+      aria-live='polite'
       className={['rcx-callout', type && `rcx-callout--${type}`, className]
         .filter(Boolean)
         .join(' ')}


### PR DESCRIPTION
Add screen reader support for

Callouts

Should be announced without focusing on them, if they come as a result from user action. If they're already in the UI before any action, they should just work as a part of the UI, so announced when focused on.
Please refer to this [video](https://www.youtube.com/watch?v=5hDCK1q2SDg) for the proper syntax for each element
[RC_ux_guidelines.pdf](https://github.com/-/project/3514/uploads/38d8f8b809b1c9891b831e670e09cf16/RC_ux_guidelines.pdf)

[WA-59](https://rocketchat.atlassian.net/browse/WA-59)

[WA-59]: https://rocketchat.atlassian.net/browse/WA-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ