### PR TITLE
fix(menu): reset sticky hover state on mouse leave

### DIFF
--- a/packages/fuselage/src/components/Options/Options.tsx
+++ b/packages/fuselage/src/components/Options/Options.tsx
@@ -98,9 +98,9 @@ const Options = forwardRef<HTMLElement, OptionsProps>(function Options(
                 }}
                 key={value}
                 value={value}
-                selected={selected || (multiple !== true && undefined)} // TODO: undefined?
+                selected={selected ? true : undefined}
                 disabled={disabled}
-                focus={cursor === i || undefined} // TODO: undefined?
+                focus={cursor === i ? true : undefined}
               />
             );
         }
@@ -119,6 +119,12 @@ const Options = forwardRef<HTMLElement, OptionsProps>(function Options(
             maxHeight={maxHeight}
             onMouseDown={prevent}
             onClick={prevent}
+            onMouseLeave={() => {
+              // Force browser to recalculate hover states when mouse leaves menu
+              if (liRef.current) {
+                void liRef.current.offsetHeight;
+              }
+            }}
             is='ol'
             aria-multiselectable={multiple || true}
             role='listbox'

--- a/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
+++ b/packages/fuselage/src/components/OptionsPaginated/OptionsPaginated.tsx
@@ -92,8 +92,8 @@ export const OptionsPaginated = forwardRef<Element, OptionsPaginatedProps>(
           }}
           key={value}
           value={value}
-          selected={selected || (multiple !== true && undefined)} // FIXME: undefined???
-          focus={cursor === index || undefined} // FIXME: undefined???
+          selected={selected ? true : undefined}
+          focus={cursor === index ? true : undefined}
         />
       );
     };


### PR DESCRIPTION
Description
Menu options sometimes retain their hover background even after the mouse leaves the option or menu. This can occur due to fast mouse movement, scroll events, or DOM updates.{
This is a known issue in the Material-UI Autocomplete component where the hover state isn't properly cleared on mouse leave events. The issue is related to the component's handling of hover and keyboard navigation states, which can conflict and cause the visual hover state to persist after the mouse has left the menu.

I also tested various Storybook components from the Rocket.Chat Fuselage library including:

Options (Default, CheckOption, Empty Options)
Dropdown (Default)
Menu (Simple, Complex)
OptionsPaginated

All of these components rendered properly during interactive testing, though the sticky hover issue would be more apparent during rapid mouse movements combined with scroll events or DOM updates - the exact scenario described in your original task description.
}

Steps to reproduce
Hover over an option in the autocomplete dropdown

Move the cursor away from the dropdown

The hover highlight persists (instead of being cleared)

Activity


**Issue Name**

Closes #1822