### PR TITLE
docs(fuselage): add description to SearchInput States story

### DIFF
--- a/packages/fuselage/src/components/SearchInput/SearchInput.stories.tsx
+++ b/packages/fuselage/src/components/SearchInput/SearchInput.stories.tsx
@@ -93,3 +93,19 @@ export const States: StoryFn<typeof SearchInput> = () => (
     />
   </>
 );
+States.parameters = {
+  docs: {
+    description: {
+      story: `
+This story visualizes the **SearchInput** across all supported interactive states and sizes.
+
+- **Default**: The standard resting state of the component.
+- **Hover**: Triggered when the mouse cursor is positioned over the input field.
+- **Active**: Triggered momentarily while the user is clicking or pressing down on the input.
+- **Focus**: Triggered when the user selects the input (via click or keyboard \`Tab\`). This state highlights the border to indicate it is ready for typing.
+- **Disabled**: The input is non-interactive and visually dimmed to indicate unavailability.
+- **Errored**: Indicates a validation failure, typically changing the border color to red.
+      `,
+    },
+  },
+};


### PR DESCRIPTION
## Proposed changes

This PR adds a detailed description to the `States` story in `SearchInput.stories.tsx`. 

**Changes:**
- Added `parameters.docs.description` to the `States` story.
- Documented all interactive states (Default, Hover, Focus, Active, Disabled, Errored) to improve clarity in Storybook.

**Screenshot:**
<img width="1068" height="316" alt="Screenshot 2026-02-06 at 5 35 52 PM" src="https://github.com/user-attachments/assets/b694b668-0019-4d7a-8986-6c03b430a2c8" />

## Issue(s)

Closes #1826

## Checklist

- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [x] I have labeled the PR correctly with the related package
- [ ] I have run visual regression tests (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules