### PR TITLE
fix(fuselage): remove flicker in closing animations in MultiSelect and AutoComplete components

### DIFF
--- a/.changeset/small-berries-feel.md
+++ b/.changeset/small-berries-feel.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+Fix dropdown flickering when closing Autocomplete, Multiselect, and similar components

--- a/packages/fuselage/src/components/AnimatedVisibility/AnimatedVisibility.tsx
+++ b/packages/fuselage/src/components/AnimatedVisibility/AnimatedVisibility.tsx
@@ -46,6 +46,7 @@ const AnimatedVisibility = (props: AnimatedVisibilityProps) => {
   const className = useStyle(
     css`
       animation-duration: 230ms;
+      animation-fill-mode: forwards;
 
       ${visibility === AnimatedVisibility.HIDING &&
       css`


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Problem
When closing the dropdown in MultiSelect and Autocomplete, there was a quick flicker at the end — the dropdown would flash back to fully visible for a split second before finally disappearing.

## Root Cause
The exit animation itself was working fine and playing all the way through. The problem was happening right after the animation finished. The browser resets the element back to its original state. That brief reset is what caused the visible flicker.

## Proposed changes (including videos or screenshots)
Added `animation-fill-mode: forwards` to `AnimatedVisibility`. This tells the browser to hold the final frame of the animation (fully hidden) instead of resetting back to visible. 

## Affected Components
AutoComplete
MultiSelect
PaginatedMultiSelectFiltered
PaginatedSelectFiltered

## Screen Recordings:

Before:
https://github.com/user-attachments/assets/1061d0fb-2a39-40cb-823c-eeba96ffb75c

After:
https://github.com/user-attachments/assets/2feb32f8-0b89-4bf2-9f82-098226c2ea79


<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
