### PR TITLE
fix(fuselage): wrap PropsVariation table to prevent mobile overflow

### DIFF
--- a/.changeset/fix-props-variation-overflow.md
+++ b/.changeset/fix-props-variation-overflow.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage": patch
+---
+
+fix(fuselage): wrap PropsVariation table to prevent mobile overflow

--- a/packages/fuselage/.storybook/PropsVariation.tsx
+++ b/packages/fuselage/.storybook/PropsVariation.tsx
@@ -15,42 +15,51 @@ function PropsVariation({
 }) {
   return (
     <Box
-      is='table'
-      marginBlock={16}
-      marginInline='auto'
-      style={{ borderCollapse: 'collapse' }}
+      overflowX='auto'
+      style={{ WebkitOverflowScrolling: 'touch', maxWidth: '100%' }}
     >
-      <Box is='thead'>
-        <Box is='tr'>
-          <Box is='th' />
-          {Object.keys(xAxis).map((xVariation, key) => (
-            <Box key={key} is='th' color='hint' fontScale='c1'>
-              {xVariation}
-            </Box>
-          ))}
-        </Box>
-      </Box>
-      <Box is='tbody'>
-        {Object.entries(yAxis).map(([yVariation, yProps], y) => (
-          <Box key={y} is='tr'>
-            <Box is='th' color='hint' fontScale='c1'>
-              {yVariation}
-            </Box>
-            {Object.values(xAxis).map((xProps, x) => (
-              <Box
-                key={x}
-                is='td'
-                margin='none'
-                paddingBlock={8}
-                paddingInline={16}
-              >
-                <Box display='flex' alignItems='center' justifyContent='center'>
-                  <Component {...common} {...xProps} {...yProps} />
-                </Box>
+      <Box
+        is='table'
+        marginBlock={16}
+        marginInline='auto'
+        style={{ borderCollapse: 'collapse' }}
+      >
+        <Box is='thead'>
+          <Box is='tr'>
+            <Box is='th' />
+            {Object.keys(xAxis).map((xVariation, key) => (
+              <Box key={key} is='th' color='hint' fontScale='c1'>
+                {xVariation}
               </Box>
             ))}
           </Box>
-        ))}
+        </Box>
+        <Box is='tbody'>
+          {Object.entries(yAxis).map(([yVariation, yProps], y) => (
+            <Box key={y} is='tr'>
+              <Box is='th' color='hint' fontScale='c1'>
+                {yVariation}
+              </Box>
+              {Object.values(xAxis).map((xProps, x) => (
+                <Box
+                  key={x}
+                  is='td'
+                  margin='none'
+                  paddingBlock={8}
+                  paddingInline={16}
+                >
+                  <Box
+                    display='flex'
+                    alignItems='center'
+                    justifyContent='center'
+                  >
+                    <Component {...common} {...xProps} {...yProps} />
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
The table in Storybook's Docs tab overflows horizontally on mobile (~375px) — 
it just goes off screen edge.

Wrapped the `is='table'` Box with an outer Box using `overflowX='auto'` so it 
scrolls sideways instead. Also noticed the original had two `style` props on 
the same element so `borderCollapse: 'collapse'` was never actually applying — 
fixed that too.

Couldn't test in Storybook locally due to an existing build error in 
`@rocket.chat/icons` (SVG parsing issue, unrelated to this). Happy to verify 
once that's resolved.

Closes #1825