### PR TITLE
fix(a11y): add dev warning for buttons missing accessible names

### DIFF
--- a/packages/fuselage/src/components/Button/Button.tsx
+++ b/packages/fuselage/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import type { AllHTMLAttributes } from 'react';
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useMemo, Children } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 import { Icon, type IconProps } from '../Icon';
@@ -82,6 +82,22 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
 
       return {};
     }, [primary, secondary, danger, warning, success]);
+
+    // --- Accessibility Check (Dev Only) ---
+    if (process.env.NODE_ENV !== 'production') {
+      const childrenArray = Children.toArray(children);
+      const hasTextContent = childrenArray.some(
+        (child) => typeof child === 'string' && child.trim().length > 0
+      );
+
+      const isVisualOnly = !hasTextContent && (!!icon || !!loading || square);
+
+      if (isVisualOnly && !props['aria-label'] && !props['aria-labelledby']) {
+        console.warn(
+          `Fuselage [Button]: Buttons without visible text (icon-only or square buttons) must provide an 'aria-label' or 'aria-labelledby' prop for accessibility.`
+        );
+      }
+    }
 
     return (
       <Box


### PR DESCRIPTION
### What this PR does
This PR adds a non-breaking accessibility check to the `Button` component that warns developers when a button is visually "empty" (icon-only, loading-only, or square) and lacks an ARIA label.

### Why is this needed?
To ensure WCAG 2.1 compliance. Icon-only buttons are unusable for screen reader users unless an `aria-label` is provided. This warning helps developers catch these omissions during development.

### Changes
- Updated `Button.tsx` to include `Children` from React.
- Added logic to detect "visual-only" buttons.
- Included a `console.warn` wrapped in a production-environment check.

### Testing
1. Render `<Button icon="edit" />` -> Console should show warning.
2. Render `<Button icon="edit" aria-label="Edit" />` -> No warning.
3. Render `<Button>Save</Button>` -> No warning.

closes #1810 