### PR TITLE
refactor(layout): Replace deprecated default imports in FormPageLayout

### DIFF
--- a/.changeset/form-page-layout.md
+++ b/.changeset/form-page-layout.md
@@ -1,0 +1,5 @@
+﻿---
+'@rocket.chat/layout': patch
+---
+
+Replace deprecated default imports with named exports in FormPageLayout

--- a/packages/layout/src/components/FormPageLayout/Form.tsx
+++ b/packages/layout/src/components/FormPageLayout/Form.tsx
@@ -2,7 +2,7 @@ import { Tile } from '@rocket.chat/fuselage';
 import type { ReactElement, FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-const Form = forwardRef<
+export const Form = forwardRef<
   HTMLElement,
   Omit<FormHTMLAttributes<HTMLFormElement>, 'is'> & {
     children: ReactNode;
@@ -23,4 +23,4 @@ const Form = forwardRef<
   ),
 );
 
-export default Form;
+

--- a/packages/layout/src/components/FormPageLayout/FormContainer.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormContainer.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@rocket.chat/fuselage';
 import type { ComponentProps } from 'react';
 
-const FormContainer = (props: ComponentProps<typeof Box>) => <Box {...props} />;
+export const FormContainer = (props: ComponentProps<typeof Box>) => <Box {...props} />;
 
-export default FormContainer;
+

--- a/packages/layout/src/components/FormPageLayout/FormFooter.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormFooter.tsx
@@ -2,7 +2,7 @@ import { Box } from '@rocket.chat/fuselage';
 import type { FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-const FormFooter = forwardRef<
+export const FormFooter = forwardRef<
   HTMLElement,
   Omit<FormHTMLAttributes<HTMLElement>, 'is'> & {
     children: ReactNode;
@@ -19,4 +19,4 @@ const FormFooter = forwardRef<
   />
 ));
 
-export default FormFooter;
+

--- a/packages/layout/src/components/FormPageLayout/FormHeader.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormHeader.tsx
@@ -2,11 +2,11 @@ import { Box } from '@rocket.chat/fuselage';
 import type { FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-const FormHeader = forwardRef<
+export const FormHeader = forwardRef<
   HTMLElement,
   Omit<FormHTMLAttributes<HTMLElement>, 'is'> & {
     children: ReactNode;
   }
 >((props, ref) => <Box is='header' mbe={24} {...props} ref={ref} />);
 
-export default FormHeader;
+

--- a/packages/layout/src/components/FormPageLayout/FormSteps.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormSteps.tsx
@@ -7,7 +7,7 @@ type FormStepsProps = {
   stepCount: number;
 };
 
-const FormSteps = ({
+export const FormSteps = ({
   currentStep,
   stepCount,
 }: FormStepsProps): ReactElement => {
@@ -20,4 +20,4 @@ const FormSteps = ({
   );
 };
 
-export default FormSteps;
+

--- a/packages/layout/src/components/FormPageLayout/FormSubtitle.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormSubtitle.tsx
@@ -2,11 +2,11 @@ import { Box } from '@rocket.chat/fuselage';
 import type { FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-const FormSubtitle = forwardRef<
+export const FormSubtitle = forwardRef<
   HTMLElement,
   Omit<FormHTMLAttributes<HTMLElement>, 'is'> & {
     children: ReactNode;
   }
 >((props, ref) => <Box fontScale='p2' color='hint' {...props} ref={ref} />);
 
-export default FormSubtitle;
+

--- a/packages/layout/src/components/FormPageLayout/FormTitle.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormTitle.tsx
@@ -2,7 +2,7 @@ import { Box } from '@rocket.chat/fuselage';
 import type { FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-const FormTitle = forwardRef<
+export const FormTitle = forwardRef<
   HTMLElement,
   Omit<FormHTMLAttributes<HTMLElement>, 'is'> & {
     children: ReactNode;
@@ -11,4 +11,4 @@ const FormTitle = forwardRef<
   <Box mbe={8} fontScale='h3' fontWeight={800} {...props} ref={ref} />
 ));
 
-export default FormTitle;
+

--- a/packages/layout/src/components/FormPageLayout/index.ts
+++ b/packages/layout/src/components/FormPageLayout/index.ts
@@ -7,32 +7,7 @@ import FormSteps from './FormSteps';
 import FormSubtitle from './FormSubtitle';
 import FormTitle from './FormTitle';
 
-export default Object.assign(Form, {
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Header: FormHeader,
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Steps: FormSteps,
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Title: FormTitle,
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Subtitle: FormSubtitle,
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Container: FormContainer,
-  /**
-   * @deprecated prefer using named imports
-   * */
-  Footer: FormFooter,
-});
+
 
 export {
   Form,


### PR DESCRIPTION
## What does this PR do?
Replaces deprecated default imports with proper named exports in FormPageLayout components.

## Motivation
Removes inline JSDoc @deprecated warnings.

## Changes Made
- Refactored Form, FormHeader, FormSteps, FormContainer, etc. to use named exports.
- Cleaned up index.ts.