### PR TITLE
fix(AutoComplete): make close button functional

### DIFF
--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -174,6 +174,15 @@ function AutoComplete<TLabel = ReactNode>({
 
   useEffect(reset, [filter, reset]);
 
+  const handleClear = (e: MouseEvent) => {
+    e.stopPropagation();
+    setFilter?.('');
+    onChange(multiple ? [] : '');
+    hide();
+    if (ref.current) {
+      ref.current.blur();
+    }
+  };
   return (
     <Box
       rcx-autocomplete
@@ -240,6 +249,13 @@ function AutoComplete<TLabel = ReactNode>({
           }
           size='x20'
           color='default'
+
+          onClick={(e) =>
+            optionsAreVisible === AnimatedVisibility.VISIBLE
+              ? handleClear(e)
+              : ref.current?.focus()
+          }
+          onMouseDown={(e) => e.preventDefault()}
         />
       </Box>
       <PositionAnimated visible={optionsAreVisible} anchor={containerRef}>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes the non-functional close/clear button in the `AutoComplete` component. Previously, the icon would switch to a 'cross' when the menu was open, but clicking it had no effect.

**Changes:**
* **Functional Clear:** Implemented a `handleClear` function that clears the filter text, resets the selected value, and closes the dropdown.
* **Smart Interaction:** Updated the Icon's `onClick` to trigger the clear action when the menu is visible, and focus the input when it is not.
* **Focus Management:** Added `onMouseDown` prevention to the Icon to stop the input from blurring before the click is registered.

### Demo


https://github.com/user-attachments/assets/48a0eaa7-2838-4c3c-a361-caed9673095a


## Issue(s)

Closes #1296

### Note on remaining behavior:
There is a small flicker in the dropdown when the clear button is clicked, likely due to event propagation and a brief re-render. This PR focuses only on making the close button functional.