### PR TITLE
chore: remove `npm-run-all` dependency

### DIFF
--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -44,7 +44,6 @@
     "eslint": "~9.39.2",
     "jest": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "rollup": "~4.60.0",
     "ts-jest": "~29.4.6",

--- a/packages/fuselage-hooks/package.json
+++ b/packages/fuselage-hooks/package.json
@@ -31,7 +31,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:rollup .:build:api",
+    "build": "run .:build:clean && run .:build:rollup && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:rollup": "rollup -c",
     ".:build:api": "api-extractor run --local",
@@ -58,7 +58,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/fuselage-toastbar/package.json
+++ b/packages/fuselage-toastbar/package.json
@@ -30,7 +30,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs .:build:api",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -66,7 +66,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/fuselage-tokens/package.json
+++ b/packages/fuselage-tokens/package.json
@@ -30,7 +30,7 @@
     "/typography.*"
   ],
   "scripts": {
-    "build": "run-s .:build:clean  .:build:legacy .:build",
+    "build": "run .:build:clean && run .:build:legacy && run .:build",
     ".:build": "node ./build --config ./config.js",
     ".:build:legacy": "build-design-tokens",
     ".:build:clean": "rimraf dist"
@@ -40,7 +40,6 @@
     "eslint": "~9.39.2",
     "eslint-config-prettier": "~10.1.8",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "postcss": "~8.5.10",
     "postcss-scss": "~4.0.9",
     "prettier": "~3.6.2",

--- a/packages/fuselage/package.json
+++ b/packages/fuselage/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "webpack --watch --mode development",
     "storybook": "storybook dev -p 6006 --no-version-updates",
-    "build": "run-s .:build:clean .:build:dev .:build:prod .:build:dts .:build:api",
+    "build": "run .:build:clean && run .:build:dev && run .:build:prod && run .:build:dts && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:prod": "webpack --mode production",
     ".:build:dev": "webpack --mode development",
@@ -84,7 +84,6 @@
     "lint-all": "workspace:~",
     "mini-css-extract-plugin": "~2.10.2",
     "normalize.css": "^8.0.1",
-    "npm-run-all": "^4.1.5",
     "path-browserify": "^1.0.1",
     "postcss": "~8.5.10",
     "postcss-dir-pseudo-class": "~9.0.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -29,7 +29,6 @@
     "build-icons": "workspace:~",
     "eslint": "~9.39.2",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "rimraf": "~6.0.1",
     "stylelint": "~16.25.0",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -23,7 +23,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs .:build:api",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -54,7 +54,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -27,7 +27,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs .:build:logo",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs && run .:build:logo",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -51,7 +51,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -26,7 +26,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:cjs .:build:esm .:build:api",
+    "build": "run .:build:clean && run .:build:cjs && run .:build:esm && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -65,7 +65,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/string-helpers/package.json
+++ b/packages/string-helpers/package.json
@@ -27,7 +27,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs .:build:api",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -42,7 +42,6 @@
     "eslint": "~9.39.2",
     "jest": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "rimraf": "~6.0.1",
     "ts-jest": "~29.4.6",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -23,7 +23,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs .:build:api",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs && run .:build:api",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -46,7 +46,6 @@
     "jest": "~30.3.0",
     "jest-environment-jsdom": "~30.3.0",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",

--- a/packages/stylis-logical-props-middleware/package.json
+++ b/packages/stylis-logical-props-middleware/package.json
@@ -23,7 +23,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "run-s .:build:clean .:build:esm .:build:cjs",
+    "build": "run .:build:clean && run .:build:esm && run .:build:cjs",
     ".:build:clean": "rimraf dist",
     ".:build:esm": "tsc -p tsconfig.esm.json",
     ".:build:cjs": "tsc -p tsconfig.cjs.json",
@@ -37,7 +37,6 @@
   "devDependencies": {
     "eslint": "~9.39.2",
     "lint-all": "workspace:~",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "rimraf": "~6.0.1",
     "stylis": "~4.3.6",

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "resolve-workspace-deps": "run-s .:resolve-workspace-deps:run-script .:resolve-workspace-deps:update-lockfile .:resolve-workspace-deps:git-commit",
+    "resolve-workspace-deps": "run .:resolve-workspace-deps:run-script && run .:resolve-workspace-deps:update-lockfile && run .:resolve-workspace-deps:git-commit",
     ".:resolve-workspace-deps:run-script": "node src/resolve-workspace-deps.ts",
     ".:resolve-workspace-deps:update-lockfile": "cross-env YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn",
     ".:resolve-workspace-deps:git-commit": "git -c user.name='Rocket.Chat' -c user.email='support@rocket.chat' commit --all --amend --no-edit --no-verify",
@@ -17,7 +17,6 @@
     "endent": "^2.1.0",
     "eslint": "~9.39.2",
     "fast-glob": "~3.3.3",
-    "npm-run-all": "^4.1.5",
     "prettier": "~3.6.2",
     "typescript": "~5.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5730,7 +5730,6 @@ __metadata:
     eslint: "npm:~9.39.2"
     jest: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     rollup: "npm:~4.60.0"
     ts-jest: "npm:~29.4.6"
@@ -5804,7 +5803,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -5874,7 +5872,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -5901,7 +5898,6 @@ __metadata:
     eslint: "npm:~9.39.2"
     eslint-config-prettier: "npm:~10.1.8"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     postcss: "npm:~8.5.10"
     postcss-scss: "npm:~4.0.9"
     prettier: "npm:~3.6.2"
@@ -5958,7 +5954,6 @@ __metadata:
     lint-all: "workspace:~"
     mini-css-extract-plugin: "npm:~2.10.2"
     normalize.css: "npm:^8.0.1"
-    npm-run-all: "npm:^4.1.5"
     path-browserify: "npm:^1.0.1"
     postcss: "npm:~8.5.10"
     postcss-dir-pseudo-class: "npm:~9.0.1"
@@ -6005,7 +6000,6 @@ __metadata:
     build-icons: "workspace:~"
     eslint: "npm:~9.39.2"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     rimraf: "npm:~6.0.1"
     stylelint: "npm:~16.25.0"
@@ -6037,7 +6031,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -6071,7 +6064,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -6151,7 +6143,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -6214,7 +6205,6 @@ __metadata:
     eslint: "npm:~9.39.2"
     jest: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     rimraf: "npm:~6.0.1"
     ts-jest: "npm:~29.4.6"
@@ -6237,7 +6227,6 @@ __metadata:
     jest: "npm:~30.3.0"
     jest-environment-jsdom: "npm:~30.3.0"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -6255,7 +6244,6 @@ __metadata:
     "@rocket.chat/css-supports": "workspace:~"
     eslint: "npm:~9.39.2"
     lint-all: "workspace:~"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     rimraf: "npm:~6.0.1"
     stylis: "npm:~4.3.6"
@@ -8622,15 +8610,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "ansi-styles@npm:3.2.1"
-  dependencies:
-    color-convert: "npm:^1.9.0"
-  checksum: 10/d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
@@ -9571,17 +9550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.4.1":
-  version: 2.4.2
-  resolution: "chalk@npm:2.4.2"
-  dependencies:
-    ansi-styles: "npm:^3.2.1"
-    escape-string-regexp: "npm:^1.0.5"
-    supports-color: "npm:^5.3.0"
-  checksum: 10/3d1d103433166f6bfe82ac75724951b33769675252d8417317363ef9d54699b7c3b2d46671b772b893a8e50c3ece70c4b933c73c01e81bc60ea4df9b55afa303
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^3.0.0":
   version: 3.0.0
   resolution: "chalk@npm:3.0.0"
@@ -9802,28 +9770,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
-  version: 1.9.3
-  resolution: "color-convert@npm:1.9.3"
-  dependencies:
-    color-name: "npm:1.1.3"
-  checksum: 10/ffa319025045f2973919d155f25e7c00d08836b6b33ea2d205418c59bd63a665d713c52d9737a9e0fe467fb194b40fbef1d849bae80d674568ee220a31ef3d10
-  languageName: node
-  linkType: hard
-
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
     color-name: "npm:~1.1.4"
   checksum: 10/fa00c91b4332b294de06b443923246bccebe9fab1b253f7fe1772d37b06a2269b4039a85e309abe1fe11b267b11c08d1d0473fda3badd6167f57313af2887a64
-  languageName: node
-  linkType: hard
-
-"color-name@npm:1.1.3":
-  version: 1.1.3
-  resolution: "color-name@npm:1.1.3"
-  checksum: 10/09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
   languageName: node
   linkType: hard
 
@@ -10027,19 +9979,6 @@ __metadata:
     cross-env: dist/bin/cross-env.js
     cross-env-shell: dist/bin/cross-env-shell.js
   checksum: 10/0e5d8bdefbbcd000460b69755e0eeb22953510abac8375e4f8b638ff7c45406141acfd57b8a4c1d1cf0b5ea42f33451b302062fb9b34408753b4d465e901b845
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^6.0.5":
-  version: 6.0.6
-  resolution: "cross-spawn@npm:6.0.6"
-  dependencies:
-    nice-try: "npm:^1.0.4"
-    path-key: "npm:^2.0.1"
-    semver: "npm:^5.5.0"
-    shebang-command: "npm:^1.2.0"
-    which: "npm:^1.2.9"
-  checksum: 10/7abf6137b23293103a22bfeaf320f2d63faae70d97ddb4b58597237501d2efdd84cdc69a30246977e0c5f68216593894d41a7f122915dd4edf448db14c74171b
   languageName: node
   linkType: hard
 
@@ -10874,7 +10813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.5, es-abstract@npm:^1.18.0-next.1, es-abstract@npm:^1.22.1, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9":
+"es-abstract@npm:^1.17.5, es-abstract@npm:^1.22.1, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9":
   version: 1.23.9
   resolution: "es-abstract@npm:1.23.9"
   dependencies:
@@ -11127,13 +11066,6 @@ __metadata:
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10/9d7169e3965b2f9ae46971afa392f6e5a25545ea30f2e2dd99c9b0a95a3f52b5653681a84f5b2911a413ddad2d7a93d3514165072f349b5ffc59c75a899970d6
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "escape-string-regexp@npm:1.0.5"
-  checksum: 10/6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
   languageName: node
   linkType: hard
 
@@ -12426,13 +12358,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "has-flag@npm:3.0.0"
-  checksum: 10/4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
@@ -12503,13 +12428,6 @@ __metadata:
   version: 1.12.1
   resolution: "hookified@npm:1.12.1"
   checksum: 10/eeecf7557d1e5ee88695c4e1939f926b84451219d3f021080399f433ae51a588429eaa575160d605f56568e9fcf9280f1042078bd1d4bc56230f70bcf7c5002f
-  languageName: node
-  linkType: hard
-
-"hosted-git-info@npm:^2.1.4":
-  version: 2.8.9
-  resolution: "hosted-git-info@npm:2.8.9"
-  checksum: 10/96da7d412303704af41c3819207a09ea2cab2de97951db4cf336bb8bce8d8e36b9a6821036ad2e55e67d3be0af8f967a7b57981203fbfb88bc05cd803407b8c3
   languageName: node
   linkType: hard
 
@@ -14190,13 +14108,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-better-errors@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "json-parse-better-errors@npm:1.0.2"
-  checksum: 10/5553232045359b767b0f2039a6777fede1a8d7dca1a0ffb1f9ef73a7519489ae7f566b2e040f2b4c38edb8e35e37ae07af7f0a52420902f869ee0dbf5dc6c784
-  languageName: node
-  linkType: hard
-
 "json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -14420,18 +14331,6 @@ __metadata:
     lint-and-fix: ./lint-and-fix.js
   languageName: unknown
   linkType: soft
-
-"load-json-file@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "load-json-file@npm:4.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.2"
-    parse-json: "npm:^4.0.0"
-    pify: "npm:^3.0.0"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10/8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
-  languageName: node
-  linkType: hard
 
 "load-plugin@npm:^6.0.0":
   version: 6.0.3
@@ -14890,13 +14789,6 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10/60e85235a0c9034f64f01e2d2124eb599d4768fe8fe9e013fe3e32ae43987ad2c821ff4f0ce77d917fccf8eede9dd4c18573392be9e03a97ab4cfcf59eccfc0d
-  languageName: node
-  linkType: hard
-
-"memorystream@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "memorystream@npm:0.3.1"
-  checksum: 10/2e34a1e35e6eb2e342f788f75f96c16f115b81ff6dd39e6c2f48c78b464dbf5b1a4c6ebfae4c573bd0f8dbe8c57d72bb357c60523be184655260d25855c03902
   languageName: node
   linkType: hard
 
@@ -15567,13 +15459,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nice-try@npm:^1.0.4":
-  version: 1.0.5
-  resolution: "nice-try@npm:1.0.5"
-  checksum: 10/0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
-  languageName: node
-  linkType: hard
-
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -15708,18 +15593,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.3.2":
-  version: 2.5.0
-  resolution: "normalize-package-data@npm:2.5.0"
-  dependencies:
-    hosted-git-info: "npm:^2.1.4"
-    resolve: "npm:^1.10.0"
-    semver: "npm:2 || 3 || 4 || 5"
-    validate-npm-package-license: "npm:^3.0.1"
-  checksum: 10/644f830a8bb9b7cc9bf2f6150618727659ee27cdd0840d1c1f97e8e6cab0803a098a2c19f31c6247ad9d3a0792e61521a13a6e8cd87cc6bb676e3150612c03d4
-  languageName: node
-  linkType: hard
-
 "normalize-package-data@npm:^6.0.0":
   version: 6.0.2
   resolution: "normalize-package-data@npm:6.0.2"
@@ -15782,27 +15655,6 @@ __metadata:
     npm-package-arg: "npm:^11.0.0"
     semver: "npm:^7.3.5"
   checksum: 10/e759e4fe4076da9169cf522964a80bbc096d50cd24c8c44b50b44706c4479bd9d9d018fbdb76c6ea0c6037e012e07c6c917a1ecaa7ae1a1169cddfae1c0f24b6
-  languageName: node
-  linkType: hard
-
-"npm-run-all@npm:^4.1.5":
-  version: 4.1.5
-  resolution: "npm-run-all@npm:4.1.5"
-  dependencies:
-    ansi-styles: "npm:^3.2.1"
-    chalk: "npm:^2.4.1"
-    cross-spawn: "npm:^6.0.5"
-    memorystream: "npm:^0.3.1"
-    minimatch: "npm:^3.0.4"
-    pidtree: "npm:^0.3.0"
-    read-pkg: "npm:^3.0.0"
-    shell-quote: "npm:^1.6.1"
-    string.prototype.padend: "npm:^3.0.0"
-  bin:
-    npm-run-all: bin/npm-run-all/index.js
-    run-p: bin/run-p/index.js
-    run-s: bin/run-s/index.js
-  checksum: 10/46020e92813223d015f4178cce5a2338164be5f25b0c391e256c0e84ac082544986c220013f1be7f002dcac07b81c7ee0cb5c5c30b84fd6ebb6de96a8d713745
   languageName: node
   linkType: hard
 
@@ -16153,16 +16005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "parse-json@npm:4.0.0"
-  dependencies:
-    error-ex: "npm:^1.3.1"
-    json-parse-better-errors: "npm:^1.0.1"
-  checksum: 10/0fe227d410a61090c247e34fa210552b834613c006c2c64d9a05cfe9e89cf8b4246d1246b1a99524b53b313e9ac024438d0680f67e33eaed7e6f38db64cfe7b5
-  languageName: node
-  linkType: hard
-
 "parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -16235,13 +16077,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "path-key@npm:2.0.1"
-  checksum: 10/6e654864e34386a2a8e6bf72cf664dcabb76574dd54013add770b374384d438aca95f4357bb26935b514a4e4c2c9b19e191f2200b282422a76ee038b9258c5e7
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^3.0.0, path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -16283,15 +16118,6 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10/2b4257422bcb870a4c2d205b3acdbb213a72f5e2250f61c80f79c9d014d010f82bdf8584441612c8e1fa4eb098678f5704a66fa8377d72646bad4be38e57a2c3
-  languageName: node
-  linkType: hard
-
-"path-type@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "path-type@npm:3.0.0"
-  dependencies:
-    pify: "npm:^3.0.0"
-  checksum: 10/735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
   languageName: node
   linkType: hard
 
@@ -16351,22 +16177,6 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
-  languageName: node
-  linkType: hard
-
-"pidtree@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "pidtree@npm:0.3.0"
-  bin:
-    pidtree: ./bin/pidtree.js
-  checksum: 10/5449508168e5a2cb8649ea7b14273d8d39d3b454c406e705c91614f331d80f4f051f810587fd230680e76097c6dcf9d0551d60c7f5665f020b431d034571750a
-  languageName: node
-  linkType: hard
-
-"pify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pify@npm:3.0.0"
-  checksum: 10/668c1dc8d9fc1b34b9ce3b16ba59deb39d4dc743527bf2ed908d2b914cb8ba40aa5ba6960b27c417c241531c5aafd0598feeac2d50cb15278cf9863fa6b02a77
   languageName: node
   linkType: hard
 
@@ -17390,17 +17200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg@npm:3.0.0"
-  dependencies:
-    load-json-file: "npm:^4.0.0"
-    normalize-package-data: "npm:^2.3.2"
-    path-type: "npm:^3.0.0"
-  checksum: 10/398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
-  languageName: node
-  linkType: hard
-
 "read-yaml-file@npm:^1.1.0":
   version: 1.1.0
   resolution: "read-yaml-file@npm:1.1.0"
@@ -17758,7 +17557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
+"resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -17824,7 +17623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -18219,20 +18018,10 @@ __metadata:
     endent: "npm:^2.1.0"
     eslint: "npm:~9.39.2"
     fast-glob: "npm:~3.3.3"
-    npm-run-all: "npm:^4.1.5"
     prettier: "npm:~3.6.2"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
-
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0":
-  version: 5.7.2
-  resolution: "semver@npm:5.7.2"
-  bin:
-    semver: bin/semver
-  checksum: 10/fca14418a174d4b4ef1fecb32c5941e3412d52a4d3d85165924ce3a47fbc7073372c26faf7484ceb4bbc2bde25880c6b97e492473dc7e9708fdfb1c6a02d546e
-  languageName: node
-  linkType: hard
 
 "semver@npm:^6.0.0, semver@npm:^6.3.1":
   version: 6.3.1
@@ -18416,15 +18205,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-command@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "shebang-command@npm:1.2.0"
-  dependencies:
-    shebang-regex: "npm:^1.0.0"
-  checksum: 10/9eed1750301e622961ba5d588af2212505e96770ec376a37ab678f965795e995ade7ed44910f5d3d3cb5e10165a1847f52d3348c64e146b8be922f7707958908
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -18434,24 +18214,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "shebang-regex@npm:1.0.0"
-  checksum: 10/404c5a752cd40f94591dfd9346da40a735a05139dac890ffc229afba610854d8799aaa52f87f7e0c94c5007f2c6af55bdcaeb584b56691926c5eaf41dc8f1372
-  languageName: node
-  linkType: hard
-
 "shebang-regex@npm:^3.0.0":
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10/1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.6.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10/af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
   languageName: node
   linkType: hard
 
@@ -18851,17 +18617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.padend@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "string.prototype.padend@npm:3.1.1"
-  dependencies:
-    call-bind: "npm:^1.0.0"
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.18.0-next.1"
-  checksum: 10/f4ca9a4c79cc38c344c5f973940c12ea295b48c5d58d51a49fac597984afecc96508248c859212efe4b83f9c215d13598071e6904d6b35138e3b406bfea1c36a
-  languageName: node
-  linkType: hard
-
 "string.prototype.repeat@npm:^1.0.0":
   version: 1.0.0
   resolution: "string.prototype.repeat@npm:1.0.0"
@@ -19158,15 +18913,6 @@ __metadata:
   version: 4.3.6
   resolution: "stylis@npm:4.3.6"
   checksum: 10/6ebe8a37827124e0caf0704c13d39c121f6e6a8433eb8c67cfce508477b24a4434d1731198ba0b6e453655022bbf5beda93585f38ff420545e5356f925f83761
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^5.3.0":
-  version: 5.5.0
-  resolution: "supports-color@npm:5.5.0"
-  dependencies:
-    has-flag: "npm:^3.0.0"
-  checksum: 10/5f505c6fa3c6e05873b43af096ddeb22159831597649881aeb8572d6fe3b81e798cc10840d0c9735e0026b250368851b7f77b65e84f4e4daa820a4f69947f55b
   languageName: node
   linkType: hard
 
@@ -20478,7 +20224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+"validate-npm-package-license@npm:^3.0.4":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
@@ -20891,7 +20637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:


### PR DESCRIPTION
Replace all `run-s` (from `npm-run-all`) invocations with Yarn Berry's built-in `run` command chained with `&&`, then remove the `npm-run-all` devDependency from all 13 packages.

### What changed

- **11 `package.json` files**: replaced `run-s .:script:a .:script:b` → `run .:script:a && run .:script:b`
- **13 `package.json` files**: removed `"npm-run-all": "^4.1.5"` from `devDependencies` (includes 2 packages that had the dep but never used it: `emitter`, `icons`)
- **`yarn.lock`**: 26 transitive packages removed

### Why

- `npm-run-all` is unmaintained (last publish 2019) and unnecessary — Yarn Berry natively supports `run <script>` in shell commands
- `fuselage-forms` was already using this pattern (`run .:build:clean && run .:build:esm && run .:build:cjs`)
- Reduces dependency surface area