### PR TITLE
fix(fuselage): Add tooltip to SidebarV2ItemTitle when truncated Channel name

### DIFF
--- a/packages/fuselage/src/components/SidebarV2/SidebarItem/SidebarItemTitle.tsx
+++ b/packages/fuselage/src/components/SidebarV2/SidebarItem/SidebarItemTitle.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes } from 'react';
 export const SidebarItemTitle = ({
   className,
   unread,
+  onMouseEnter,
   ...props
 }: { unread?: boolean } & HTMLAttributes<HTMLDivElement>) => (
   <div
@@ -13,6 +14,15 @@ export const SidebarItemTitle = ({
     ]
       .filter(Boolean)
       .join(' ')}
+    onMouseEnter={(e) => {
+      const { currentTarget } = e;
+      if (currentTarget.scrollWidth > currentTarget.clientWidth) {
+        currentTarget.title = currentTarget.textContent ?? '';
+      } else {
+        currentTarget.title = '';
+      }
+      onMouseEnter?.(e);
+    }}
     {...props}
   />
 );


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This PR adds a lightweight tooltip to the SidebarV2ItemTitle component.

The Problem: When channel names in the sidebar are long, they are truncated with an ellipsis (...), but there was no way for users to see the full name without opening the channel.


https://github.com/user-attachments/assets/d21a29d1-d12c-4538-8eda-b1566ad77218



**After**


https://github.com/user-attachments/assets/d01b193d-d866-40f2-af38-4923f35d07f8



<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

Add smart tooltip to SidebarV2ItemTitle when truncated

<!-- END CHANGELOG -->


<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
For this implementation, I used the native browser 
title
 attribute to keep the sidebar as lightweight as possible, especially given the high number of items it can contain. I've also ensured that any onMouseEnter prop passed by consumers is still executed correctly.

Does this approach look good to you, or would you prefer using a custom Tooltip component to match the design system more closely? I'm happy to refine this based on your feedback