### PR TITLE
fix: disable unsupported labelChildren Storybook control

### DIFF
--- a/packages/fuselage/src/components/CheckBox/CheckBox.stories.tsx
+++ b/packages/fuselage/src/components/CheckBox/CheckBox.stories.tsx
@@ -11,6 +11,11 @@ import CheckBox from './CheckBox';
 export default {
   title: 'Inputs/CheckBox',
   component: CheckBox,
+  argTypes: {
+    labelChildren: {
+      control: false,
+    },
+  },
 } satisfies Meta<typeof CheckBox>;
 
 const Template: StoryFn<typeof CheckBox> = (args) => (


### PR DESCRIPTION
## Proposed changes

Disabled the unsupported `labelChildren` Storybook control for the `CheckBox` component.

This prevents Storybook from attempting to render unsupported object values for the prop, avoiding runtime crashes in the controls panel.

## Issue(s)

Fixes #1906

## Further comments

Added `argTypes` configuration to disable controls for the `labelChildren` prop while keeping the component behavior unchanged.
