### PR TITLE
fix(fuselage): issues not caught by visual regression testing after Sass rewrite

### DIFF
--- a/.changeset/ten-cats-occur.md
+++ b/.changeset/ten-cats-occur.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): issues not caught by visual regression testing after Sass rewrite

--- a/packages/fuselage/src/components/Avatar/Avatar.styles.scss
+++ b/packages/fuselage/src/components/Avatar/Avatar.styles.scss
@@ -26,9 +26,9 @@ $avatar-border-radii: (
   32: theme('avatar-border-radius-32', lengths.border-radius(medium)),
   36: theme('avatar-border-radius-36', lengths.border-radius(medium)),
   40: theme('avatar-border-radius-40', lengths.border-radius(medium)),
-  48: theme('avatar-border-radius-48', lengths.border-radius(large)),
-  124: theme('avatar-border-radius-124', lengths.border-radius(large)),
-  200: theme('avatar-border-radius-200', lengths.border-radius(large)),
+  48: theme('avatar-border-radius-48', lengths.border-radius(medium)),
+  124: theme('avatar-border-radius-124', lengths.border-radius(medium)),
+  200: theme('avatar-border-radius-200', lengths.border-radius(medium)),
   332: theme('avatar-border-radius-332', lengths.border-radius(large)),
 );
 

--- a/packages/fuselage/src/components/Chip/Chip.styles.scss
+++ b/packages/fuselage/src/components/Chip/Chip.styles.scss
@@ -5,6 +5,7 @@
 @use '../../styles/mixins/button.scss';
 @use '../../styles/variables/button-colors.scss' as *;
 @use '../../styles/mixins/interactivity.scss' as *;
+@use '../Box/Box.styles.scss';
 
 // to do: replace button with stroke
 
@@ -56,6 +57,8 @@ $chip-disabled-border-color: theme(
 $chip-disabled-color: theme('chip-disabled-color', colors.font(disabled));
 
 .rcx-chip {
+  @extend %box--full;
+
   @include button.kind-variant(
     (
       background-color: $chip-background-color,

--- a/packages/fuselage/src/styles/primitives/link.scss
+++ b/packages/fuselage/src/styles/primitives/link.scss
@@ -9,8 +9,8 @@ $link-focus-outline-color: theme(
   'link-focus-outline-color',
   colors.stroke(highlight)
 );
-$link-focus-outline-color: theme(
-  'link-focus-outline-color',
+$link-focus-box-shadow-color: theme(
+  'link-focus-box-shadow-color',
   colors.stroke(extra-light-highlight)
 );
 $link-visited-color: theme('link-visited-color', colors.font(info));
@@ -28,7 +28,7 @@ $link-active-color: theme('link-active-color', colors.font(info));
     border-radius: lengths.border-radius(small);
     outline: $link-focus-outline-color solid 1px;
     outline-offset: 0;
-    @include use-focus-shadow($link-focus-outline-color);
+    @include use-focus-shadow($link-focus-box-shadow-color);
   }
 
   &:where(:visited),


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
It fixes issues in `Avatar`, `Chip`, and `<a>` elements.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
@gabriellsh suggested my visual regression test was botched due to pixel diff tolerance getting bamboozled in large snapshots; he was right.

Introduced here https://github.com/RocketChat/fuselage/pull/1765