### PR TITLE
fix(fuselage): add a11y warning and enforce default type="button" for Buttons

### DIFF
--- a/packages/fuselage/src/components/Button/Button.tsx
+++ b/packages/fuselage/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import type { AllHTMLAttributes } from 'react';
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useMemo, Children } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 import { Icon, type IconProps } from '../Icon';
@@ -82,6 +82,22 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
 
       return {};
     }, [primary, secondary, danger, warning, success]);
+
+    // --- Accessibility Check (Dev Only) ---
+    if (process.env.NODE_ENV !== 'production') {
+      const childrenArray = Children.toArray(children);
+      const hasTextContent = childrenArray.some(
+        (child) => typeof child === 'string' && child.trim().length > 0
+      );
+
+      const isVisualOnly = !hasTextContent && (!!icon || !!loading || square);
+
+      if (isVisualOnly && !props['aria-label'] && !props['aria-labelledby']) {
+        console.warn(
+          `Fuselage [Button]: Buttons without visible text (icon-only or square buttons) must provide an 'aria-label' or 'aria-labelledby' prop for accessibility.`
+        );
+      }
+    }
 
     return (
       <Box

--- a/packages/fuselage/src/components/Button/Button.tsx
+++ b/packages/fuselage/src/components/Button/Button.tsx
@@ -39,6 +39,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       external,
       icon,
       is = 'button',
+      type = 'button', // Defaulting to 'button' here for safety
       rel: _rel,
       tiny,
       mini,
@@ -53,15 +54,20 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
     },
     ref,
   ) {
-    const extraProps =
-      (is === 'a' && {
-        rel: external ? 'noopener noreferrer' : undefined,
-        target: external ? '_blank' : undefined,
-      }) ||
-      (is === 'button' && {
-        type: 'button',
-      }) ||
-      {};
+    const extraProps = useMemo(() => {
+      if (is === 'a') {
+        return {
+          rel: external ? 'noopener noreferrer' : undefined,
+          target: external ? '_blank' : undefined,
+        };
+      }
+
+      if (is === 'button') {
+        return { type }; // Uses the 'type' prop (default 'button')
+      }
+
+      return {};
+    }, [is, external, type]);
 
     const kindAndVariantProps = useMemo(() => {
       const variant =
@@ -102,7 +108,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
     return (
       <Box
         is={is}
-        type='button'
         rcx-button
         {...kindAndVariantProps}
         rcx-button--small={small}


### PR DESCRIPTION
### What this PR does
This PR addresses two areas of improvement for the `Button` component:

1. **Accessibility**: Adds a development-time warning when a `Button` is icon-only, loading, or square but lacks an `aria-label` or `aria-labelledby`.
2. **Form Safety**: Sets `type="button"` as the default attribute. In HTML, buttons inside forms default to `type="submit"`, which often leads to unintended form submissions when developers use buttons for actions like "Cancel" or "Close".

### Why this is needed
- **A11y**: Screen readers cannot identify the purpose of icon-only buttons without an accessible name.
- **UX**: Prevents accidental page reloads and form submissions, aligning Fuselage with modern UI library standards (MUI, Radix).

### Changes
- Destructured `type` with a default of `'button'`.
- Implemented `Children.toArray` check for accessible text content.
- Added `process.env.NODE_ENV` check for console warnings.

### Testing
- Tested `<Button icon="edit" />` triggers a warning.
- Tested `<Button type="submit">Submit</Button>` still renders correctly as a submit button.

closes #1813 