### PR TITLE
test: add missing type attribute and behavior tests for Button component

### DIFF
--- a/packages/fuselage/src/components/Button/Button.spec.tsx
+++ b/packages/fuselage/src/components/Button/Button.spec.tsx
@@ -52,4 +52,22 @@ describe('[IconButton Component]', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  it('should default to type="button" to prevent accidental form submissions', () => {
+    const { getByRole } = render(<Default />);
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('should allow overriding type attribute when explicitly passed', () => {
+    const { getByRole } = render(<Default type='submit' />);
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('type', 'submit');
+  });
+
+  it('should render as anchor tag when is="a" prop is passed', () => {
+    const { getByRole } = render(<Default is='a' href='#' />);
+    const link = getByRole('link');
+    expect(link.tagName).toBe('A');
+  });
 });


### PR DESCRIPTION
Adds missing unit tests for the Button component to verify:

1. Button defaults to type="button" to prevent accidental form submissions
2. Button allows overriding type attribute when explicitly passed
3. Button renders as anchor tag when is="a" prop is passed

The existing tests only checked rendering and accessibility (a11y).
There were no tests verifying the Button's type attribute behavior,
which is critical to prevent accidental form submissions in apps
using Fuselage components.

Issue(s):
Closes #1813

Further comments:
This PR adds test coverage for the default type="button" behavior 
discussed in #1813. The Button component already correctly sets 
type="button" as default, but there were no tests to verify this 
behavior and prevent future regressions.

Tests added:
- Verifies Button renders with type="button" by default
- Verifies type attribute can be overridden when explicitly passed
- Verifies Button renders as anchor when is="a" prop is passed