### PR TITLE
fix(storybook): prevent Docs args table overflow on mobile

### DIFF
--- a/packages/fuselage/.storybook/DocsContainer.tsx
+++ b/packages/fuselage/.storybook/DocsContainer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { addons } from 'storybook/preview-api';
 import { themes } from 'storybook/theming';
 import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
+import './preview.css';
 
 const channel = addons.getChannel();
 

--- a/packages/fuselage/.storybook/preview.css
+++ b/packages/fuselage/.storybook/preview.css
@@ -1,0 +1,5 @@
+*:has(> .docblock-argstable) {
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+  }


### PR DESCRIPTION
Fix Storybook Docs Args table overflow on mobile
What does this PR do?

Fixes a mobile layout issue in Storybook Docs where the Args/Props table overflows the viewport, causing the entire Docs page to scroll horizontally.

On small screens, long type definitions and controls force the table width beyond the viewport, breaking the mobile experience.

How is it fixed?

Wraps Storybook Docs content in a scoped container

Applies a mobile-only horizontal overflow rule so only the Args table scrolls

Keeps desktop layout and dark mode behavior unchanged

Why this change is needed

Prevents page-level horizontal scrolling on mobile

Improves readability and usability of Docs on small screens

Maintains backward compatibility with existing Storybook setup

Testing

Ran Storybook locally using yarn storybook

Verified behavior on mobile viewport (~375px width)

Confirmed no visual regression on desktop

Verified dark mode still works correctly