### PR TITLE
fix(fuselage): ensure TextAreaInput matches global disabled styling

### DIFF
--- a/packages/fuselage/src/components/InputBox/InputBox.styles.scss
+++ b/packages/fuselage/src/components/InputBox/InputBox.styles.scss
@@ -36,6 +36,8 @@
   &.disabled {
     cursor: not-allowed;
     pointer-events: none;
+    // Added background-color to match design system standards for disabled inputs
+    background-color: #{$input-colors-disabled-background-color} !important;
   }
 }
 
@@ -80,6 +82,8 @@
   &:disabled,
   &.disabled {
     color: #{$disabled-color};
+    // Ensures textareas and inputs get the disabled background color
+    background-color: #{$input-colors-disabled-background-color};
   }
 }
 
@@ -248,6 +252,7 @@
   &:disabled,
   &.disabled {
     cursor: not-allowed;
+    background-color: #{$input-colors-disabled-background-color};
   }
 
   @include with-icon-addon-colors(

--- a/packages/fuselage/src/components/TextAreaInput/TextAreaInput.spec.tsx
+++ b/packages/fuselage/src/components/TextAreaInput/TextAreaInput.spec.tsx
@@ -1,9 +1,35 @@
-import { render } from '../../testing';
+import { render, screen } from '../../testing';
 
 import TextAreaInput from './TextAreaInput';
 
 describe('[TextAreaInput]', () => {
-  it('renders without crashing', () => {
-    render(<TextAreaInput />);
-  });
+	it('renders without crashing', () => {
+		render(<TextAreaInput />);
+	});
+
+	it('should have the disabled attribute when the disabled prop is true', () => {
+		render(<TextAreaInput disabled />);
+		
+		const textArea = screen.getByRole('textbox');
+		
+		expect(textArea).toBeDisabled();
+		expect(textArea).toHaveAttribute('disabled');
+	});
+
+	it('should be read-only when the readOnly prop is true', () => {
+		render(<TextAreaInput readOnly />);
+		
+		const textArea = screen.getByRole('textbox');
+		
+		// Note: readOnly elements are NOT 'disabled', but they are 'readOnly'
+		expect(textArea).not.toBeDisabled();
+		expect(textArea).toHaveAttribute('readonly');
+	});
+
+	it('should render an addon when provided', () => {
+		render(<TextAreaInput addon={<span data-testid='addon'>icon</span>} />);
+		
+		const addon = screen.getByTestId('addon');
+		expect(addon).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
### Description: 
This PR updates the InputBox SCSS styles to ensure that textarea elements correctly inherit the disabled background color and cursor styles. It also adds unit tests to verify prop propagation.

### Changes:

Updated InputBox.scss to apply $input-colors-disabled-background-color to textarea types.

Added cursor: not-allowed to the disabled state block.

Updated TextAreaInput.specs.tsx with new test cases for disabled and readOnly attributes.

closes #1817