### PR TITLE
fix: set default button type to 'button' to prevent accidental form submissions

### DIFF
--- a/packages/fuselage/src/components/Button/Button.tsx
+++ b/packages/fuselage/src/components/Button/Button.tsx
@@ -39,6 +39,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       external,
       icon,
       is = 'button',
+      type='button',
       rel: _rel,
       tiny,
       mini,
@@ -57,11 +58,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       (is === 'a' && {
         rel: external ? 'noopener noreferrer' : undefined,
         target: external ? '_blank' : undefined,
-      }) ||
-      (is === 'button' && {
-        type: 'button',
-      }) ||
-      {};
+      }) || {};
 
     const kindAndVariantProps = useMemo(() => {
       const variant =
@@ -86,7 +83,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
     return (
       <Box
         is={is}
-        type='button'
+ type={is === 'button' ? type : undefined}
         rcx-button
         {...kindAndVariantProps}
         rcx-button--small={small}


### PR DESCRIPTION
Currently, HTML <button> elements default to type="submit" when inside a <form>. 
This PR sets the Fuselage Button default to type="button" to prevent unintended form submissions.
