### PR TITLE
feat: add fuselage-craft design skill suite

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,229 @@
+---
+name: Fuselage
+description: Rocket.Chat design system usage contract. Values are NOT stored here. They resolve from @rocket.chat/fuselage-tokens. This file references token names only.
+# ───────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH. Do not copy values into this file or into product code.
+#   tokens:     @rocket.chat/fuselage-tokens   (colors, typography, breakpoints)
+#   components: @rocket.chat/fuselage           (Box styling props, components)
+#   forms:      @rocket.chat/fuselage-forms     (a11y field wrappers)
+#   hooks:      @rocket.chat/fuselage-hooks     (responsive / interaction)
+# Consumers reference SEMANTIC names (color='font-default', p='x16', <Button primary>).
+# The value lives in the package and resolves at runtime via --rcx-* custom properties.
+# NAMES ARE NOT AUTHORITATIVE HERE EITHER. The entries below map a ROLE to the token a
+# consumer should reach for; the current, authoritative name set is resolved live with
+#   node skills/fuselage-craft/resolve.mjs <category>
+# Treat any name in this file as illustrative of its role, not a catalog. If a name here
+# disagrees with the resolver, the resolver (and the type gate) win.
+# ───────────────────────────────────────────────────────────────────────────
+sourceOfTruth:
+  tokens: "@rocket.chat/fuselage-tokens"
+  components: "@rocket.chat/fuselage"
+  forms: "@rocket.chat/fuselage-forms"
+  hooks: "@rocket.chat/fuselage-hooks"
+  resolver: "node skills/fuselage-craft/resolve.mjs <category>  # live, authoritative name set"
+colors:
+  # Box `color=` / `bg=` semantic values. Role only. Resolve value from the package.
+  font-default: "Default body and foreground text"
+  font-titles-labels: "Headings, labels, highest-emphasis text"
+  font-hint: "Placeholders, helper text, secondary info"
+  font-annotation: "De-emphasized metadata"
+  font-disabled: "Disabled foreground"
+  font-danger: "Error text"
+  font-info: "Informational and link text"
+  surface-room: "Default content surface"
+  surface-light: "Raised content surface"
+  surface-tint: "Recessed app background behind content"
+  surface-hover: "Row and control hover"
+  surface-selected: "Selected rows"
+  surface-dark: "Inverted surface"
+  surface-featured: "Promoted / featured surfaces (rare)"
+  surface-overlay: "Modal and scrim backdrop"
+  stroke-extra-light: "Default 1px separator / border"
+  stroke-light: "Input borders"
+  stroke-medium: "Stronger separators"
+  stroke-highlight: "Focused / active border (primary)"
+  stroke-error: "Error border"
+  status-background-info: "Info callout background"
+  status-background-success: "Success callout background"
+  status-background-danger: "Danger callout background"
+  status-background-warning: "Warning callout background"
+typography:
+  # Box `fontScale=` values. Resolve size / weight / line-height from fuselage-tokens.
+  hero: "Marketing-scale hero only"
+  h1: "Page titles"
+  h2: "Major section headings"
+  h3: "Card / panel titles"
+  h4: "Sub-section headings"
+  h5: "Dense headings"
+  p1: "Default body"
+  p1m: "Body, medium emphasis"
+  p1b: "Body, bold"
+  p2: "Dense body / table cells"
+  c1: "Caption / helper / metadata"
+  c2: "Caption, bold"
+  micro: "Badges, smallest annotations"
+spacing:
+  # Box spacing props (p, m, pi, pb, mi, mb...). Named scale. Never literal px.
+  x4: "tightest"
+  x8: "compact"
+  x12: "snug"
+  x16: "default block padding"
+  x24: "section gap"
+  x32: "large section gap"
+rounded:
+  # `borderRadius`. Resolve px from the fuselage-tokens border-radius scale.
+  small: "subtle (chips, small controls)"
+  medium: "default (buttons, inputs)"
+  large: "containers / cards"
+  extra-large: "prominent containers"
+  full: "pills / circular"
+elevation:
+  # Box `elevation=` values. Resolve shadow from the fuselage-tokens shadow scale.
+  "0": "flat at rest (default)"
+  "1": "low float (hover)"
+  "2": "overlay (menu / tooltip / dialog)"
+components:
+  # Reference Fuselage components + prop patterns. No values.
+  button-primary: "<Button primary>"
+  button-secondary: "<Button secondary>"
+  button-danger: "<Button danger> or <Button secondary danger>"
+  button-success: "<Button success>"
+  input: "<TextInput> inside <Field><FieldRow>"
+  field: "<Field><FieldLabel/><FieldRow/><FieldError/></Field>"
+  card: "<Tile> or <Box bg='surface-room' elevation='0' borderRadius='large'>"
+  callout: "<Callout type='info|success|warning|danger'>"
+---
+
+# Design System: Fuselage
+
+> **Source of truth.** Every value resolves from `@rocket.chat/fuselage-tokens` and the `@rocket.chat/fuselage` Box styling layer; this document never restates a hex, px, weight, or shadow. It also does not own the *names*: the current, authoritative token / component / hook / fontScale names are resolved live with `node skills/fuselage-craft/resolve.mjs <category>`, validated by the type gate. The names used below are illustrative of their role, not a catalog. To know a value, read the package; to know a name, run the resolver. Product code does the same: reference the name, let Fuselage resolve it. A literal value copied here or in product code, or a name that disagrees with the resolver, is a bug.
+
+## 1. Overview
+
+**Creative North Star: "The Control Surface"**
+
+Fuselage is the instrument panel the rest of Rocket.Chat flies on. Every control is exact, legible, and quiet: a pilot reads an altimeter, they do not admire it. The system makes state unambiguous and action reliable, then disappears. Personality is borrowed from the surface it serves, never asserted by the surface itself.
+
+Density is moderate and information-first, on a strict 4px grid expressed through the `x*` spacing scale. Surfaces are near-flat, separated by `stroke-extra-light` borders and tonal surface shifts (`surface-room` over `surface-tint`) rather than drop shadows. Color is overwhelmingly neutral, with a single decisive primary action (`<Button primary>`) per view. Semantic color carries meaning before decoration: `font-danger`/`status-background-danger` mean danger, `status-background-success` means success, `status-background-warning` means caution.
+
+This system rejects the **generic Bootstrap / AdminLTE** look: stock cards, default cornflower blue, undifferentiated chrome. It equally rejects **ad hoc, one-off styling**: a component that only works in one place is a defect. Coherence across every consuming surface outranks any single screen looking impressive.
+
+**Key Characteristics:**
+- Neutral-dominant; one primary action per view; semantic color discipline
+- 4px grid via the `x*` spacing scale, moderate density, information-first
+- Flat by default (`elevation='0'`); borders and tonal layering over shadows
+- Tight radii (`small` to `large`); `extra-large` and `full` for specific affordances
+- Three first-class themes: light, high-contrast, dark, all resolved from tokens
+- Inter for all UI text, Menlo for code (defined in fuselage-tokens)
+
+## 2. Colors
+
+A neutral foundation carrying a small set of semantic accents, each with a fixed meaning. Consumers select by **`color=` / `bg=` prop name**, never by value.
+
+### Primary
+- **Primary action**: expressed as `<Button primary>`. Its background, hover, and press states resolve inside Fuselage. Highlight and focus borders use `stroke-highlight`. Subtle highlight surfaces use the button/highlight tokens. Never hand-color a primary button.
+
+### Secondary
+- **`surface-featured`**: promoted or featured surfaces (e.g. emphasized rooms). Rare by design; not a general accent.
+
+### Tertiary (semantic, fixed meaning)
+- **`font-danger` / `status-background-danger`**: danger and destructive actions, plus error text and backgrounds.
+- **`status-background-success`**: success and positive status.
+- **`status-background-warning`**: warning and caution status.
+
+### Neutral
+- **`font-titles-labels`**: headings, labels, highest-emphasis text.
+- **`font-default`**: body copy, default foreground.
+- **`font-hint`**: secondary info, placeholders, helper text.
+- **`font-annotation`**: de-emphasized metadata.
+- **`font-disabled`**: disabled foreground.
+- **`surface-room`**: default content surface. **`surface-tint`**: recessed app background. **`surface-hover`** / **`surface-selected`**: interaction states.
+- **`stroke-extra-light` / `stroke-light` / `stroke-medium`**: structural separation, ascending weight.
+- **`surface-overlay`**: modal and scrim backdrop.
+
+### Named Rules
+**The One Action Rule.** One `<Button primary>` per view. If two buttons are primary, one is wrong. Everything else is `secondary` until proven it must shout.
+
+**The Semantic Color Rule.** Danger / success / warning tokens are never decorative. A `font-danger` element means danger; a `status-background-success` element means success. Using a semantic token for visual flavor is forbidden.
+
+**The No-Literal-Color Rule.** Product code never contains a hex value. It references a `color=` / `bg=` token name, or it is wrong. The value lives in fuselage-tokens.
+
+## 3. Typography
+
+**Fonts** are defined in fuselage-tokens (Inter family for UI, Menlo family for code). Consumers never declare a font-family; they use `fontScale=` and let the token resolve everything.
+
+**Character:** one neutral, highly legible sans carries the entire interface. Hierarchy comes from `fontScale`, never from swapping typefaces or hand-setting size.
+
+### Hierarchy (select by `fontScale=` name)
+- **`hero`**: marketing-scale hero text only. Rare in product surfaces.
+- **`h1`** to **`h5`**: page title down to dense heading. Pick the step that fits the density.
+- **`p1`** (with `p1m` / `p1b` variants): default reading text and emphasis. Cap measured text at 65 to 75ch.
+- **`p2`**: dense UI text, table cells, secondary copy.
+- **`c1`** / **`c2`**: helper text, metadata, labels.
+- **`micro`**: badges and the smallest annotations only.
+
+### Named Rules
+**The fontScale Rule.** Text size and weight come from `fontScale=`. Product code never sets `font-size`, `font-weight`, or `line-height` literally. There is no third font family.
+
+## 4. Elevation
+
+**Flat by default, border-first.** Depth is a `stroke-extra-light` border plus a tonal surface shift (`surface-room` over `surface-tint`), not a shadow. Shadows resolve through `elevation=` and are reserved for genuine overlays.
+
+### Elevation scale (select by `elevation=` name)
+- **`elevation='0'`**: flat at rest. The default for cards, rows, sections. Separation is a border.
+- **`elevation='1'`**: low float, e.g. hover lift.
+- **`elevation='2'`**: floating overlays only (menus, tooltips, popovers, dialogs).
+
+### Named Rules
+**The Flat-At-Rest Rule.** If an element is part of the page (card, row, section), it gets a border, not a shadow. Shadow is the signal that something has detached from the page and overlays it. Express it with `elevation=`, never a literal `box-shadow`.
+
+## 5. Components
+
+Reach for the Fuselage component first, then `Box` with semantic props, then never raw DOM for styled output.
+
+### Buttons
+- **Primary:** `<Button primary>`. The one emphasized action per view.
+- **Secondary:** `<Button secondary>`. Default for everything that is not the primary action.
+- **Danger:** `<Button danger>` for destructive confirmation; `<Button secondary danger>` for lower-stakes destructive actions.
+- **Success / Warning:** `<Button success>` / `<Button warning>` where semantically correct.
+- **Sizes / states:** boolean props (`small`, `large`, `loading`, `disabled`, `icon`). Hover / focus / press states resolve inside the component. Never restyle a button's states by hand.
+
+### Inputs / Fields
+- **Always wrap in `Field`:** `<Field>` with `<FieldLabel>`, `<FieldRow>` (containing `<TextInput>` / `<Select>` / etc.), `<FieldError>`, `<FieldHint>`. This carries the a11y contract (label association, error wiring). Hand-rolling a label + input breaks it.
+- **Focus / error / disabled:** handled by the controls and `FieldError`; do not hand-color.
+
+### Cards / Containers
+- **`<Tile>`**, or `<Box bg='surface-room' elevation='0' borderRadius='large' p='x16'>`. Separation is a border at `elevation='0'`, never a shadow at rest.
+
+### Callouts / Status
+- **`<Callout type='info|success|warning|danger'>`** for inline status. Carries the matching `status-background-*` token automatically.
+
+### Navigation
+- Use the Fuselage `Sidebar` / `NavBar` primitives. Default state quiet; hover takes `surface-hover`; active pairs the highlight token with weight or an indicator. Active is never conveyed by color alone.
+
+### Theming (signature)
+Every token resolves across **light**, **high-contrast**, and **dark** automatically. Components consume semantic token names, so a theme switch propagates everywhere with no consumer change. A component that hard-codes a value cannot theme, and is therefore wrong.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** use one `<Button primary>` per view; everything else `secondary`. (The One Action Rule.)
+- **Do** reference token names (`color='font-default'`, `bg='surface-tint'`); let Fuselage resolve the value. (The No-Literal-Color Rule.)
+- **Do** size text with `fontScale=` and space with the `x*` scale on the 4px grid.
+- **Do** separate surfaces with a `stroke-extra-light` border at `elevation='0'` before any shadow. (The Flat-At-Rest Rule.)
+- **Do** reserve `elevation='2'` shadows for floating overlays: menus, tooltips, dialogs.
+- **Do** use danger / success / warning tokens strictly semantically. (The Semantic Color Rule.)
+- **Do** wrap inputs in `Field` for built-in a11y; target WCAG 2.2 AA.
+- **Do** drive responsive behavior with fuselage-hooks (`useBreakpoints`, `usePrefersReducedMotion`), not literal media queries.
+
+### Don't:
+- **Don't** put a literal hex, px, weight, or `box-shadow` in product code. Ever. The value lives in fuselage-tokens.
+- **Don't** produce the generic Bootstrap / AdminLTE look: stock cards, default cornflower blue, undifferentiated chrome.
+- **Don't** introduce one-off, ad hoc component styling; if it only works in one place, it does not belong.
+- **Don't** hand-roll a Button, Modal, input label, or error message that Fuselage already ships.
+- **Don't** put more than one primary button in a single action group.
+- **Don't** use a side-stripe `border-left` / `border-right` over 1px as a colored accent.
+- **Don't** apply gradient text, `background-clip: text`, or decorative glassmorphism.
+- **Don't** use danger / success / warning tokens decoratively; never for flavor.
+- **Don't** add drop shadows to inline cards or rows; flat-at-rest.
+- **Don't** convey state by color alone; pair it with weight, icon, or text.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,43 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Two audiences consume Fuselage, and the system must serve both without forking its personality:
+
+- **Rocket.Chat internal engineers** building product surfaces (the main app, admin, onboarding). They assemble UI from Fuselage primitives and expect correct defaults, stable APIs, and zero per-feature styling decisions.
+- **External open-source developers** who install the public `@rocket.chat/*` packages from npm and rely on Storybook as the documentation surface. They need a discoverable, well-documented, semver-stable contract.
+
+The job to be done is the same for both: ship coherent, accessible UI fast, without reinventing components or drifting from the system.
+
+## Product Purpose
+
+Fuselage is Rocket.Chat's React component library and design-system toolkit: design tokens, components, hooks, icons, layout primitives, and Storybook docs, published as independent packages from a monorepo.
+
+It exists to make **consistency at scale** the path of least resistance. A change to a token or a component should propagate correctly to every consuming surface, so the entire Rocket.Chat ecosystem stays visually and behaviorally coherent as it grows. Success is measured by coherence across surfaces, not by any single screen looking impressive: when one primitive changes, everything downstream updates predictably and nothing drifts.
+
+## Brand Personality
+
+**Precise, neutral, trustworthy.**
+
+Fuselage is infrastructure, not a statement. It should feel predictable, exact, and quietly dependable, in the discipline of MUI or Radix. The system gets out of the way so the consuming product carries the personality. Voice in docs and APIs is plain, technical, and unembellished: name things for what they are, document the contract, no marketing tone.
+
+## Anti-references
+
+- **Generic Bootstrap / AdminLTE.** Dated, undifferentiated admin-template look: heavy default cards, stock blues, no point of view. Fuselage must read as a considered system, not a template.
+- **Inconsistent / ad hoc styling.** One-off component looks, drifting spacing scales, primitives that don't compose. This is precisely the failure mode a design system exists to eliminate; tolerating it anywhere undermines the system everywhere.
+
+## Design Principles
+
+1. **Consistency is the product.** The value is coherence across surfaces, not any one screen. Favor the choice that propagates correctly over the choice that looks best in isolation.
+2. **Accessible by default, not by opt-in.** Correct ARIA, keyboard navigation, focus management, and contrast ship inside the component so consumers cannot get it wrong without trying.
+3. **Get out of the way.** The system is neutral infrastructure. When in doubt, recede: let the consuming product own the personality and the data own the attention.
+4. **Compose, don't special-case.** New needs are met by combining existing primitives, not by adding one-off variants. A component that doesn't compose is a future inconsistency.
+5. **Stable contracts.** APIs and tokens are a public promise to internal and external consumers. Change them deliberately, version them honestly, document the contract.
+
+## Accessibility & Inclusion
+
+Target **WCAG 2.2 AA** as the shipped baseline for every component. This extends the 2.1 AA bar with target size (minimum), focus-not-obscured, and dragging-movement alternatives. Components must ship correct ARIA roles, full keyboard operability, visible and unobscured focus states, and AA contrast as defaults. `eslint-plugin-jsx-a11y` is already enforced in lint and is the floor, not the ceiling. Honor `prefers-reduced-motion` in any motion the system introduces.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,58 @@
+# Fuselage skills
+
+Claude Code skills shipped from this repo. They are checked into source control here and
+installed into Claude Code via symlink, so the repo stays the single source of truth and
+edits apply live.
+
+## fuselage-craft
+
+Design and refine UI in products that **consume** `@rocket.chat/fuselage`, keeping the
+result faithful to the design system. It treats the installed Fuselage packages as the
+single source of truth and never copies a Fuselage value or name into product code.
+
+Commands: `audit`, `migrate`, `polish`, `harden`, `critique`, `clarify`, `adapt`, `shape`,
+`craft`. See [`fuselage-craft/SKILL.md`](./fuselage-craft/SKILL.md) and its
+[`gate/`](./fuselage-craft/gate/README.md).
+
+## Install into Claude Code (symlink)
+
+Personal skills live in `~/.claude/skills/<name>/`. Symlink the skill there instead of
+copying, so changes in this repo take effect immediately and nothing drifts out of sync.
+
+From the repo root:
+
+```sh
+ln -s "$(pwd)/skills/fuselage-craft" ~/.claude/skills/fuselage-craft
+```
+
+Verify:
+
+```sh
+ls -l ~/.claude/skills/fuselage-craft   # should point at <repo>/skills/fuselage-craft
+```
+
+Claude Code discovers skills at startup, so **restart Claude Code** to pick it up. After
+that, invoke it from any Fuselage-consuming repo:
+
+```
+/fuselage-craft audit src/**
+/fuselage-craft migrate src/components/Legacy.tsx
+```
+
+### Gate dependencies
+
+The gate needs `eslint` (9+) and `typescript-eslint`. It resolves them from the host repo
+when present; otherwise install the gate's own deps once:
+
+```sh
+cd skills/fuselage-craft/gate && npm install
+```
+
+`gate/node_modules` is gitignored. The type gate also needs the consumer repo's
+`typescript`.
+
+## Uninstall
+
+```sh
+rm ~/.claude/skills/fuselage-craft   # removes only the symlink, not the repo files
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,8 +11,9 @@ result faithful to the design system. It treats the installed Fuselage packages 
 single source of truth and never copies a Fuselage value or name into product code.
 
 Commands: `audit`, `migrate`, `polish`, `harden`, `critique`, `clarify`, `adapt`, `shape`,
-`craft`. See [`fuselage-craft/SKILL.md`](./fuselage-craft/SKILL.md) and its
-[`gate/`](./fuselage-craft/gate/README.md).
+`craft`. See [`fuselage-craft/README.md`](./fuselage-craft/README.md) for the command
+catalog (what each does and produces), plus [`SKILL.md`](./fuselage-craft/SKILL.md) (the
+agent contract) and [`gate/`](./fuselage-craft/gate/README.md).
 
 ## Install into Claude Code (symlink)
 

--- a/skills/fuselage-craft/README.md
+++ b/skills/fuselage-craft/README.md
@@ -1,0 +1,145 @@
+# fuselage-craft
+
+A Claude Code skill for building and refining UI in products that **consume**
+`@rocket.chat/fuselage`. It keeps consumer code faithful to the design system: it treats
+the installed Fuselage packages as the single source of truth and never copies a Fuselage
+value or name into product code.
+
+This README is the human-facing overview. The authoritative pieces live elsewhere and this
+file links to them rather than restating them:
+
+- [`SKILL.md`](./SKILL.md) — the agent contract: the laws, the source-of-truth rules, the router.
+- [`reference/`](./reference) — the per-command flows the agent follows.
+- [`gate/README.md`](./gate/README.md) — the enforcement layer (lint + type gate).
+- [`../README.md`](../README.md) — how to install this skill into Claude Code (symlink).
+
+Not for authoring Fuselage itself. That work happens in the Fuselage repo with its own
+tokens and components.
+
+## Mental model
+
+Three live mechanisms, all reading the installed package, none holding a copy:
+
+1. **Resolve, don't recall.** Token / component / hook names come from
+   `node skills/fuselage-craft/resolve.mjs <category>`, read live from the installed
+   packages. The skill bakes in no vocabulary.
+2. **The type gate enforces.** Emitted JSX must typecheck against the installed Fuselage
+   types, so a wrong prop or token is a compile error, not a guess.
+3. **The lint gate kills literals.** Raw hex, px, shadows, hand-rolled inputs are banned by
+   value-free ESLint rules.
+
+So product code references token names (`color='font-default'`, `p='x16'`, `<Button primary>`),
+the value resolves inside Fuselage at runtime, and a token change propagates everywhere with
+no consumer edit. See [`SKILL.md`](./SKILL.md) for the full laws.
+
+## Commands
+
+Invoke as `/fuselage-craft <command> <target>`. If the first word is not a command, the
+whole input is treated as a general request under the laws.
+
+| Command | Category | What it does | Edits code | Runs gate | You get |
+|---|---|---|:---:|:---:|---|
+| `audit` | Evaluate | Conformance scan: gate drift + a judgment pass | no | yes | A report, no edits |
+| `critique` | Evaluate | UX heuristic review (hierarchy, load, IA) | no | no | Scored findings |
+| `shape` | Build | Plan the feature as a Fuselage component tree | no | no | A composition plan |
+| `craft` | Build | Shape, then build the feature end to end | yes | yes | Implemented feature |
+| `migrate` | Fix | Convert legacy / raw-CSS UI to Fuselage | yes | yes | Rewritten code + mapping |
+| `clarify` | Fix | Fix UX copy, labels, error messages | yes | yes | Reworded code |
+| `adapt` | Fix | Make it responsive via fuselage-hooks | yes | yes | Responsive code |
+| `polish` | Refine | Complete states: loading, empty, error, focus | yes | yes | Polished code |
+| `harden` | Refine | Edge cases, i18n, RTL, a11y, error paths | yes | yes | Hardened code |
+
+### Evaluate
+
+- **`audit`** — the flagship. Runs the lint + type gate against the installed package, then
+  a judgment pass for things the gate cannot see (wrong component choice, weak hierarchy,
+  color-only state, missing states). Reports drift with file:line and a prioritized fix
+  list; makes no edits unless you ask. Use it first on an unfamiliar or legacy surface.
+  Example: `/fuselage-craft audit src/**`
+- **`critique`** — a UX design review (visual hierarchy, cognitive load, information
+  architecture, a11y posture). Writes nothing, runs no gate. Use it when the question is
+  "is this good UX," not "is this conformant." Example: `/fuselage-craft critique src/views/Admin`
+
+### Build
+
+- **`shape`** — plans a feature as a Fuselage component composition tree (which components,
+  which token roles, which states, the a11y and responsive approach) before any code.
+  Produces a plan to confirm, no code, no gate. Use it before building anything non-trivial.
+  Example: `/fuselage-craft shape "workspace settings page with a form"`
+- **`craft`** — shapes first, confirms, then builds the feature end to end under the laws
+  (component first, then `Box`, never raw styled DOM; `Field` for inputs; hooks for
+  responsive), closing with the gate. Use it to go from intent to working UI.
+  Example: `/fuselage-craft craft "invite-members dialog"`
+
+### Fix
+
+- **`migrate`** — converts legacy or non-Fuselage UI (styled-components, inline styles, raw
+  `<button>`/`<input>`, literal hex/px) into Fuselage components and token references. Maps
+  by role, never by matching an old value to a token. Produces rewritten code plus a
+  migration table. Highest-value command for adopting Fuselage in an existing codebase.
+  Example: `/fuselage-craft migrate src/components/LegacyToolbar.tsx`
+- **`clarify`** — improves UX copy: labels, button text, error and helper messages, empty
+  states. Changes only strings, never Fuselage values. Example: `/fuselage-craft clarify src/forms`
+- **`adapt`** — fixes responsive behavior by replacing literal media queries and breakpoint
+  px with `fuselage-hooks` (`useBreakpoints`, `useMediaQuery`) and responsive props.
+  Example: `/fuselage-craft adapt src/views/Dashboard.tsx`
+
+### Refine
+
+- **`polish`** — the final pass before shipping: complete the states (loading via `Throbber`
+  or `Button loading`, errors via `Callout` / `FieldError`, empty states, hover, focus),
+  tighten spacing rhythm and hierarchy. Introduces no new literals.
+  Example: `/fuselage-craft polish src/views/Channel`
+- **`harden`** — production-readiness: edge cases (long text, overflow, zero/many items),
+  i18n, RTL via logical spacing props, error / disabled / loading paths, keyboard and focus
+  a11y, reduced motion. Example: `/fuselage-craft harden src/components/MemberList.tsx`
+
+## The gate
+
+Every command that writes code closes by running
+`node skills/fuselage-craft/gate/run-gate.mjs <target>`:
+
+- **Lint gate** bans literal design values (value-free rules, zero Fuselage knowledge baked in).
+- **Type gate** validates the emitted JSX against the consumer's installed Fuselage types.
+
+A change is not done until both pass. Details and rule options: [`gate/README.md`](./gate/README.md).
+
+## Keeping in sync with Fuselage
+
+The skill is designed to track Fuselage **automatically**. It holds no copy of the design
+system, so most Fuselage releases need no action here.
+
+**Auto-tracked (do nothing):**
+
+- New / renamed / removed tokens, components, hooks: `resolve.mjs` reads them live from the
+  installed packages on the next run.
+- New / changed / removed props or token types: the type gate (`tsc`) validates emitted code
+  against the installed types automatically.
+- Literal-value rules: value-free, so Fuselage changes never affect them.
+
+Illustrative token / component names in this README, `SKILL.md`, the `reference/` files, and
+`DESIGN.md` may become cosmetically stale if Fuselage renames something. They are marked
+illustrative and the resolver is authoritative, so this is never functional drift. Tidy them
+opportunistically; do not hand-sync vocabulary.
+
+**The one manual surface:** `resolve.mjs` hardcodes *structural access paths*, the package
+specifiers, the `colors.mjs` / `typography.mjs` subpaths, and the `Theme.ts` `Palette`
+sub-object keys (`surface`, `text`, `stroke`, `status`, ...). Only a Fuselage **packaging
+restructure** (renaming those exports or files) touches them. The failure mode is safe: a
+broken path makes that resolver category report `unavailable`, and the type gate still
+enforces correctness. The skill degrades, it never silently produces wrong output.
+
+**Verify after a Fuselage major bump:**
+
+```sh
+node skills/fuselage-craft/resolve.mjs all          # every category resolves (no "unavailable")
+node skills/fuselage-craft/gate/tests/run-tests.mjs  # lint rules still green
+```
+
+If a category reports `unavailable`, update its access path in `resolve.mjs` to match the new
+package structure. That is the only maintenance this skill needs.
+
+## Install
+
+This skill is installed into Claude Code via symlink so the repo stays the source of truth.
+See [`../README.md`](../README.md#install-into-claude-code-symlink).

--- a/skills/fuselage-craft/SKILL.md
+++ b/skills/fuselage-craft/SKILL.md
@@ -47,9 +47,12 @@ The target repo depends on Fuselage. Resolve against what is actually installed:
 Generated or modified product code MUST:
 
 - **Carry no literal design values.** No hex, no px spacing, no font-size/weight, no
-  `box-shadow`. Use token-name references: `color='font-default'` (illustrative; resolve the live set with `resolve.mjs semantic`), `bg='surface-tint'`,
+  `box-shadow`. Use token-name references: `color='default'`, `bg='surface-tint'` (or bare `bg='tint'`),
   `p='x16'`, `fontScale='h3'`, `elevation='2'`, `borderRadius='large'`. The value resolves
-  inside Fuselage at runtime via `--rcx-*` custom properties.
+  inside Fuselage at runtime via `--rcx-*` custom properties. Important: the Box
+  transforms prepend prefixes — `color=` prepends `font-`, `borderColor=` prepends `stroke-`
+  (so pass the BARE semantic name); `bg=` prepends `surface-` but also accepts the full
+  `surface-*` name. Resolve live names with `resolve.mjs semantic`.
 - **Reach for the component first.** Fuselage component → then `Box` with semantic props
   → never raw styled DOM. Never hand-roll a Button, Modal, input label, or error that
   Fuselage ships (`<Button primary>`, not a styled `<button>`).
@@ -139,6 +142,6 @@ above. Setup (below) runs first either way.
    installed, stop - this skill does not apply.
 2. Load product intent: `PRODUCT.md` if present (register, users, principles). The token
    contract is NOT a local DESIGN.md with values; it is the installed Fuselage package.
-3. Run `node skills/fuselage-craft/resolve.mjs <relevant category>` for the vocabulary the task touches. Treat its output as current truth. Never guess names.
+3. Run `node skills/fuselage-craft/resolve.mjs <relevant category>` for the vocabulary the task touches. Treat its output as current truth. Never guess names. The resolver is cwd-anchored — for an external consumer repo (not the fuselage monorepo) run it as `cd <consumer-repo> && node <abs-path-to-skill>/resolve.mjs <category>`, otherwise it resolves the wrong package and reports "unavailable".
 4. Resolve the specific components / props / tokens the task touches from the package.
 5. Do the work under the laws above. Close with the gate.

--- a/skills/fuselage-craft/SKILL.md
+++ b/skills/fuselage-craft/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: fuselage-craft
+description: >-
+  Design and refine UI in products that CONSUME @rocket.chat/fuselage. Use when working
+  on a downstream app's components, screens, forms, dashboards, settings, onboarding, or
+  empty states and you want the result to stay on the Fuselage design system. Commands:
+  audit, migrate, polish, harden, critique, clarify, adapt, shape, craft. Every command
+  treats the installed Fuselage packages as the single source of truth and never copies a
+  Fuselage value. Not for authoring Fuselage itself.
+---
+
+# Fuselage Craft
+
+A design-and-refine skill suite for repos that build product UI on top of
+`@rocket.chat/fuselage`. It keeps consumer code fluent in, and faithful to, the design
+system. It is **not** for authoring Fuselage itself (that work lives in the Fuselage repo
+with its own tokens and components).
+
+## Prime directive: reference, never replicate
+
+**Fuselage is the source of truth. This skill holds no copy of it.**
+
+- No extracted manifest, no token snapshot, no hardcoded value in this skill or in the
+  code it produces.
+- Anything the skill needs about a component, prop, or token, it resolves from the
+  **installed package** at use-time. The package is always more current than any copy.
+- Correctness comes from pointing at the real thing, not from remembering it.
+
+## Source-of-truth resolution
+
+The target repo depends on Fuselage. Resolve against what is actually installed:
+
+1. **Pin the version.** At session start, read the consumer's `package.json` + lockfile
+   for `@rocket.chat/fuselage*`. All reasoning is pinned to THAT version. State it.
+2. **Resolve vocabulary live.** Never recall Fuselage names from memory. Run
+   `node skills/fuselage-craft/resolve.mjs <category>` to get the current token / component / hook / fontScale names. Use ONLY what it returns. The type gate is the final authority for anything the resolver marks type-only (elevation, radius, spacing).
+3. **Resolve live, don't cache.** To confirm a prop, value, component, or token, read it
+   from `node_modules/@rocket.chat/fuselage*` (types, token JSON, exports), or the
+   workspace package if in-monorepo. Read on demand; never persist a derived copy.
+4. **Prefer the type definitions.** The shipped `.d.ts` are the API contract: the Box
+   `color=` / `bg=` / `fontScale=` / `elevation=` unions, the Button boolean variants,
+   the form components, the hooks. Read the types, not your memory.
+5. **Prefer stories for idiom.** `*.stories.tsx` show blessed composition. Match them.
+
+## Output contract (every command obeys)
+
+Generated or modified product code MUST:
+
+- **Carry no literal design values.** No hex, no px spacing, no font-size/weight, no
+  `box-shadow`. Use token-name references: `color='font-default'` (illustrative; resolve the live set with `resolve.mjs semantic`), `bg='surface-tint'`,
+  `p='x16'`, `fontScale='h3'`, `elevation='2'`, `borderRadius='large'`. The value resolves
+  inside Fuselage at runtime via `--rcx-*` custom properties.
+- **Reach for the component first.** Fuselage component → then `Box` with semantic props
+  → never raw styled DOM. Never hand-roll a Button, Modal, input label, or error that
+  Fuselage ships (`<Button primary>`, not a styled `<button>`).
+- **Use the a11y wrappers.** Inputs go inside `Field` / `FieldLabel` / `FieldRow` /
+  `FieldError` (`@rocket.chat/fuselage-forms`). Never hand-wire a label to an input.
+- **Drive responsiveness with hooks.** `useBreakpoints`, `useMediaQuery`,
+  `usePrefersReducedMotion`, `usePosition` from `@rocket.chat/fuselage-hooks`. Not literal
+  media queries, not hardcoded breakpoint px.
+- **Theme through tokens.** Code must resolve across light / high-contrast / dark with no
+  change, because it references semantic names. Hard-coding a value breaks theming and is
+  therefore wrong.
+
+## The gate (how "done" is proven)
+
+Conformance against Fuselage is largely OBJECTIVE. Two gates, both run against the
+installed package, not a copy:
+
+- **Type gate (authoritative).** Emitted JSX must typecheck against the installed Fuselage
+  types (`tsc` / LSP). `fontScale='h9'`, `<Button variant="primary">`, a nonexistent
+  component: all become type errors. Drift is impossible if it typechecks.
+- **Lint gate.** What types can't see: `no raw hex`, `no literal px spacing`,
+  `prefer <Box> over styled <div>`, `require Field wrapper around inputs`,
+  `no color-only state`. An ESLint rule pack (extends the repo's existing eslint +
+  jsx-a11y) carries this.
+
+A change is not done until both pass. Report the version checked, the gate results, and
+any drift found.
+
+## Laws (the bans)
+
+| Forbidden | Use instead |
+|---|---|
+| Literal hex / rgb in product code | `color=` / `bg=` semantic token name |
+| Literal px spacing / margin / padding | `p` / `m` / `pi` / `pb` on the `x*` scale |
+| `font-size` / `font-weight` / `line-height` | `fontScale=` name |
+| Literal `box-shadow` | `elevation=` name |
+| Literal `border-radius` px | `borderRadius=` scale name |
+| Hand-rolled `<button>` / styled `<div>` button | `<Button primary\|secondary\|danger\|...>` |
+| Hand-wired `<label>` + `<input>` | `<Field>` + `<FieldLabel>` + `<FieldRow>` |
+| Literal media query / breakpoint px | `useBreakpoints` / `useMediaQuery` |
+| Component/prop not in the installed types | nothing - see "When the system lacks it" |
+| State conveyed by color alone | color + weight / icon / text |
+
+Cross-register bans still apply: no side-stripe borders >1px, no gradient text, no
+decorative glassmorphism.
+
+## Anti-drift test
+
+> Would a Fuselage maintainer look at this and say "that is not how you use Fuselage"?
+
+If yes, it failed. Rewrite using the real component/token, resolved from the package.
+
+## When the system lacks something
+
+If the task genuinely needs a component, prop, or token Fuselage does not ship: **do not
+hand-roll it in product code.** That is how drift starts. Instead:
+
+1. Stop and surface it as a blocker.
+2. Propose the Fuselage extension (new component / token / prop) as the correct fix, to be
+   made in the Fuselage repo.
+3. Keep consumer code within the system until the extension lands.
+
+This skill's job is fluent, drift-free *use* of the system, never quiet extension of it.
+
+## Commands
+
+When the first argument matches a command below, **load its `reference/<command>.md` and
+follow it**; everything after the command name is the target. If the first argument matches
+no command, treat the whole argument as a general Fuselage-craft request under the laws
+above. Setup (below) runs first either way.
+
+| Command | Category | What it does | Reference |
+|---|---|---|---|
+| `audit` | Evaluate | Flagship. Run the type + lint gate against the installed package; report drift (literal values, reinvented components, missing `Field`, props that don't typecheck), then a judgment pass. | [reference/audit.md](reference/audit.md) |
+| `migrate` | Fix | Convert legacy raw-CSS / hex / hand-rolled UI into Fuselage components + token references. Map by role, never by copying the old value. | [reference/migrate.md](reference/migrate.md) |
+| `polish` | Refine | Final pass: loading (`Throbber`), errors (`Callout` / `FieldError`), empty states, focus, state completeness. No new literals. | [reference/polish.md](reference/polish.md) |
+| `harden` | Refine | Edge cases, i18n, RTL, error / disabled / loading paths, a11y, all through Fuselage. | [reference/harden.md](reference/harden.md) |
+| `critique` | Evaluate | UX heuristics (hierarchy, cognitive load, IA). No code change, no gate. | [reference/critique.md](reference/critique.md) |
+| `clarify` | Fix | UX copy, labels, error messages. Changes words, never Fuselage values. | [reference/clarify.md](reference/clarify.md) |
+| `adapt` | Fix | Responsive behavior via `fuselage-hooks`, not media-query literals. | [reference/adapt.md](reference/adapt.md) |
+| `shape` | Build | Plan a feature as a Fuselage component composition tree. No code. | [reference/shape.md](reference/shape.md) |
+| `craft` | Build | Shape, then build the feature end to end under the laws. | [reference/craft.md](reference/craft.md) |
+
+## Setup (every command, before work)
+
+1. Confirm the repo consumes `@rocket.chat/fuselage`; read installed version(s). If not
+   installed, stop - this skill does not apply.
+2. Load product intent: `PRODUCT.md` if present (register, users, principles). The token
+   contract is NOT a local DESIGN.md with values; it is the installed Fuselage package.
+3. Run `node skills/fuselage-craft/resolve.mjs <relevant category>` for the vocabulary the task touches. Treat its output as current truth. Never guess names.
+4. Resolve the specific components / props / tokens the task touches from the package.
+5. Do the work under the laws above. Close with the gate.

--- a/skills/fuselage-craft/gate/README.md
+++ b/skills/fuselage-craft/gate/README.md
@@ -1,0 +1,112 @@
+# fuselage-craft gate
+
+Enforcement layer for the **fuselage-craft** skill. Ensures downstream products use
+`@rocket.chat/fuselage` as the single source of truth and never copy Fuselage values
+(hex colors, px dimensions, shadows) into product code.
+
+## Two gates, one command
+
+### Lint gate — literal-value bans
+
+Five ESLint rules that ban raw design values from product code. **Zero Fuselage values are
+baked into the rules.** They ban literal patterns generically (any hex, any px in a style
+context) — they do not know or check specific Fuselage token values. Fuselage-specific API
+validation is the type gate's job.
+
+| Rule | Severity | What it flags |
+|---|---|---|
+| `no-raw-color` | error | Hex/rgb/rgba/hsl literals in JSX color attrs, `style={{}}`, `css`/`styled` templates |
+| `no-literal-dimension` | error | Literal `px`/`rem` values for spacing/sizing props in `style={{}}` and `css`/`styled` |
+| `no-literal-shadow` | error | Literal `boxShadow`/`box-shadow` values in `style={{}}` and `css`/`styled` |
+| `require-field-wrapper` | error | Input controls (`<input>`, `<TextInput>`, etc.) not inside a `<Field>` ancestor |
+| `prefer-box` | warn | Raw DOM elements (`div`, `span`, etc.) with inline `style={{}}` objects |
+
+### Type gate — validate against installed Fuselage types
+
+Runs the consumer's own `tsc --noEmit`. TypeScript validates that every `color=`,
+`fontScale=`, `elevation=`, etc. prop passed to Fuselage components matches the installed
+package's type declarations. This catches invalid token names, wrong prop types, and API
+mismatches without the gate needing to know any token values.
+
+## Requirements
+
+The gate needs `eslint` (9+) and `typescript-eslint`. It resolves them from the host repo
+when present; otherwise install the gate's own deps once:
+
+```sh
+cd skills/fuselage-craft/gate && npm install
+```
+
+`node_modules` here is gitignored. The type gate also needs the consumer's `typescript`.
+
+## Usage
+
+### Run the full gate
+
+```sh
+# from the consumer repo root (default targets src/**/*.{ts,tsx})
+node skills/fuselage-craft/gate/run-gate.mjs
+
+# with explicit globs
+node skills/fuselage-craft/gate/run-gate.mjs 'src/**/*.tsx' 'app/**/*.tsx'
+```
+
+The gate exits nonzero if lint errors > 0 **or** `tsc` exits nonzero. Warnings (prefer-box)
+do not fail the gate.
+
+### Lint only
+
+```sh
+npx eslint --config skills/fuselage-craft/gate/eslint.config.mjs src/
+```
+
+### Type check only
+
+```sh
+node skills/fuselage-craft/gate/typecheck.mjs
+node skills/fuselage-craft/gate/typecheck.mjs -p tsconfig.app.json
+```
+
+### Run rule tests
+
+```sh
+# from repo root
+node skills/fuselage-craft/gate/tests/run-tests.mjs
+
+# or from gate/ directory
+cd skills/fuselage-craft/gate && npm test
+```
+
+## Rule options
+
+### `require-field-wrapper`
+
+Accepts a config object:
+
+```js
+// in your eslint.config.mjs:
+'fuselage-craft-gate/require-field-wrapper': ['error', {
+  controls: ['TextInput', 'Select', 'MyCustomInput'],  // replaces default list
+  fieldComponent: 'FormField',  // default: 'Field'
+}]
+```
+
+The default `controls` list is **raw HTML only** (`input`, `select`, `textarea`) so the rule
+bakes in zero Fuselage names. `run-gate.mjs` augments it at runtime with the live list of
+`@rocket.chat/fuselage-forms` controls, resolved by `resolve.mjs` from the installed package.
+Override `controls` only when running the rule standalone or with a different wrapper.
+
+## Design constraints
+
+- **Zero hardcoded Fuselage values** in any rule. The rules ban literal patterns; correctness
+  of token names is enforced by TypeScript types from the installed package.
+- **Component name lists** (e.g. which components count as inputs) are rule options with
+  sensible defaults — configuration, not value replication.
+- Allowed exceptions: `0`, `auto`, `100%`, `var(--...)`, `calc(...)` for dimensions;
+  `none`/`unset`/`inherit` for shadows.
+
+## Graduation note
+
+These rules can later move into a published `packages/eslint-plugin-fuselage`; kept in
+the skill for now so the gate ships with the skill and stays co-located with the
+fuselage-craft design guidance.

--- a/skills/fuselage-craft/gate/eslint.config.mjs
+++ b/skills/fuselage-craft/gate/eslint.config.mjs
@@ -1,0 +1,114 @@
+/**
+ * ESLint 9 flat config for the fuselage-craft gate.
+ *
+ * Intended to be run standalone via --config against a consumer repo's source:
+ *   npx eslint --config path/to/gate/eslint.config.mjs src/
+ *
+ * Parser: typescript-eslint's parser is resolved from the host repo's installed
+ * packages (consumer's node_modules). Falls back gracefully if not present.
+ *
+ * Plugin: the local fuselage-craft-gate plugin (rules/index.mjs).
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import fuselageCraftGate from './rules/index.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Resolve typescript-eslint's parser from:
+ *  1. The consumer's CWD node_modules (runtime consumer)
+ *  2. This gate's own node_modules (when gate has its own install)
+ *  3. Dynamic import fallback for ESM-only installs
+ *
+ * Returns the parser object or undefined (lint runs without TS parsing).
+ */
+async function resolveParser() {
+  const searchPaths = [process.cwd(), __dirname];
+  for (const base of searchPaths) {
+    // Try a package.json anchor in that directory; fall back to a synthetic path
+    const anchors = [resolve(base, 'package.json'), resolve(base, '_anchor.js')];
+    for (const anchor of anchors) {
+      try {
+        const req = createRequire(anchor);
+        // typescript-eslint re-exports the parser
+        const te = req('typescript-eslint');
+        if (te && te.parser) return te.parser;
+      } catch {
+        // not found at this anchor
+      }
+      try {
+        const req = createRequire(anchor);
+        return req('@typescript-eslint/parser');
+      } catch {
+        // not found
+      }
+    }
+  }
+  // Final fallback: dynamic import (works for ESM-only packages in scope)
+  try {
+    const tseslint = await import('typescript-eslint');
+    const mod = tseslint.default || tseslint;
+    if (mod && mod.parser) return mod.parser;
+  } catch {
+    // no parser found — lint will run without TypeScript parsing
+  }
+  return undefined;
+}
+
+const tsParser = await resolveParser();
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  {
+    // Ignore common build artifacts
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/.yarn/**',
+      '**/*.d.ts',
+      '**/storybook-static/**',
+    ],
+  },
+  {
+    // Apply to all JS/TS/JSX/TSX files
+    files: ['**/*.{ts,tsx,js,jsx,mjs}'],
+    plugins: {
+      'fuselage-craft-gate': fuselageCraftGate,
+    },
+    ...(tsParser
+      ? {
+          languageOptions: {
+            parser: tsParser,
+            parserOptions: {
+              ecmaVersion: 'latest',
+              sourceType: 'module',
+              ecmaFeatures: { jsx: true },
+              // Skip full type-aware linting for speed — no project reference needed
+              project: false,
+            },
+          },
+        }
+      : {
+          languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            parserOptions: {
+              ecmaFeatures: { jsx: true },
+            },
+          },
+        }),
+    rules: {
+      // Errors — literal value bans
+      'fuselage-craft-gate/no-raw-color': 'error',
+      'fuselage-craft-gate/no-literal-dimension': 'error',
+      'fuselage-craft-gate/no-literal-shadow': 'error',
+      'fuselage-craft-gate/require-field-wrapper': 'error',
+      // Warning — conservative suggestion
+      'fuselage-craft-gate/prefer-box': 'warn',
+    },
+  },
+];

--- a/skills/fuselage-craft/gate/eslint.config.mjs
+++ b/skills/fuselage-craft/gate/eslint.config.mjs
@@ -61,6 +61,27 @@ async function resolveParser() {
 
 const tsParser = await resolveParser();
 
+/**
+ * No-op catch-all plugin for foreign rule namespaces.
+ *
+ * Consumer code often has inline-disable directives for plugins that are NOT
+ * loaded by this gate (e.g. react, @typescript-eslint, import, jsx-a11y).
+ * In ESLint 9, an unknown rule namespace in a disable directive is a FATAL
+ * error (not just a warning), even with reportUnusedDisableDirectives:'off'.
+ * Registering the common namespaces as no-op plugins (via a Proxy that returns
+ * an empty rule stub for every lookup) makes the disable directives resolve
+ * without errors, while the gate still enforces ONLY its own fuselage-craft-gate
+ * rules. The linterOptions reportUnusedDisableDirectives:'off' suppresses the
+ * residual "unused disable directive" warning for directives that match no
+ * active rule in this config.
+ */
+const noopPlugin = {
+  rules: new Proxy(
+    {},
+    { get: () => ({ meta: {}, create: () => ({}) }) },
+  ),
+};
+
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
@@ -78,6 +99,22 @@ export default [
     files: ['**/*.{ts,tsx,js,jsx,mjs}'],
     plugins: {
       'fuselage-craft-gate': fuselageCraftGate,
+      // Foreign namespaces registered as no-ops so their inline-disable
+      // directives in consumer code don't cause "rule not found" fatal errors.
+      'react': noopPlugin,
+      'react-hooks': noopPlugin,
+      '@typescript-eslint': noopPlugin,
+      'import': noopPlugin,
+      'jsx-a11y': noopPlugin,
+      'unicorn': noopPlugin,
+      'simple-import-sort': noopPlugin,
+      'prettier': noopPlugin,
+      'no-relative-import-paths': noopPlugin,
+    },
+    linterOptions: {
+      // Suppress "unused disable directive" warnings that arise when a directive
+      // references a no-op rule (i.e. a foreign namespace registered above).
+      reportUnusedDisableDirectives: 'off',
     },
     ...(tsParser
       ? {
@@ -102,12 +139,19 @@ export default [
           },
         }),
     rules: {
-      // Errors — literal value bans
+      // Errors — objective drift the type gate cannot see and that is unambiguously wrong.
       'fuselage-craft-gate/no-raw-color': 'error',
       'fuselage-craft-gate/no-literal-dimension': 'error',
       'fuselage-craft-gate/no-literal-shadow': 'error',
-      'fuselage-craft-gate/require-field-wrapper': 'error',
-      // Warning — conservative suggestion
+      // Registered but no-op here — the live `palette` option is injected only by
+      // run-gate.mjs via resolveCategory('semantic'). Under standalone `npx eslint
+      // --config` this rule has no palette and deliberately no-ops (never false-positives).
+      // The authoritative check is always via run-gate.mjs.
+      'fuselage-craft-gate/valid-color-token': 'error',
+      // Warnings — accessibility/idiom recommendations, not hard conformance failures.
+      // A missing Field wrapper is advisory (toolbar/filter inputs legitimately skip it);
+      // it informs without blocking the gate. Reserve errors for objective drift above.
+      'fuselage-craft-gate/require-field-wrapper': 'warn',
       'fuselage-craft-gate/prefer-box': 'warn',
     },
   },

--- a/skills/fuselage-craft/gate/package.json
+++ b/skills/fuselage-craft/gate/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@rocket.chat/fuselage-craft-gate",
+  "version": "0.1.0",
+  "description": "Lint + type gate for fuselage-craft skill — enforces Fuselage as single source of truth in consumer repos",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./rules/index.mjs",
+    "./eslint-config": "./eslint.config.mjs"
+  },
+  "scripts": {
+    "test": "node tests/run-tests.mjs",
+    "gate": "node run-gate.mjs"
+  },
+  "peerDependencies": {
+    "eslint": ">=9.0.0",
+    "typescript-eslint": ">=8.0.0"
+  },
+  "devDependencies": {
+    "eslint": "~9.39.2",
+    "typescript-eslint": "~8.57.2"
+  }
+}

--- a/skills/fuselage-craft/gate/rules/index.mjs
+++ b/skills/fuselage-craft/gate/rules/index.mjs
@@ -1,0 +1,25 @@
+/**
+ * ESLint plugin — fuselage-craft-gate
+ *
+ * Exposes the five gate rules as a standard ESLint plugin object.
+ * Import this in eslint.config.mjs via the local path.
+ */
+
+import noRawColor from './no-raw-color.mjs';
+import noLiteralDimension from './no-literal-dimension.mjs';
+import noLiteralShadow from './no-literal-shadow.mjs';
+import requireFieldWrapper from './require-field-wrapper.mjs';
+import preferBox from './prefer-box.mjs';
+
+export default {
+  meta: {
+    name: 'fuselage-craft-gate',
+  },
+  rules: {
+    'no-raw-color': noRawColor,
+    'no-literal-dimension': noLiteralDimension,
+    'no-literal-shadow': noLiteralShadow,
+    'require-field-wrapper': requireFieldWrapper,
+    'prefer-box': preferBox,
+  },
+};

--- a/skills/fuselage-craft/gate/rules/index.mjs
+++ b/skills/fuselage-craft/gate/rules/index.mjs
@@ -10,6 +10,7 @@ import noLiteralDimension from './no-literal-dimension.mjs';
 import noLiteralShadow from './no-literal-shadow.mjs';
 import requireFieldWrapper from './require-field-wrapper.mjs';
 import preferBox from './prefer-box.mjs';
+import validColorToken from './valid-color-token.mjs';
 
 export default {
   meta: {
@@ -21,5 +22,6 @@ export default {
     'no-literal-shadow': noLiteralShadow,
     'require-field-wrapper': requireFieldWrapper,
     'prefer-box': preferBox,
+    'valid-color-token': validColorToken,
   },
 };

--- a/skills/fuselage-craft/gate/rules/no-literal-dimension.mjs
+++ b/skills/fuselage-craft/gate/rules/no-literal-dimension.mjs
@@ -10,7 +10,10 @@
  * Zero hardcoded Fuselage values — bans the literal pattern only.
  */
 
-const DIMENSION_RE = /(-?\d+(\.\d+)?(px|rem))/i;
+// Bounded digit runs (no unbounded `+`) so the pattern is linear by
+// construction and cannot backtrack polynomially. No real dimension has more
+// than a handful of digits.
+const DIMENSION_RE = /-?\d{1,9}(?:\.\d{1,9})?(?:px|rem)/i;
 
 const DIMENSION_PROPS = new Set([
   'padding',

--- a/skills/fuselage-craft/gate/rules/no-literal-dimension.mjs
+++ b/skills/fuselage-craft/gate/rules/no-literal-dimension.mjs
@@ -1,0 +1,189 @@
+/**
+ * no-literal-dimension — flag literal px/rem dimension values in style objects
+ * and css/styled tagged templates ONLY (to avoid false positives elsewhere).
+ *
+ * Tracked properties: padding*, margin*, fontSize, fontWeight, lineHeight,
+ * borderRadius, gap, width, height.
+ *
+ * Allowed values: 0, auto, 100%, CSS var(), calc() references.
+ *
+ * Zero hardcoded Fuselage values — bans the literal pattern only.
+ */
+
+const DIMENSION_RE = /(-?\d+(\.\d+)?(px|rem))/i;
+
+const DIMENSION_PROPS = new Set([
+  'padding',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingBlock',
+  'paddingBlockStart',
+  'paddingBlockEnd',
+  'paddingInline',
+  'paddingInlineStart',
+  'paddingInlineEnd',
+  'margin',
+  'marginTop',
+  'marginRight',
+  'marginBottom',
+  'marginLeft',
+  'marginBlock',
+  'marginBlockStart',
+  'marginBlockEnd',
+  'marginInline',
+  'marginInlineStart',
+  'marginInlineEnd',
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+  'borderRadius',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'width',
+  'height',
+  'minWidth',
+  'maxWidth',
+  'minHeight',
+  'maxHeight',
+  // CSS kebab-case equivalents (may appear in template literals)
+  'padding-top',
+  'padding-right',
+  'padding-bottom',
+  'padding-left',
+  'padding-block',
+  'padding-block-start',
+  'padding-block-end',
+  'padding-inline',
+  'padding-inline-start',
+  'padding-inline-end',
+  'margin-top',
+  'margin-right',
+  'margin-bottom',
+  'margin-left',
+  'margin-block',
+  'margin-block-start',
+  'margin-block-end',
+  'margin-inline',
+  'margin-inline-start',
+  'margin-inline-end',
+  'font-size',
+  'font-weight',
+  'line-height',
+  'border-radius',
+  'row-gap',
+  'column-gap',
+  'min-width',
+  'max-width',
+  'min-height',
+  'max-height',
+]);
+
+const ALLOWED_RE = /^(0|auto|100%|var\(|calc\()/;
+
+function isAllowed(value) {
+  if (typeof value !== 'string') return true;
+  const trimmed = value.trim();
+  return ALLOWED_RE.test(trimmed);
+}
+
+function hasDimensionLiteral(value) {
+  if (typeof value !== 'string') return false;
+  if (isAllowed(value)) return false;
+  return DIMENSION_RE.test(value);
+}
+
+function isInsideStyleJSXAttr(node) {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === 'JSXAttribute' &&
+      current.name &&
+      current.name.name === 'style'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isInsideCssTaggedTemplate(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'TaggedTemplateExpression') {
+      const { tag } = current;
+      if (
+        (tag.type === 'Identifier' && tag.name === 'css') ||
+        (tag.type === 'MemberExpression' &&
+          tag.object &&
+          tag.object.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.type === 'MemberExpression' &&
+          tag.callee.object &&
+          tag.callee.object.name === 'styled')
+      ) {
+        return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/** Get the string key of a Property node. */
+function getPropKey(node) {
+  if (!node.key) return null;
+  if (node.key.type === 'Identifier') return node.key.name;
+  if (node.key.type === 'Literal') return String(node.key.value);
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow literal px/rem dimension values in style objects and css/styled tagged templates. Use Box spacing props (p/m on x* scale), fontScale=, or borderRadius= scale names.',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noLiteralDimension:
+        'Literal dimension value detected. Use Box spacing props (`p`/`m` on the x* scale), `fontScale=`, or a `borderRadius=` scale name so spacing resolves from the Fuselage design system.',
+    },
+  },
+
+  create(context) {
+    return {
+      // style={{ padding: '16px' }}
+      Property(node) {
+        if (!isInsideStyleJSXAttr(node)) return;
+        const key = getPropKey(node);
+        if (!key || !DIMENSION_PROPS.has(key)) return;
+        const val = node.value;
+        if (val && val.type === 'Literal' && typeof val.value === 'string') {
+          if (hasDimensionLiteral(val.value)) {
+            context.report({ node: val, messageId: 'noLiteralDimension' });
+          }
+        }
+      },
+
+      // Template quasis in css`...`/styled`...`
+      TemplateElement(node) {
+        const raw = node.value && node.value.raw;
+        if (!raw) return;
+        if (!isInsideCssTaggedTemplate(node)) return;
+        if (hasDimensionLiteral(raw)) {
+          context.report({ node, messageId: 'noLiteralDimension' });
+        }
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/rules/no-literal-shadow.mjs
+++ b/skills/fuselage-craft/gate/rules/no-literal-shadow.mjs
@@ -1,0 +1,117 @@
+/**
+ * no-literal-shadow — flag literal boxShadow / box-shadow values in:
+ *   - style={{...}} objects
+ *   - css/styled tagged templates
+ *
+ * Message: use Box `elevation=`.
+ *
+ * Zero hardcoded Fuselage values — bans the literal pattern, not specific token values.
+ */
+
+const SHADOW_PROPS = new Set(['boxShadow', 'box-shadow']);
+
+function isInsideStyleJSXAttr(node) {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === 'JSXAttribute' &&
+      current.name &&
+      current.name.name === 'style'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isInsideCssTaggedTemplate(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'TaggedTemplateExpression') {
+      const { tag } = current;
+      if (
+        (tag.type === 'Identifier' && tag.name === 'css') ||
+        (tag.type === 'MemberExpression' &&
+          tag.object &&
+          tag.object.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.type === 'MemberExpression' &&
+          tag.callee.object &&
+          tag.callee.object.name === 'styled')
+      ) {
+        return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function getPropKey(node) {
+  if (!node.key) return null;
+  if (node.key.type === 'Identifier') return node.key.name;
+  if (node.key.type === 'Literal') return String(node.key.value);
+  return null;
+}
+
+/**
+ * A heuristic to detect whether a template literal chunk contains a box-shadow
+ * declaration. Matches lines like:  box-shadow: 0 2px 4px rgba(0,0,0,.2);
+ */
+const SHADOW_DECL_RE = /box-shadow\s*:/i;
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow literal boxShadow/box-shadow values. Use Box `elevation=` prop so shadows resolve from the Fuselage design system.',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noLiteralShadow:
+        'Literal shadow value detected. Use the Box `elevation=` prop (e.g. elevation="2") so the shadow resolves from the Fuselage design system.',
+    },
+  },
+
+  create(context) {
+    return {
+      // style={{ boxShadow: '0 2px 4px #000' }}
+      Property(node) {
+        if (!isInsideStyleJSXAttr(node)) return;
+        const key = getPropKey(node);
+        if (!key || !SHADOW_PROPS.has(key)) return;
+        const val = node.value;
+        // Any non-trivial value (string literal, non-zero, non-none) is flagged.
+        if (val && val.type === 'Literal') {
+          const v = val.value;
+          // Allow 'none', 'unset', 'inherit', '0'
+          if (
+            typeof v === 'string' &&
+            !['none', 'unset', 'inherit', 'initial', '0'].includes(
+              v.trim().toLowerCase(),
+            )
+          ) {
+            context.report({ node: val, messageId: 'noLiteralShadow' });
+          }
+        }
+      },
+
+      // TemplateElement inside css`...`/styled`...` containing box-shadow declarations
+      TemplateElement(node) {
+        const raw = node.value && node.value.raw;
+        if (!raw) return;
+        if (!isInsideCssTaggedTemplate(node)) return;
+        if (SHADOW_DECL_RE.test(raw)) {
+          context.report({ node, messageId: 'noLiteralShadow' });
+        }
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/rules/no-raw-color.mjs
+++ b/skills/fuselage-craft/gate/rules/no-raw-color.mjs
@@ -1,0 +1,138 @@
+/**
+ * no-raw-color — flag literal color values in JSX/style/CSS contexts.
+ *
+ * Detects hex (#rrggbb etc.), rgb(), rgba(), hsl(), hsla() in:
+ *   - JSXAttribute string values whose attribute name relates to color
+ *   - ObjectExpression property values inside a `style={{...}}` JSX attribute
+ *   - TemplateLiteral / string arguments of tagged templates named `css` or `styled.*`
+ *
+ * Zero hardcoded Fuselage values — bans the literal pattern, not specific tokens.
+ */
+
+const COLOR_RE = /#([0-9a-fA-F]{3,8})\b|rgb\(|rgba\(|hsl\(|hsla\(/i;
+
+const COLOR_PROP_RE = /^(color|background|backgroundColor|background-color|fill|stroke|border-color|borderColor|outline|outlineColor|caretColor|textDecorationColor|columnRuleColor|accentColor)$/i;
+
+/** Return true when the string value contains a color literal. */
+function hasColorLiteral(value) {
+  return typeof value === 'string' && COLOR_RE.test(value);
+}
+
+/** Walk up ancestors to find whether this node is inside a `style={{...}}` JSX attribute. */
+function isInsideStyleJSXAttr(node) {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === 'JSXAttribute' &&
+      current.name &&
+      current.name.name === 'style'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/** Return true when the node is inside a tagged template whose tag is `css` or `styled.*`. */
+function isInsideCssTaggedTemplate(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'TaggedTemplateExpression') {
+      const { tag } = current;
+      if (
+        (tag.type === 'Identifier' && tag.name === 'css') ||
+        (tag.type === 'MemberExpression' &&
+          tag.object &&
+          tag.object.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.name === 'styled') ||
+        (tag.type === 'CallExpression' &&
+          tag.callee &&
+          tag.callee.type === 'MemberExpression' &&
+          tag.callee.object &&
+          tag.callee.object.name === 'styled')
+      ) {
+        return true;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow literal color values in JSX/style/CSS contexts. Use Box color=/bg= semantic token names instead.',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noRawColor:
+        'Literal color value detected. Use a Box `color=` or `bg=` semantic token name (e.g. color="font-default") so the value resolves from the Fuselage design system at runtime.',
+    },
+  },
+
+  create(context) {
+    /**
+     * Report a node if its string value matches the color pattern.
+     */
+    function reportIfColor(node, value) {
+      if (hasColorLiteral(value)) {
+        context.report({ node, messageId: 'noRawColor' });
+      }
+    }
+
+    return {
+      // Style object properties: style={{ color: '#fff' }}
+      Property(node) {
+        if (!isInsideStyleJSXAttr(node)) return;
+        const val = node.value;
+        if (val && val.type === 'Literal' && typeof val.value === 'string') {
+          reportIfColor(val, val.value);
+        }
+      },
+
+      // JSXAttribute string values where the attribute name relates to color
+      // e.g. <div color="#fff"> or <Comp background="rgba(0,0,0,0.5)">
+      JSXAttribute(node) {
+        if (!node.value) return;
+        const attrName =
+          node.name.type === 'JSXIdentifier' ? node.name.name : '';
+        if (!COLOR_PROP_RE.test(attrName)) return;
+
+        const val = node.value;
+        if (val.type === 'Literal' && typeof val.value === 'string') {
+          reportIfColor(val, val.value);
+        } else if (
+          val.type === 'JSXExpressionContainer' &&
+          val.expression.type === 'Literal' &&
+          typeof val.expression.value === 'string'
+        ) {
+          reportIfColor(val.expression, val.expression.value);
+        }
+      },
+
+      // String literals inside css`...` / styled.xxx`...` tagged templates
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        if (!isInsideCssTaggedTemplate(node)) return;
+        reportIfColor(node, node.value);
+      },
+
+      // Template literal quasis inside css`...` / styled.xxx`...`
+      TemplateElement(node) {
+        const raw = node.value && node.value.raw;
+        if (!raw) return;
+        if (!isInsideCssTaggedTemplate(node)) return;
+        if (hasColorLiteral(raw)) {
+          context.report({ node, messageId: 'noRawColor' });
+        }
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/rules/no-raw-color.mjs
+++ b/skills/fuselage-craft/gate/rules/no-raw-color.mjs
@@ -73,7 +73,7 @@ export default {
     schema: [],
     messages: {
       noRawColor:
-        'Literal color value detected. Use a Box `color=` or `bg=` semantic token name (e.g. color="font-default") so the value resolves from the Fuselage design system at runtime.',
+        'Literal color value detected. Use a Box `color=` or `bg=` semantic token name (e.g. color="default") so the value resolves from the Fuselage design system at runtime.',
     },
   },
 

--- a/skills/fuselage-craft/gate/rules/prefer-box.mjs
+++ b/skills/fuselage-craft/gate/rules/prefer-box.mjs
@@ -1,0 +1,81 @@
+/**
+ * prefer-box — warn when a raw DOM element (lowercase tag) uses `style={{...}}`
+ * inline styles, suggesting a Fuselage <Box> with semantic props instead.
+ *
+ * Severity: WARN (not error) — kept conservative to limit noise.
+ * Only targets lowercase JSX elements (div, span, section, etc.) with a style
+ * prop that contains an ObjectExpression (not a variable reference).
+ */
+
+// HTML tags that are reasonable candidates for <Box> replacement
+const CANDIDATE_TAGS = new Set([
+  'div',
+  'span',
+  'section',
+  'article',
+  'aside',
+  'main',
+  'header',
+  'footer',
+  'nav',
+  'ul',
+  'ol',
+  'li',
+  'p',
+  'a',
+  'button',
+  'form',
+  'fieldset',
+  'label',
+]);
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Fuselage <Box> with semantic props over raw DOM elements with inline styles.',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      preferBox:
+        'Avoid inline style objects on raw DOM element <{{tag}}>. Use the Fuselage <Box> component with semantic props (p=, color=, fontScale=, etc.) so styles resolve from the design system.',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        const nameNode = node.name;
+        // Only lowercase (DOM) elements
+        if (nameNode.type !== 'JSXIdentifier') return;
+        const tagName = nameNode.name;
+        if (!CANDIDATE_TAGS.has(tagName)) return;
+
+        // Find a style attribute with an inline object expression
+        const styleAttr = node.attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' &&
+            attr.name &&
+            attr.name.name === 'style' &&
+            attr.value &&
+            attr.value.type === 'JSXExpressionContainer' &&
+            attr.value.expression &&
+            attr.value.expression.type === 'ObjectExpression',
+        );
+
+        if (!styleAttr) return;
+
+        // Only warn when the object has at least one property (not empty {})
+        if (styleAttr.value.expression.properties.length === 0) return;
+
+        context.report({
+          node,
+          messageId: 'preferBox',
+          data: { tag: tagName },
+        });
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/rules/require-field-wrapper.mjs
+++ b/skills/fuselage-craft/gate/rules/require-field-wrapper.mjs
@@ -1,0 +1,129 @@
+/**
+ * require-field-wrapper — flag input controls that are NOT inside a <Field> JSX ancestor.
+ *
+ * Controls checked:
+ *   - Raw HTML: input, select, textarea
+ *   - Configurable list of Fuselage control component names (camelCase)
+ *
+ * Options (single schema object):
+ *   controls  {string[]}  Additional / override component names to check.
+ *   fieldComponent {string}  The wrapper component name (default: 'Field').
+ *
+ * Zero hardcoded Fuselage values — component list is configurable rule option.
+ */
+
+// Default: only raw HTML elements. Fuselage control names are supplied at
+// runtime via the `controls` option (populated by run-gate.mjs from the
+// live resolver). Nothing Fuselage-specific is hardcoded here.
+const DEFAULT_CONTROLS = ['input', 'select', 'textarea'];
+
+const DEFAULT_FIELD = 'Field';
+
+/**
+ * Walk JSX ancestor chain and return true when a matching wrapper is found.
+ * The field wrapper may be `Field` or `FieldRow` (or the configured name).
+ */
+function hasFieldAncestor(node, fieldComponent) {
+  const variants = new Set([fieldComponent, `${fieldComponent}Row`]);
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'JSXElement') {
+      const opening = current.openingElement;
+      if (opening) {
+        const name = opening.name;
+        // <Field> — JSXIdentifier
+        if (name.type === 'JSXIdentifier' && variants.has(name.name)) {
+          return true;
+        }
+        // <Field.Row> — JSXMemberExpression
+        if (
+          name.type === 'JSXMemberExpression' &&
+          name.object &&
+          name.object.type === 'JSXIdentifier' &&
+          variants.has(name.object.name)
+        ) {
+          return true;
+        }
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require input controls to be wrapped in a <Field> component for built-in a11y.',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          controls: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'List of component names considered input controls. Replaces the default list when provided.',
+          },
+          fieldComponent: {
+            type: 'string',
+            description:
+              'Name of the field wrapper component (default: "Field").',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      requireFieldWrapper:
+        'Input control "{{name}}" must be wrapped in a <{{field}}> (or <{{field}}Row>) component for built-in accessibility. See Fuselage Field docs.',
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const controls = new Set(
+      Array.isArray(options.controls) ? options.controls : DEFAULT_CONTROLS,
+    );
+    const fieldComponent =
+      typeof options.fieldComponent === 'string'
+        ? options.fieldComponent
+        : DEFAULT_FIELD;
+
+    return {
+      JSXOpeningElement(node) {
+        const name = node.name;
+        let componentName = null;
+
+        if (name.type === 'JSXIdentifier') {
+          componentName = name.name;
+        } else if (name.type === 'JSXMemberExpression') {
+          // e.g. <Foo.Bar> — build full name for matching
+          const parts = [];
+          let n = name;
+          while (n.type === 'JSXMemberExpression') {
+            parts.unshift(n.property.name);
+            n = n.object;
+          }
+          if (n.type === 'JSXIdentifier') parts.unshift(n.name);
+          componentName = parts.join('.');
+        }
+
+        if (!componentName || !controls.has(componentName)) return;
+
+        // The JSXOpeningElement's parent is JSXElement
+        if (!hasFieldAncestor(node.parent, fieldComponent)) {
+          context.report({
+            node,
+            messageId: 'requireFieldWrapper',
+            data: { name: componentName, field: fieldComponent },
+          });
+        }
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/rules/valid-color-token.mjs
+++ b/skills/fuselage-craft/gate/rules/valid-color-token.mjs
@@ -1,0 +1,243 @@
+/**
+ * valid-color-token — flag invalid/malformed Fuselage color token names.
+ *
+ * Catches the case where a developer passes the FULL internal token name
+ * (e.g. color='font-default') when the Box transform already prepends the
+ * prefix — resulting in font-font-default at runtime (invalid, console warning).
+ *
+ * Two error kinds:
+ *   doublePrefix  — value starts with the group prefix (font-/stroke-) when the
+ *                   prop already adds that prefix. The fix is to use the bare name.
+ *   unknownToken  — value is a string that is not in the installed palette at all.
+ *
+ * CRITICAL: If the `palette` option is absent or empty this rule is a complete
+ * NO-OP. It must NEVER false-positive when it has no live data. Standalone
+ * `npx eslint --config` won't inject the palette — that's intentional.
+ * The authoritative run is via run-gate.mjs which injects the live palette.
+ *
+ * Options (single schema object):
+ *   palette  {Array<{groupName: string, meta: object|null, keys: string[]}>}
+ *     The `semantic` resolver output array. Injected by run-gate.mjs; not
+ *     present in standalone eslint runs.
+ */
+
+/** CSS-literal patterns that belong to no-raw-color, not here. Skip them. */
+const RAW_COLOR_RE = /var\(|#|rgb|hsl/i;
+
+/**
+ * Return true when a string value should be skipped by this rule
+ * (non-semantic, handled by no-raw-color or is a dynamic expression).
+ */
+function isRawOrDynamic(value) {
+  return RAW_COLOR_RE.test(value);
+}
+
+/**
+ * Build the validation sets from the palette array.
+ *
+ * Returns:
+ *   colorValid      Set<string>  — valid bare names for color=
+ *   bgValid         Set<string>  — valid bare AND full names for bg=/backgroundColor=
+ *   borderColorValid Set<string> — valid bare names for borderColor=
+ */
+function buildSets(palette) {
+  const colorValid = new Set();
+  const bgValid = new Set();
+  const borderColorValid = new Set();
+
+  for (const group of palette) {
+    const { groupName, meta, keys } = group;
+
+    if (groupName === 'text') {
+      // text group: meta.prop includes 'color='; keys are already bare (font- stripped)
+      for (const k of keys) {
+        colorValid.add(k);
+      }
+    } else if (groupName === 'surface') {
+      // surface group: meta.prop is 'bg= / backgroundColor='; keys are already bare
+      // bg= accepts BOTH bare ('light') and full ('surface-light') forms
+      for (const k of keys) {
+        bgValid.add(k);
+        bgValid.add('surface-' + k);
+      }
+    } else if (groupName === 'stroke') {
+      // stroke group: meta.prop is 'borderColor='; keys are already bare (stroke- stripped)
+      for (const k of keys) {
+        borderColorValid.add(k);
+      }
+    } else if (groupName === 'statusColor') {
+      // statusColor group: full names (e.g. 'success', 'danger') also valid for color=
+      for (const k of keys) {
+        colorValid.add(k);
+      }
+    } else if (groupName === 'status') {
+      // status group: status-background-* full names are valid for bg=
+      for (const k of keys) {
+        bgValid.add(k);
+      }
+    }
+    // badge, shadow, and other groups: not mapped to JSX props — skip
+  }
+
+  return { colorValid, bgValid, borderColorValid };
+}
+
+/**
+ * Validate a single string value for a given prop and report if invalid.
+ * @param {object} context  ESLint context
+ * @param {object} node     AST node to report on
+ * @param {string} prop     JSX attribute name (color/bg/backgroundColor/borderColor)
+ * @param {string} value    The string literal value to check
+ * @param {Set}    colorValid
+ * @param {Set}    bgValid
+ * @param {Set}    borderColorValid
+ */
+function checkValue(context, node, prop, value, colorValid, bgValid, borderColorValid) {
+  // Skip raw CSS literals — those are no-raw-color's job
+  if (isRawOrDynamic(value)) return;
+
+  if (prop === 'color') {
+    // double-prefix: developer wrote 'font-default' but transform adds 'font-' itself
+    if (value.startsWith('font-')) {
+      const bare = value.slice('font-'.length);
+      context.report({
+        node,
+        messageId: 'doublePrefix',
+        data: { prop, prefix: 'font-', bare, value },
+      });
+      return;
+    }
+    if (!colorValid.has(value)) {
+      context.report({
+        node,
+        messageId: 'unknownToken',
+        data: { prop, value },
+      });
+    }
+  } else if (prop === 'borderColor') {
+    // double-prefix: developer wrote 'stroke-light' but transform adds 'stroke-' itself
+    if (value.startsWith('stroke-')) {
+      const bare = value.slice('stroke-'.length);
+      context.report({
+        node,
+        messageId: 'doublePrefix',
+        data: { prop, prefix: 'stroke-', bare, value },
+      });
+      return;
+    }
+    if (!borderColorValid.has(value)) {
+      context.report({
+        node,
+        messageId: 'unknownToken',
+        data: { prop, value },
+      });
+    }
+  } else if (prop === 'bg' || prop === 'backgroundColor') {
+    // bg= is permissive: accepts bare ('light') and full ('surface-light') forms
+    if (!bgValid.has(value)) {
+      context.report({
+        node,
+        messageId: 'unknownToken',
+        data: { prop, value },
+      });
+    }
+  }
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Flag invalid or double-prefixed Fuselage color token names in JSX color/bg/borderColor props.',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          palette: {
+            type: 'array',
+            description:
+              'Semantic palette array from resolveCategory("semantic"). Injected by run-gate.mjs. ' +
+              'When absent the rule is a no-op.',
+            items: {
+              type: 'object',
+              properties: {
+                groupName: { type: 'string' },
+                meta: {},
+                keys: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['groupName', 'keys'],
+              additionalProperties: true,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      doublePrefix:
+        'Fuselage `{{prop}}` takes the BARE token name — the transform adds the `{{prefix}}` prefix itself. ' +
+        "Use {{prop}}='{{bare}}', not '{{value}}'.",
+      unknownToken:
+        "Unknown Fuselage color token '{{value}}' for `{{prop}}=` — not in the installed palette. " +
+        'Resolve valid names via resolve.mjs semantic.',
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const palette = Array.isArray(options.palette) ? options.palette : null;
+
+    // NO-OP guard: if palette is absent or empty, disable entirely
+    if (!palette || palette.length === 0) {
+      return {};
+    }
+
+    const { colorValid, bgValid, borderColorValid } = buildSets(palette);
+
+    const TARGET_PROPS = new Set(['color', 'bg', 'backgroundColor', 'borderColor']);
+
+    return {
+      JSXAttribute(node) {
+        if (!node.value) return;
+
+        const attrName =
+          node.name.type === 'JSXIdentifier' ? node.name.name : '';
+        if (!TARGET_PROPS.has(attrName)) return;
+
+        const val = node.value;
+
+        // Direct string literal: color="something"
+        if (val.type === 'Literal' && typeof val.value === 'string') {
+          checkValue(context, val, attrName, val.value, colorValid, bgValid, borderColorValid);
+          return;
+        }
+
+        // JSXExpressionContainer: color={"something"} or color={condition ? "a" : "b"}
+        if (val.type === 'JSXExpressionContainer') {
+          const expr = val.expression;
+
+          // String literal in braces: color={"something"}
+          if (expr.type === 'Literal' && typeof expr.value === 'string') {
+            checkValue(context, expr, attrName, expr.value, colorValid, bgValid, borderColorValid);
+            return;
+          }
+
+          // Conditional expression with string literal branches: color={x ? "a" : "b"}
+          if (expr.type === 'ConditionalExpression') {
+            const { consequent, alternate } = expr;
+            if (consequent.type === 'Literal' && typeof consequent.value === 'string') {
+              checkValue(context, consequent, attrName, consequent.value, colorValid, bgValid, borderColorValid);
+            }
+            if (alternate.type === 'Literal' && typeof alternate.value === 'string') {
+              checkValue(context, alternate, attrName, alternate.value, colorValid, bgValid, borderColorValid);
+            }
+          }
+          // Non-literal expressions (variables, function calls, etc.) — skip
+        }
+      },
+    };
+  },
+};

--- a/skills/fuselage-craft/gate/run-gate.mjs
+++ b/skills/fuselage-craft/gate/run-gate.mjs
@@ -31,7 +31,9 @@ const targetGlobs = argv.slice(2).length > 0 ? argv.slice(2) : DEFAULT_GLOBS;
 // ─── Live Fuselage control list ───────────────────────────────────────────────
 
 /**
- * Load the live list of Fuselage form input control names from the resolver.
+ * Load the live list of Fuselage input control primitive names from the resolver.
+ * These are the actual user-facing controls (TextInput, Select, CheckBox, etc.) —
+ * NOT the Field wrapper family (Field, FieldRow, FieldGroup...) which is `forms`.
  * These are passed as the `controls` option to the require-field-wrapper rule
  * so no Fuselage names are baked into the rule itself.
  *
@@ -44,12 +46,12 @@ async function loadLiveFuselageControls() {
   ).href;
   try {
     const { resolveCategory } = await import(resolverPath);
-    const result = await resolveCategory('forms');
+    const result = await resolveCategory('inputs');
     if (result.status === 'ok' && Array.isArray(result.data) && result.data.length > 0) {
       return result.data;
     }
     process.stderr.write(
-      `run-gate: resolver returned ${result.status} for forms: ${result.reason ?? ''}\n`,
+      `run-gate: resolver returned ${result.status} for inputs: ${result.reason ?? ''}\n`,
     );
     return null;
   } catch (err) {
@@ -60,9 +62,38 @@ async function loadLiveFuselageControls() {
   }
 }
 
+/**
+ * Load the live semantic color palette from the resolver.
+ * This is passed as the `palette` option to the valid-color-token rule so no
+ * Fuselage token names are baked into the rule itself.
+ *
+ * Returns the semantic data array on success, or null on failure (rule no-ops).
+ */
+async function loadLivePalette() {
+  const resolverPath = pathToFileURL(
+    join(GATE_DIR, '..', 'resolve.mjs'),
+  ).href;
+  try {
+    const { resolveCategory } = await import(resolverPath);
+    const result = await resolveCategory('semantic');
+    if (result.status === 'ok' && Array.isArray(result.data) && result.data.length > 0) {
+      return result.data;
+    }
+    process.stderr.write(
+      `run-gate: resolver returned ${result.status} for semantic: ${result.reason ?? ''}\n`,
+    );
+    return null;
+  } catch (err) {
+    process.stderr.write(
+      `run-gate: could not load semantic palette (${err.message}); valid-color-token will no-op\n`,
+    );
+    return null;
+  }
+}
+
 // ─── Lint gate ────────────────────────────────────────────────────────────────
 
-async function runLintGate(fuselageControls) {
+async function runLintGate(fuselageControls, livePalette) {
   // Build rule options for require-field-wrapper.
   // If we have a live control list, merge it with the raw-HTML defaults.
   const rawHtml = ['input', 'select', 'textarea'];
@@ -70,17 +101,20 @@ async function runLintGate(fuselageControls) {
     ? [...new Set([...rawHtml, ...fuselageControls])]
     : null; // null = rule uses its own DEFAULT_CONTROLS (raw HTML only)
 
-  const overrideConfig = controls
-    ? [
-        {
-          rules: {
-            'fuselage-craft-gate/require-field-wrapper': [
-              'error',
-              { controls },
-            ],
-          },
-        },
-      ]
+  // Build overrideConfig combining require-field-wrapper and valid-color-token options.
+  // Both rules degrade gracefully when their live data is absent.
+  const overrideRules = {};
+  if (controls) {
+    // 'warn': a missing Field wrapper is an a11y recommendation (toolbar/filter inputs
+    // legitimately skip it), not a hard conformance failure. Informs without blocking.
+    overrideRules['fuselage-craft-gate/require-field-wrapper'] = ['warn', { controls }];
+  }
+  if (livePalette) {
+    overrideRules['fuselage-craft-gate/valid-color-token'] = ['error', { palette: livePalette }];
+  }
+
+  const overrideConfig = Object.keys(overrideRules).length > 0
+    ? [{ rules: overrideRules }]
     : undefined;
 
   const eslint = new ESLint({
@@ -98,7 +132,33 @@ async function runLintGate(fuselageControls) {
     return { errors: 1, warnings: 0 };
   }
 
-  let totalErrors = 0;
+  // Honesty guard: a file OUTSIDE the cwd base path matches no flat-config block
+  // (`files: ['**/*...']` only matches under cwd), so ESLint lints it with ZERO
+  // rules and returns a clean result — a silent false PASS. Refuse to report PASS
+  // for any target that was processed without the gate's own rules attached.
+  let unconfigured = 0;
+  for (const result of results) {
+    let cfg;
+    try {
+      cfg = await eslint.calculateConfigForFile(result.filePath);
+    } catch {
+      cfg = undefined;
+    }
+    const gated =
+      cfg &&
+      cfg.rules &&
+      Object.keys(cfg.rules).some((k) => k.startsWith('fuselage-craft-gate/'));
+    if (!gated) {
+      process.stderr.write(
+        `Lint gate: '${relative(cwd(), result.filePath)}' is outside the cwd base path — ` +
+          `the gate config did not apply to it, so it was NOT checked. Run the gate from the ` +
+          `consumer repo root and target paths under it (e.g. src/**).\n`,
+      );
+      unconfigured += 1;
+    }
+  }
+
+  let totalErrors = unconfigured;
   let totalWarnings = 0;
 
   for (const result of results) {
@@ -153,16 +213,29 @@ process.stdout.write(
 const fuselageControls = await loadLiveFuselageControls();
 if (fuselageControls) {
   process.stdout.write(
-    `resolver: loaded ${fuselageControls.length} Fuselage form controls for require-field-wrapper\n`,
+    `resolver: loaded ${fuselageControls.length} Fuselage input controls for require-field-wrapper\n`,
   );
 } else {
   process.stdout.write(
-    `resolver: could not load Fuselage controls — require-field-wrapper will check raw HTML only\n`,
+    `resolver: could not load Fuselage input controls — require-field-wrapper will check raw HTML only\n`,
+  );
+}
+
+// Load live semantic palette for valid-color-token (degrade gracefully on failure)
+const livePalette = await loadLivePalette();
+if (livePalette) {
+  const tokenCount = livePalette.reduce((n, g) => n + g.keys.length, 0);
+  process.stdout.write(
+    `resolver: loaded ${tokenCount} semantic color tokens across ${livePalette.length} groups for valid-color-token\n`,
+  );
+} else {
+  process.stdout.write(
+    `resolver: could not load semantic palette — valid-color-token will no-op\n`,
   );
 }
 
 process.stdout.write('─── Lint gate ───────────────────────────────────────\n');
-const { errors: lintErrors, warnings: lintWarnings } = await runLintGate(fuselageControls);
+const { errors: lintErrors, warnings: lintWarnings } = await runLintGate(fuselageControls, livePalette);
 
 process.stdout.write(
   '\n─── Type gate ───────────────────────────────────────\n',

--- a/skills/fuselage-craft/gate/run-gate.mjs
+++ b/skills/fuselage-craft/gate/run-gate.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * run-gate.mjs — ESM orchestrator for the fuselage-craft gate.
+ *
+ * Runs:
+ *   1. Lint gate — programmatic ESLint with the local gate config
+ *   2. Type gate — spawns typecheck.mjs (which runs tsc --noEmit)
+ *
+ * Usage:
+ *   node skills/fuselage-craft/gate/run-gate.mjs [globs...]
+ *   node skills/fuselage-craft/gate/run-gate.mjs src/**\/*.{ts,tsx}
+ *
+ * Exits nonzero if lint errors > 0 OR tsc exits nonzero.
+ * Warnings do NOT fail the gate.
+ */
+
+import { ESLint } from 'eslint';
+import { spawn } from 'child_process';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { dirname, resolve as pathResolve, relative, join } from 'path';
+import { argv, exit, cwd } from 'process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const GATE_DIR = __dirname;
+
+const DEFAULT_GLOBS = ['src/**/*.{ts,tsx}'];
+const targetGlobs = argv.slice(2).length > 0 ? argv.slice(2) : DEFAULT_GLOBS;
+
+// ─── Live Fuselage control list ───────────────────────────────────────────────
+
+/**
+ * Load the live list of Fuselage form input control names from the resolver.
+ * These are passed as the `controls` option to the require-field-wrapper rule
+ * so no Fuselage names are baked into the rule itself.
+ *
+ * On failure, returns null and the rule falls back to its raw-HTML default.
+ */
+async function loadLiveFuselageControls() {
+  // Locate resolve.mjs relative to this file: ../resolve.mjs
+  const resolverPath = pathToFileURL(
+    join(GATE_DIR, '..', 'resolve.mjs'),
+  ).href;
+  try {
+    const { resolveCategory } = await import(resolverPath);
+    const result = await resolveCategory('forms');
+    if (result.status === 'ok' && Array.isArray(result.data) && result.data.length > 0) {
+      return result.data;
+    }
+    process.stderr.write(
+      `run-gate: resolver returned ${result.status} for forms: ${result.reason ?? ''}\n`,
+    );
+    return null;
+  } catch (err) {
+    process.stderr.write(
+      `run-gate: could not load resolver (${err.message}); require-field-wrapper will use raw-HTML default\n`,
+    );
+    return null;
+  }
+}
+
+// ─── Lint gate ────────────────────────────────────────────────────────────────
+
+async function runLintGate(fuselageControls) {
+  // Build rule options for require-field-wrapper.
+  // If we have a live control list, merge it with the raw-HTML defaults.
+  const rawHtml = ['input', 'select', 'textarea'];
+  const controls = fuselageControls
+    ? [...new Set([...rawHtml, ...fuselageControls])]
+    : null; // null = rule uses its own DEFAULT_CONTROLS (raw HTML only)
+
+  const overrideConfig = controls
+    ? [
+        {
+          rules: {
+            'fuselage-craft-gate/require-field-wrapper': [
+              'error',
+              { controls },
+            ],
+          },
+        },
+      ]
+    : undefined;
+
+  const eslint = new ESLint({
+    overrideConfigFile: pathResolve(GATE_DIR, 'eslint.config.mjs'),
+    ...(overrideConfig ? { overrideConfig } : {}),
+    // Let the consumer's cwd be the base for glob resolution
+    cwd: cwd(),
+  });
+
+  let results;
+  try {
+    results = await eslint.lintFiles(targetGlobs);
+  } catch (err) {
+    process.stderr.write(`Lint gate error: ${err.message}\n`);
+    return { errors: 1, warnings: 0 };
+  }
+
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  for (const result of results) {
+    if (result.messages.length === 0) continue;
+
+    const relPath = relative(cwd(), result.filePath);
+    for (const msg of result.messages) {
+      const severity = msg.severity === 2 ? 'error' : 'warn';
+      const loc = `${relPath}:${msg.line}:${msg.column}`;
+      const ruleId = msg.ruleId ? ` [${msg.ruleId}]` : '';
+      process.stdout.write(`${severity}  ${loc}${ruleId}  ${msg.message}\n`);
+    }
+
+    totalErrors += result.errorCount;
+    totalWarnings += result.warningCount;
+  }
+
+  return { errors: totalErrors, warnings: totalWarnings };
+}
+
+// ─── Type gate ────────────────────────────────────────────────────────────────
+
+function runTypeGate() {
+  return new Promise((promiseResolve) => {
+    const scriptPath = new URL('./typecheck.mjs', import.meta.url).pathname;
+
+    const child = spawn(process.execPath, [scriptPath], {
+      stdio: 'inherit',
+      shell: false,
+    });
+
+    child.on('close', (code) => {
+      promiseResolve(code ?? 1);
+    });
+
+    child.on('error', (err) => {
+      process.stderr.write(
+        `Type gate: failed to spawn typecheck: ${err.message}\n`,
+      );
+      promiseResolve(1);
+    });
+  });
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+process.stdout.write(
+  `\nfuselage-craft gate — targeting: ${targetGlobs.join(', ')}\n\n`,
+);
+
+// Load live Fuselage form control list before lint (degrade gracefully on failure)
+const fuselageControls = await loadLiveFuselageControls();
+if (fuselageControls) {
+  process.stdout.write(
+    `resolver: loaded ${fuselageControls.length} Fuselage form controls for require-field-wrapper\n`,
+  );
+} else {
+  process.stdout.write(
+    `resolver: could not load Fuselage controls — require-field-wrapper will check raw HTML only\n`,
+  );
+}
+
+process.stdout.write('─── Lint gate ───────────────────────────────────────\n');
+const { errors: lintErrors, warnings: lintWarnings } = await runLintGate(fuselageControls);
+
+process.stdout.write(
+  '\n─── Type gate ───────────────────────────────────────\n',
+);
+const typeExitCode = await runTypeGate();
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+process.stdout.write('\n═════════════════════════════════════════════════════\n');
+const typeStatus = typeExitCode === 0 ? 'PASS' : 'FAIL';
+const lintStatus = lintErrors > 0 ? 'FAIL' : 'PASS';
+
+process.stdout.write(`Type gate : ${typeStatus}\n`);
+process.stdout.write(
+  `Lint gate : ${lintStatus}  (${lintErrors} errors, ${lintWarnings} warnings)\n`,
+);
+process.stdout.write('═════════════════════════════════════════════════════\n\n');
+
+const failed = lintErrors > 0 || typeExitCode !== 0;
+exit(failed ? 1 : 0);

--- a/skills/fuselage-craft/gate/tests/no-literal-dimension.test.mjs
+++ b/skills/fuselage-craft/gate/tests/no-literal-dimension.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Tests for rules/no-literal-dimension.mjs
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gateDir = resolve(__dirname, '..');
+
+const req = createRequire(resolve(gateDir, 'package.json'));
+const { RuleTester } = req('eslint');
+const tseslint = req('typescript-eslint');
+
+import rule from '../rules/no-literal-dimension.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+      project: false,
+    },
+  },
+});
+
+tester.run('no-literal-dimension', rule, {
+  valid: [
+    // 0 is allowed
+    {
+      code: `const C = () => <div style={{ padding: '0' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // auto is allowed
+    {
+      code: `const C = () => <div style={{ margin: 'auto' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // 100% is allowed
+    {
+      code: `const C = () => <div style={{ width: '100%' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // CSS var() is allowed
+    {
+      code: `const C = () => <div style={{ padding: 'var(--rcx-spacing-x16)' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // px outside style={{}} — not flagged (false positive guard)
+    {
+      code: `const label = '16px font';`,
+      filename: 'comp.tsx',
+    },
+  ],
+
+  invalid: [
+    // Literal px in padding inside style={{}}
+    {
+      code: `const C = () => <div style={{ padding: '16px' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralDimension' }],
+    },
+    // Literal rem in fontSize inside style={{}}
+    {
+      code: `const C = () => <div style={{ fontSize: '1.5rem' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralDimension' }],
+    },
+    // Literal px in borderRadius inside style={{}}
+    {
+      code: `const C = () => <div style={{ borderRadius: '4px' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralDimension' }],
+    },
+    // Literal px in css tagged template
+    {
+      code: `const s = css\`padding: 16px;\`;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralDimension' }],
+    },
+  ],
+});
+
+console.log('no-literal-dimension: all tests passed');

--- a/skills/fuselage-craft/gate/tests/no-literal-shadow.test.mjs
+++ b/skills/fuselage-craft/gate/tests/no-literal-shadow.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Tests for rules/no-literal-shadow.mjs
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gateDir = resolve(__dirname, '..');
+
+const req = createRequire(resolve(gateDir, 'package.json'));
+const { RuleTester } = req('eslint');
+const tseslint = req('typescript-eslint');
+
+import rule from '../rules/no-literal-shadow.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+      project: false,
+    },
+  },
+});
+
+tester.run('no-literal-shadow', rule, {
+  valid: [
+    // 'none' is allowed
+    {
+      code: `const C = () => <div style={{ boxShadow: 'none' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // No shadow prop — no issue
+    {
+      code: `const C = () => <div style={{ color: 'var(--rcx-color-font-default)' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // 'unset' is allowed
+    {
+      code: `const C = () => <div style={{ boxShadow: 'unset' }} />;`,
+      filename: 'comp.tsx',
+    },
+  ],
+
+  invalid: [
+    // Literal shadow value
+    {
+      code: `const C = () => <div style={{ boxShadow: '0 2px 4px rgba(0,0,0,0.2)' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralShadow' }],
+    },
+    // Literal shadow with hex color
+    {
+      code: `const C = () => <div style={{ boxShadow: '0 0 4px #000' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralShadow' }],
+    },
+    // box-shadow in styled tagged template
+    {
+      code: `const S = styled.div\`box-shadow: 0 1px 3px rgba(0,0,0,0.3);\`;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noLiteralShadow' }],
+    },
+  ],
+});
+
+console.log('no-literal-shadow: all tests passed');

--- a/skills/fuselage-craft/gate/tests/no-raw-color.test.mjs
+++ b/skills/fuselage-craft/gate/tests/no-raw-color.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Tests for rules/no-raw-color.mjs
+ *
+ * Run via: node tests/run-tests.mjs (from the gate/ directory)
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gateDir = resolve(__dirname, '..');
+
+// Resolve from gate's own node_modules
+const req = createRequire(resolve(gateDir, 'package.json'));
+const { RuleTester } = req('eslint');
+const tseslint = req('typescript-eslint');
+
+import rule from '../rules/no-raw-color.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+      project: false,
+    },
+  },
+});
+
+tester.run('no-raw-color', rule, {
+  valid: [
+    // Box with semantic token name — no literal color
+    {
+      code: `const C = () => <Box color="font-default" bg="surface-tint" />;`,
+      filename: 'comp.tsx',
+    },
+    // style with a CSS variable — allowed
+    {
+      code: `const C = () => <div style={{ color: 'var(--rcx-color-font-default)' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // Non-color style property — not a color attribute name, not in style context
+    {
+      code: `const C = () => <Box fontScale="h3" />;`,
+      filename: 'comp.tsx',
+    },
+    // String that looks like a hex but is in a non-color prop name
+    {
+      code: `const C = () => <input id="#something" />;`,
+      filename: 'comp.tsx',
+    },
+  ],
+
+  invalid: [
+    // Hex color in style object
+    {
+      code: `const C = () => <div style={{ color: '#156FF5' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noRawColor' }],
+    },
+    // rgba in style object
+    {
+      code: `const C = () => <div style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noRawColor' }],
+    },
+    // Hex in css tagged template
+    {
+      code: `const styles = css\`color: #fff;\`;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noRawColor' }],
+    },
+    // hsl in styled tagged template
+    {
+      code: `const Comp = styled.div\`background: hsl(200, 50%, 50%);\`;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'noRawColor' }],
+    },
+  ],
+});
+
+console.log('no-raw-color: all tests passed');

--- a/skills/fuselage-craft/gate/tests/prefer-box.test.mjs
+++ b/skills/fuselage-craft/gate/tests/prefer-box.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Tests for rules/prefer-box.mjs
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gateDir = resolve(__dirname, '..');
+
+const req = createRequire(resolve(gateDir, 'package.json'));
+const { RuleTester } = req('eslint');
+const tseslint = req('typescript-eslint');
+
+import rule from '../rules/prefer-box.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+      project: false,
+    },
+  },
+});
+
+tester.run('prefer-box', rule, {
+  valid: [
+    // Box with semantic props — no inline style
+    {
+      code: `const C = () => <Box p="x16" color="font-default" />;`,
+      filename: 'comp.tsx',
+    },
+    // Custom component (uppercase) with style — not a raw DOM element
+    {
+      code: `const C = () => <MyComponent style={{ padding: 'var(--x)' }} />;`,
+      filename: 'comp.tsx',
+    },
+    // Empty style object on div — should not warn (no properties)
+    {
+      code: `const C = () => <div style={{}} />;`,
+      filename: 'comp.tsx',
+    },
+    // Raw div without any style prop
+    {
+      code: `const C = () => <div className="foo" />;`,
+      filename: 'comp.tsx',
+    },
+  ],
+
+  invalid: [
+    // div with inline style object
+    {
+      code: `const C = () => <div style={{ display: 'flex' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'preferBox', data: { tag: 'div' } }],
+    },
+    // span with inline style object
+    {
+      code: `const C = () => <span style={{ fontWeight: 'bold' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'preferBox', data: { tag: 'span' } }],
+    },
+    // section with inline style object
+    {
+      code: `const C = () => <section style={{ margin: 'auto' }} />;`,
+      filename: 'comp.tsx',
+      errors: [{ messageId: 'preferBox', data: { tag: 'section' } }],
+    },
+  ],
+});
+
+console.log('prefer-box: all tests passed');

--- a/skills/fuselage-craft/gate/tests/require-field-wrapper.test.mjs
+++ b/skills/fuselage-craft/gate/tests/require-field-wrapper.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * Tests for rules/require-field-wrapper.mjs
+ */
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gateDir = resolve(__dirname, '..');
+
+const req = createRequire(resolve(gateDir, 'package.json'));
+const { RuleTester } = req('eslint');
+const tseslint = req('typescript-eslint');
+
+import rule from '../rules/require-field-wrapper.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+      project: false,
+    },
+  },
+});
+
+tester.run('require-field-wrapper', rule, {
+  valid: [
+    // Raw input inside <Field>
+    {
+      code: `const C = () => <Field><input type="text" /></Field>;`,
+      filename: 'comp.tsx',
+    },
+    // Fuselage TextInput inside <Field> — valid when controls option includes it
+    {
+      code: `const C = () => <Field><TextInput /></Field>;`,
+      filename: 'comp.tsx',
+      options: [{ controls: ['TextInput'] }],
+    },
+    // Select inside nested <Field> ancestor — valid when controls option includes it
+    {
+      code: `const C = () => <Field><Field.Row><Select options={[]} /></Field.Row></Field>;`,
+      filename: 'comp.tsx',
+      options: [{ controls: ['Select'] }],
+    },
+    // Non-control element — not checked regardless of options
+    {
+      code: `const C = () => <Box><Button>Submit</Button></Box>;`,
+      filename: 'comp.tsx',
+    },
+    // Fuselage TextInput outside Field — NOT flagged when not in controls list (default)
+    {
+      code: `const C = () => <div><TextInput /></div>;`,
+      filename: 'comp.tsx',
+    },
+  ],
+
+  invalid: [
+    // Raw input with no Field ancestor — always flagged (raw HTML in default)
+    {
+      code: `const C = () => <div><input type="text" /></div>;`,
+      filename: 'comp.tsx',
+      errors: [
+        { messageId: 'requireFieldWrapper', data: { name: 'input', field: 'Field' } },
+      ],
+    },
+    // Fuselage TextInput with no Field ancestor — flagged when controls option includes it
+    {
+      code: `const C = () => <div><TextInput /></div>;`,
+      filename: 'comp.tsx',
+      options: [{ controls: ['input', 'select', 'textarea', 'TextInput'] }],
+      errors: [
+        { messageId: 'requireFieldWrapper', data: { name: 'TextInput', field: 'Field' } },
+      ],
+    },
+    // Fuselage Select with no Field ancestor — flagged when controls option includes it
+    {
+      code: `const C = () => <form><Select options={[]} /></form>;`,
+      filename: 'comp.tsx',
+      options: [{ controls: ['input', 'select', 'textarea', 'Select'] }],
+      errors: [
+        { messageId: 'requireFieldWrapper', data: { name: 'Select', field: 'Field' } },
+      ],
+    },
+    // Custom field component name via options
+    {
+      code: `const C = () => <div><TextInput /></div>;`,
+      filename: 'comp.tsx',
+      options: [{ controls: ['TextInput'], fieldComponent: 'FormField' }],
+      errors: [
+        { messageId: 'requireFieldWrapper', data: { name: 'TextInput', field: 'FormField' } },
+      ],
+    },
+  ],
+});
+
+console.log('require-field-wrapper: all tests passed');

--- a/skills/fuselage-craft/gate/tests/run-tests.mjs
+++ b/skills/fuselage-craft/gate/tests/run-tests.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * run-tests.mjs — runs all rule RuleTester suites.
+ *
+ * Each test module calls RuleTester.run() which throws on failure.
+ * All five suites must pass or the process exits nonzero.
+ *
+ * Usage (from gate/ directory):
+ *   node tests/run-tests.mjs
+ *
+ * Usage (from repo root):
+ *   node skills/fuselage-craft/gate/tests/run-tests.mjs
+ */
+
+const suites = [
+  './no-raw-color.test.mjs',
+  './no-literal-dimension.test.mjs',
+  './no-literal-shadow.test.mjs',
+  './require-field-wrapper.test.mjs',
+  './prefer-box.test.mjs',
+];
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+for (const suite of suites) {
+  try {
+    await import(new URL(suite, import.meta.url).href);
+    passed++;
+  } catch (err) {
+    failed++;
+    failures.push({ suite, err });
+    process.stderr.write(`\nFAIL: ${suite}\n${err.message}\n`);
+    if (err.cause) {
+      process.stderr.write(`  cause: ${err.cause}\n`);
+    }
+  }
+}
+
+process.stdout.write(
+  `\n────────────────────────────────────────────────\n`,
+);
+process.stdout.write(`Test results: ${passed} passed, ${failed} failed\n`);
+
+if (failed > 0) {
+  process.stdout.write(`\nFailed suites:\n`);
+  for (const { suite } of failures) {
+    process.stdout.write(`  - ${suite}\n`);
+  }
+  process.exit(1);
+} else {
+  process.stdout.write(`All gate rule tests passed.\n`);
+}

--- a/skills/fuselage-craft/gate/typecheck.mjs
+++ b/skills/fuselage-craft/gate/typecheck.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * typecheck.mjs — thin TYPE GATE wrapper.
+ *
+ * Spawns `tsc --noEmit` and streams its output, then exits with tsc's exit code.
+ * This is the type gate: it validates emitted JSX against the consumer's installed
+ * Fuselage types. It doesn't know anything about Fuselage values — correctness comes
+ * from the consumer's own TypeScript project and installed Fuselage type declarations.
+ *
+ * Usage:
+ *   node typecheck.mjs                     # uses tsconfig.json in cwd
+ *   node typecheck.mjs -p tsconfig.app.json
+ *   node typecheck.mjs --project tsconfig.app.json
+ */
+
+import { spawn } from 'child_process';
+import { argv, exit } from 'process';
+
+const args = argv.slice(2);
+
+// Build tsc command args: --noEmit plus any -p / --project forwarding
+const tscArgs = ['--noEmit'];
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '-p' || arg === '--project') {
+    tscArgs.push(arg);
+    if (args[i + 1]) {
+      tscArgs.push(args[i + 1]);
+      i++;
+    }
+  } else {
+    // Forward any other flags as-is
+    tscArgs.push(arg);
+  }
+}
+
+const child = spawn('npx', ['tsc', ...tscArgs], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+child.on('close', (code) => {
+  exit(code ?? 1);
+});
+
+child.on('error', (err) => {
+  process.stderr.write(`typecheck.mjs: failed to spawn tsc: ${err.message}\n`);
+  exit(1);
+});

--- a/skills/fuselage-craft/reference/adapt.md
+++ b/skills/fuselage-craft/reference/adapt.md
@@ -1,0 +1,35 @@
+# adapt (Fix)
+
+Responsive behavior via Fuselage hooks, not literal media queries. Replace hardcoded breakpoint px with `useBreakpoints` / `useMediaQuery`. Logical spacing. Mobile vs desktop composition.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Examine the installed `@rocket.chat/fuselage-hooks` export and breakpoint schema.
+
+## Flow
+
+1. **Replace media query px.** Any `@media (min-width: 768px)` or hardcoded breakpoint becomes `useBreakpoints()` or `useMediaQuery()`. Read the hook signature from the installed package. Never hardcode breakpoint values.
+
+2. **useBreakpoints hook.** Returns an object with boolean flags for each breakpoint (xs, sm, md, lg, xl). Use it to conditionally render or apply Box props. Example: `const { lg } = useBreakpoints(); return <Box p={lg ? 'x24' : 'x16'}>...</Box>`.
+
+3. **useMediaQuery hook.** For custom media queries that don't fit standard breakpoints (e.g., aspect ratio, pointer-hover). Pass a media query string; get a boolean.
+
+4. **Responsive Box props.** Box accepts responsive arrays on certain props (p, m, gap, etc.). Use them instead of nested ternaries. Confirm syntax from the installed types.
+
+5. **usePrefersReducedMotion.** If the design has motion (e.g., slide-in, fade, spin), honor `usePrefersReducedMotion()` and skip or soften the animation. Respect user preferences.
+
+6. **Logical spacing.** Use `pi`, `pb`, `mi`, `mb` (inline and block) instead of `paddingLeft`, `marginRight`. This makes layouts RTL-safe automatically.
+
+7. **Mobile vs desktop composition.** Sidebar menu becomes a hamburger menu on mobile (use `useBreakpoints()` to show/hide). List becomes a card grid on desktop. Confirm the layout shift with the design.
+
+## Output
+
+Responsive behavior driven entirely by hooks and token names. No literal media query syntax. No hardcoded breakpoint px. Layouts adapt smoothly.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs <target>`. Type gate and lint gate must pass. Warnings OK. Confirm no literal media queries remain. Done when green.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs hooks breakpoints`. This pass drives responsive behavior through hooks (illustrative: useBreakpoints for breakpoint flags, useMediaQuery for custom queries, usePrefersReducedMotion for motion preferences), Box responsive props, logical spacing, and semantic color tokens.

--- a/skills/fuselage-craft/reference/audit.md
+++ b/skills/fuselage-craft/reference/audit.md
@@ -1,0 +1,69 @@
+# Audit (Evaluate)
+
+Flagship conformance command. Runs the mechanical gate, then a judgment pass. Reports drift; makes no edits unless explicitly asked.
+
+## Inherit first
+
+- Load the SKILL.md law layer before doing anything else.
+- Read the consumer's `package.json` and lockfile; confirm the installed `@rocket.chat/fuselage*` version. State it.
+- Resolve every component, prop, and token reference from the installed package (`node_modules/@rocket.chat/fuselage*` types, token JSON, exports). Never use memory.
+
+## Flow
+
+1. **Setup.** Confirm installed Fuselage version. Resolve the target globs or paths to audit.
+
+2. **Mechanical pass.** Run the gate:
+   ```
+   node skills/fuselage-craft/gate/run-gate.mjs <target>
+   ```
+   Capture all output. Two categories:
+
+   - **Lint drift** (rules: `no-raw-color`, `no-literal-dimension`, `no-literal-shadow`, `require-field-wrapper` [error], `prefer-box` [warn]):
+     - Literal color values in product code (hex, rgb, hsl, named CSS colors)
+     - Literal dimension values (px, rem, em used directly for spacing, font-size, border-radius, box-shadow)
+     - Inputs not wrapped in a `Field` / `FieldLabel` / `FieldRow` structure
+     - Raw styled DOM where a Fuselage component ships (`<button>`, `<div>` standing in for `<Button>`, `<Modal>`, etc.)
+     - Inline `style=` props carrying design values
+
+   - **Type drift** (tsc `--noEmit` against installed Fuselage types):
+     - `fontScale=` value not in the installed union (typo, stale name, invented value)
+     - Nonexistent component imported from `@rocket.chat/fuselage*`
+     - `color=` or `bg=` token name not in the installed type
+     - `Button` used with a `variant=` string prop instead of boolean flags (`primary`, `secondary`, `danger`, `success`, `warning`)
+     - Any other JSX prop that fails the installed type contract
+
+3. **Judgment pass.** What the gate cannot see -- requires reading the code and context:
+
+   - **Wrong component choice.** Hand-rolled component where Fuselage ships one (e.g. a custom alert where `Callout` exists). Resolve the full component set with `resolve.mjs components` rather than recalling it.
+   - **Weak hierarchy.** `fontScale` used in a way that inverts or collapses visual hierarchy (e.g., body text set to `h1`, labels set to `hero`).
+   - **Color-only state.** State (error, selected, disabled, active) communicated by color alone with no icon, weight, or text reinforcement.
+   - **Missing states.** Loading path lacks `Throbber`; error path lacks `Callout` or `FieldError`; empty path has no empty-state treatment.
+   - **A11y gaps beyond Field.** Interactive elements missing accessible labels, focus management absent from modals or overlays, non-descriptive link/button text.
+   - **Repeated composition.** The same multi-component pattern appears 3+ times and should be extracted into one shared component.
+   - **Multiple primary actions.** More than one `<Button primary>` in the same view or modal, creating competing calls to action.
+
+4. **Report.** Structured output in three sections:
+
+   - **Section A -- Drift (mechanical).** Every gate finding, grouped by rule. Each entry: `file:line`, rule name, offending code snippet. Errors and warnings separated.
+   - **Section B -- Judgment findings.** Each finding: severity (`high` / `med` / `low`), description, file reference, and the correct Fuselage pattern to replace it.
+   - **Section C -- Prioritized fix list.** Ordered by severity. For each item, include the appropriate command to hand off to: `migrate` for raw-CSS / literal-value blocks, `polish` for missing states and empty-state gaps, `harden` for a11y and edge cases, `adapt` for literal breakpoints or media queries.
+
+5. **Conformance summary line.** End the report with a single line, e.g.:
+   ```
+   Fuselage @X.Y.Z | literal values: N | type errors: N | missing Field: N | judgment findings: N (H high, M med, L low)
+   ```
+
+## Output
+
+A structured conformance report (Sections A, B, C) plus the conformance summary line. No code changes. After the report, offer to:
+- Fix all mechanical (Section A) drift -- hand off to `migrate`
+- Fix state completeness gaps -- hand off to `polish`
+- Hand the full report to the user for triage
+
+## Close with the gate
+
+Audit IS the mechanical gate pass. Step 2 runs `run-gate.mjs` as its primary instrument. There is no separate "close with gate" step: the gate output becomes Section A of the report, and the exit code (nonzero on lint errors or tsc failure) is the conformance verdict. Audit makes no edits; it does not need to re-run the gate at the end.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live, do not recall it: `node skills/fuselage-craft/resolve.mjs all`. The type gate validates anything type-only (elevation, radius, spacing). Examples below are illustrative, not a catalog. This command reasons about Box (color, bg, fontScale, spacing, elevation props), Button (variants, sizes, states), Field family for form structure, Callout, Throbber, and hooks like useBreakpoints for responsive detection.

--- a/skills/fuselage-craft/reference/clarify.md
+++ b/skills/fuselage-craft/reference/clarify.md
@@ -1,0 +1,35 @@
+# clarify (Fix)
+
+UX copy: labels, button text, error messages, helper text, empty-state copy, tooltips. Voice is plain, exact, i18n-friendly. Changes only strings, never Fuselage design values.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Identify all user-facing strings in the feature.
+
+## Flow
+
+1. **Labels.** Input labels (via `FieldLabel`) are noun phrases or short instructions, not marketing. "Name" not "Please enter your name here". "Phone" not "What's your phone number?". Consistent across the product.
+
+2. **Button text.** Action buttons start with a verb ("Save", "Delete", "Invite", "Send"). Secondary buttons are smaller verbs ("Cancel", "Close") or neutral ("More"). Danger buttons are explicit ("Delete forever", not just "Delete"). Loading state shows "Saving...", "Sending...", not the original verb.
+
+3. **Error messages.** Via `FieldError`. Specific, actionable, plain language. "Email already in use" not "Invalid input". "Password must be at least 8 characters" not "Requirement not met". Users understand what went wrong and how to fix it.
+
+4. **Helper text.** Via `FieldHint` or `FieldDescription`. Short, clarifying, optional detail. "At least 8 characters" below a password field. "Used for login notifications" below an email field.
+
+5. **Empty states.** User-facing message when there is nothing to show. "No conversations yet. Create one to get started." not "No data". Pair with an icon or illustration.
+
+6. **Consistency.** Do not mix "Save" and "Submit" in the same product. Do not say "Please" in some places and not others. Build a glossary if the product is large.
+
+7. **Internationalization.** No concatenated strings ("Hello " + name). Use proper i18n keys and interpolation. Numbers, dates: respect locale (use `Intl.NumberFormat`, `Intl.DateTimeFormat`). Do not hardcode "January", "Monday", locale-specific text.
+
+## Output
+
+String changes only. No CSS, no component restructure, no design value changes. All changes are purely textual and localization-friendly.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs <target>`. Type gate (tsc) and lint gate must pass. Warnings OK. Confirm no unintended code drift occurred. Done when green.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs forms components`. This pass changes only text. Components involved: FieldLabel, FieldHint (illustrative examples of form text), FieldError, Callout, Button text, and semantic copy patterns for empty and error states.

--- a/skills/fuselage-craft/reference/craft.md
+++ b/skills/fuselage-craft/reference/craft.md
@@ -1,0 +1,42 @@
+# craft (Build)
+
+Build a feature end to end under the laws. Shape first, then code using Fuselage components. Cover all states.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Resolve every component, prop, and token from the package.
+
+## Flow
+
+1. **Shape or load.** Run shape first (or load an existing shape plan). Confirm the component tree, token strategy, state coverage, and a11y approach with the user. Do not skip this. Shape is the contract.
+
+2. **Build the component tree.** Use Fuselage components first: Button, Field/FieldLabel/FieldRow/FieldError, Callout, Modal, Tabs, Table, Avatar, Tile, Throbber. Never hand-roll a button, label, error message, or modal. Then Box with semantic props. Never raw HTML.
+
+3. **Apply tokens.** Every design value comes from the installed package as a token name, never a literal hex/px/size:
+   - Colors: `color=` / `bg=` with semantic names (font-default, surface-tint, stroke-light, status-background-danger, etc.).
+   - Spacing: `p` / `m` / `pi` / `pb` / `mi` / `mb` on x* scale only (x4, x8, x12, x16, x24, x32).
+   - Type: `fontScale=` name (h1, h2, h3, h4, h5, p1, p1m, p1b, p2, c1, c2, micro).
+   - Shadows: `elevation=` name (0, 1, 2) not literal `box-shadow`.
+   - Corners: `borderRadius=` name (small, medium, large, extra-large, full) not px.
+
+4. **Cover all states.** Implement loading (Button `loading`, `Throbber`, or state machine). Implement empty (custom UI with icon and copy, or `Callout`). Implement error (`Callout` or `FieldError` on inputs). Implement disabled (component `disabled` prop). Implement success (check icon, `Callout type='success'`). Nothing silently disappears.
+
+5. **Responsive via hooks.** Use `useBreakpoints()` or `useMediaQuery()` for adaptive layouts. No hardcoded media query px. Honor `usePrefersReducedMotion()` for animation.
+
+6. **Accessibility wired.** Inputs inside `Field` + `FieldLabel`. Labels have clear `htmlFor`. Focus order is logical. Keyboard shortcuts (Tab, Enter, Escape) work. Error messages are crisp (`FieldError`). Icons have `aria-label`. Test with a screen reader briefly.
+
+7. **Resolve from the package.** If a prop or token is not in the installed types, STOP. Do not invent it. Surface as a blocker - the extension belongs in the Fuselage repo, not product code.
+
+8. **Dark mode and themes.** All colors are semantic tokens that resolve correctly across light, dark, and high-contrast themes. The code has no conditional logic for theming (no "if dark mode then use this hex"). The tokens handle it.
+
+## Output
+
+A complete, state-rich feature built entirely with Fuselage components and token references. Code passes the type gate and lint gate. Feature is production-ready.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs <target>`. Type gate (`tsc --noEmit`) must pass (no type errors). Lint gate must pass (no raw hex, no literal px, no hand-rolled components, no missing Field wrappers). Warnings are OK; errors stop the build. Repeat until green. Then deploy.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs all`. Type gate is authoritative for spacing, elevation, radius. This build uses Box for layout, Button for actions (illustrative: primary, secondary, danger variants), Field family for form structure, Callout for messages, Throbber for loading, and containers like Modal, Tabs, Table. Responsive behavior via hooks (illustrative: useBreakpoints, useMediaQuery, usePrefersReducedMotion). Semantic tokens (resolve the full set with resolve.mjs) for color, spacing on x* scale, fontScale, elevation, and borderRadius.

--- a/skills/fuselage-craft/reference/critique.md
+++ b/skills/fuselage-craft/reference/critique.md
@@ -1,0 +1,40 @@
+# critique (Evaluate)
+
+UX design review via heuristics. Does not write code or run the gate. Produce findings and recommendations grounded in Fuselage components and tokens.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Understand the feature intent and user flow.
+
+## Flow
+
+1. **Visual hierarchy.** Are the most important actions most prominent? Is `fontScale=` used correctly (h1 for page title, h3 for sections, p1/p2 for body)? Do color tokens distinguish primary from secondary? Check against Fuselage stories to confirm the idiom.
+
+2. **Cognitive load.** Is the page overwhelming? Too many options, too much text, confusing grouping? Suggest consolidation, progressive disclosure via Tabs or Modal, or clearer affordances via icon + label on Buttons.
+
+3. **Information architecture.** Can a user understand what to do first? Is the call-to-action clear? Use Fuselage components to re-order: primary `<Button primary>` at eye level, secondary actions smaller or in a Sidebar menu, less common options in an overflow menu.
+
+4. **Affordances.** Do interactive elements look clickable? Are disabled states visually different (use `<Button disabled>`; gray, not color-only)? Do inputs have clear labels (`FieldLabel`) and hints (`FieldHint`)?
+
+5. **Consistency with Fuselage.** Are you using Fuselage components (Button, Field, Callout, Modal, Tabs, etc.) or hand-rolling? Hand-rolled means potential for drift and inconsistency. Recommend using the system component.
+
+6. **Accessibility posture.** Are labels paired with inputs (via `Field`)? Can keyboard users navigate (Tab, Enter, arrow keys work)? Are error messages clear (`FieldError`)? Does the design reduce motion where possible (honor `usePrefersReducedMotion`)?
+
+## Output
+
+Scored findings:
+- HIGH: blocks shipping (e.g., no error state, disabled state is invisible, no labels on inputs)
+- MED: polish opportunity (e.g., hierarchy weak, spacing off, cognitive load high)
+- LOW: nice-to-have (e.g., could add icon to button, could improve loading feedback)
+
+Each finding includes a recommendation that cites the Fuselage component or token by name. For example: "Use `<Callout type='danger'>` instead of a red alert box." or "Apply `fontScale='h2'` to section headers to strengthen hierarchy."
+
+Optionally recommend running polish, harden, migrate, or clarify afterward depending on what you found.
+
+## No code, no gate
+
+This command writes nothing and runs no gate. Hand off findings to the product team or to craft/polish/harden for implementation.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs components semantic fontscale`. This review reasons about Button for action hierarchy (illustrative: primary, secondary, danger), Field family for label pairing, Callout for alerts, Modal and Tabs for structure, fontScale for hierarchy, semantic color tokens, and hooks like useBreakpoints for responsiveness.

--- a/skills/fuselage-craft/reference/harden.md
+++ b/skills/fuselage-craft/reference/harden.md
@@ -1,0 +1,33 @@
+# harden (Refine)
+
+Production-readiness. Cover edge cases, i18n, RTL, error paths, all through Fuselage. No hand-rolled fallbacks or shortcuts.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Resolve every component/prop/token from the installed package, never memory.
+
+## Flow
+
+1. **Edge cases.** Long text (truncate with `Box` or Typography component wrapping, not hard `max-width`). Zero items (show empty state with `Callout` or well-formed empty placeholder). Many items (pagination or virtualization). Overflow (clip or scroll via logical Box props, never hardcoded values).
+
+2. **Internationalization.** No concatenated strings. Use proper i18n keys. Numbers, dates, currency: use `Intl` or the app's i18n library. No hardcoded locale assumptions. Test with RTL locale (Arabic, Hebrew) to catch right-to-left regressions.
+
+3. **Logical spacing (RTL-safe).** Use `pi` (padding-inline-start), `pb` (padding-block-start), `mi` (margin-inline-start), `mb` (margin-block-start). Never `paddingLeft`, `marginRight`, or literal left/right. The layout flips automatically in RTL.
+
+4. **Error and disabled paths.** Every input, button, field has an error state (via `FieldError`), a disabled state, and a loading state. Test them. Error messages are specific and actionable.
+
+5. **Failure and empty states.** Network errors, permission denied, no results: show `Callout` or custom empty state. Never silently hide content or show a blank screen.
+
+6. **Accessibility.** Keyboard navigation (Tab, Enter, arrow keys, Escape) works. Focus order is logical. All labels use `FieldLabel` paired with inputs in `Field`. Honor `usePrefersReducedMotion` (no auto-play, no flashing, no parallax). Test with a screen reader (even a quick scan).
+
+## Output
+
+Hardening passes make the feature robust. It survives edge cases, works globally, is accessible, and degrades gracefully when things break.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs <target>`. Type gate and lint gate must pass. Warnings OK. Done when green.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs components forms hooks semantic`. The type gate is authoritative. This pass hardens through Field family for a11y, Callout for edge-case messages, hooks like useBreakpoints and usePrefersReducedMotion for responsive and preference-aware behavior, logical spacing, and semantic color tokens.

--- a/skills/fuselage-craft/reference/migrate.md
+++ b/skills/fuselage-craft/reference/migrate.md
@@ -29,7 +29,7 @@ Convert legacy or non-Fuselage UI into Fuselage components and token references.
    | Field layout | Field + FieldLabel + FieldRow + FieldError | Form field role |
    | Spacing | `p=` / `m=` on x* scale | Layout intent |
    | Text style | `fontScale=` | Typographic role |
-   | Color | `color=` or `bg=` semantic token name | Color role, not hex match |
+   | Color | `color=` bare font name (e.g. `default`, `danger`) / `bg=` surface name (e.g. `surface-tint` or bare `tint`) / `borderColor=` bare stroke name (e.g. `error`, `light`); resolve live via `resolve.mjs semantic` | Color role, not hex match |
    | Shadow | `elevation=` | Depth role |
    | Media query | `useBreakpoints` or `useMediaQuery` | Responsive intent |
 

--- a/skills/fuselage-craft/reference/migrate.md
+++ b/skills/fuselage-craft/reference/migrate.md
@@ -1,0 +1,54 @@
+# Migrate (Fix)
+
+Convert legacy or non-Fuselage UI into Fuselage components and token references. Map by role and intent, never by matching literal values to tokens.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Resolve every component, prop, and token from the installed package, never memory.
+
+## Flow
+
+1. **Setup.** Confirm the installed package version. Scope the target: file, directory, or component. Read the SKILL.md law layer in full before touching any code.
+
+2. **Inventory the legacy surface.** Catalogue every violation in scope:
+   - styled-components or emotion blocks
+   - `style={{}}` inline style objects
+   - CSS modules and SCSS files
+   - Raw `<button>`, `<input>`, `<select>`, `<label>` elements
+   - Hand-rolled label+input field layouts
+   - Literal media queries (`@media (max-width: ...)`)
+   - Literal hex colors, px dimensions, box-shadow values
+
+3. **Map each finding to Fuselage by role.** Build a mapping table before writing any code:
+
+   | Legacy construct | Fuselage replacement | Mapped by |
+   |---|---|---|
+   | Raw element | Fuselage component or Box | Role/function |
+   | Primary action | `<Button primary>` | It IS the primary action |
+   | Destructive action | `<Button danger>` | It IS destructive |
+   | Field layout | Field + FieldLabel + FieldRow + FieldError | Form field role |
+   | Spacing | `p=` / `m=` on x* scale | Layout intent |
+   | Text style | `fontScale=` | Typographic role |
+   | Color | `color=` or `bg=` semantic token name | Color role, not hex match |
+   | Shadow | `elevation=` | Depth role |
+   | Media query | `useBreakpoints` or `useMediaQuery` | Responsive intent |
+
+   THE CARDINAL RULE: a legacy `#156FF5` primary button becomes `<Button primary>` because it IS the primary action, not because some token resolves to that hex. Never reverse-engineer a token from a color value. If the role is ambiguous, STOP and ask the user.
+
+4. **Rewrite incrementally.** One component or block at a time. Preserve all behavior, event handlers, and prop interfaces. Prefer the named Fuselage component; fall back to Box with semantic props; never use raw styled DOM elements.
+
+5. **No Fuselage equivalent.** If a construct has no counterpart in the installed package, STOP. Surface it as a blocker. Propose the Fuselage extension path (authoring lane) rather than hand-rolling a one-off implementation.
+
+6. **Gate.** Run the gate and iterate until both lint and type checks pass.
+
+## Output
+
+Migrated source files plus a migration summary table listing every legacy construct mapped to its Fuselage component or token, annotated with the role that drove the decision.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs [globs]` against all modified files. Fix every lint error (no-raw-color, no-literal-dimension, no-literal-shadow, require-field-wrapper, prefer-box) and every TypeScript error from `tsc --noEmit`. Warnings do not fail the gate; errors do. Do not mark migration complete until the gate exits zero.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs semantic components forms hooks fontscale`. The type gate validates anything type-only. This lane relies on Box for styling, Button for actions (illustrative variants: primary, secondary, danger), Field family for form structure, Callout for messages, and hooks like useBreakpoints for responsive composition.

--- a/skills/fuselage-craft/reference/polish.md
+++ b/skills/fuselage-craft/reference/polish.md
@@ -1,0 +1,33 @@
+# polish (Refine)
+
+Final quality pass before shipping. Complete all states, tighten spacing rhythm, verify hierarchy, ensure consistent elevation. Introduce no new literal values.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Resolve every component/prop/token from the installed package, never memory.
+
+## Flow
+
+1. **States.** For every interactive element, add: loading state (`Button loading` or `Throbber`); empty state with contextual copy; error state (`Callout` or `FieldError` for inputs); disabled state; hover and focus-visible. Nothing should disappear or become broken when in a non-happy-path state.
+
+2. **Spacing rhythm.** Walk the layout and verify all padding, margin, gap use the `x*` scale (x4, x8, x12, x16, x24, x32). Tighten any jagged gaps. Use logical props: `pi`, `pb`, `mi`, `mb` (never left/right/top/bottom). No literal px anywhere.
+
+3. **Type hierarchy.** Check `fontScale=` names match weight and context: h1/h2/h3 for headers, p1/p2 for body, micro for footnotes. Use the Fuselage stories to confirm the idiom.
+
+4. **Elevation.** Hover and focus states often use `elevation='1'` or `elevation='2'`. Modal, popover, dropdown: confirm they use the right elevation depth. No literal box-shadow.
+
+5. **Icon and color pairing.** If color conveys state (danger red), pair it with an icon or text. Never state-by-color-alone.
+
+6. **Dark mode and themes.** Render in light, dark, and high-contrast. All colors must be semantic token names (`font-default`, `surface-tint`, `stroke-error`); the design system resolves them correctly.
+
+## Output
+
+Polish passes are zero-breaking refines. The feature is already functional; now it is complete and shipworthy.
+
+## Close with the gate
+
+Run `node skills/fuselage-craft/gate/run-gate.mjs <target>`. Type gate (tsc) and lint gate must both pass. Warnings are OK; errors are not. Done when green.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs components semantic fontscale spacing elevation radius`. Type gate is authoritative for spacing, elevation, radius. This pass polishes Button states (illustrative: loading, primary, disabled), Throbber, Callout, FieldError, and applies semantic color tokens and spacing rhythm.

--- a/skills/fuselage-craft/reference/polish.md
+++ b/skills/fuselage-craft/reference/polish.md
@@ -18,7 +18,7 @@ Final quality pass before shipping. Complete all states, tighten spacing rhythm,
 
 5. **Icon and color pairing.** If color conveys state (danger red), pair it with an icon or text. Never state-by-color-alone.
 
-6. **Dark mode and themes.** Render in light, dark, and high-contrast. All colors must be semantic token names (`font-default`, `surface-tint`, `stroke-error`); the design system resolves them correctly.
+6. **Dark mode and themes.** Render in light, dark, and high-contrast. All colors must be semantic token names passed as bare prop values: `color='default'`, `bg='surface-tint'` (or bare `bg='tint'`), `borderColor='error'`; the design system resolves them correctly. Never pass `color='font-default'` or `borderColor='stroke-error'` — the Box transforms prepend the prefix, so those forms double-prefix and produce invalid tokens.
 
 ## Output
 

--- a/skills/fuselage-craft/reference/shape.md
+++ b/skills/fuselage-craft/reference/shape.md
@@ -1,0 +1,63 @@
+# shape (Build)
+
+Plan a feature as a Fuselage component composition tree before writing code. No product code written. Confirms with the user before craft builds.
+
+## Inherit first
+
+- Load the SKILL.md law layer. Confirm the installed @rocket.chat/fuselage version. Understand the feature intent, user flow, and context.
+
+## Flow
+
+1. **Decompose the UI.** Sketch the component tree. What is the top-level container (Page, Modal, Sidebar)? What are the child sections? What goes inside each (inputs, buttons, cards, lists)?
+
+2. **Choose Fuselage components.** For each role in the tree, pick the right Fuselage component or Box with semantic props. Button for actions, Field/FieldLabel/FieldRow for inputs, Callout for messages, Tabs for navigation, Modal for overlays, Table for data, Avatar for identity, Tile for cards.
+
+3. **Token and prop plan.** For each component, decide the token names: color scheme (which semantic colors: `font-default`, `surface-tint`, `stroke-light`?). Spacing rhythm (padding/margin on x* scale). Type hierarchy (fontScale names). Elevation (depth via `elevation=`). BorderRadius (small/medium/large).
+
+4. **State coverage.** List all states the feature must support: loading (via `Throbber` or Button `loading`), empty (custom empty state with `Callout` or icon), error (via `Callout` or `FieldError`), disabled (via component prop), success (via `Callout type='success'` or check icon). Do not leave any state blank.
+
+5. **Accessibility approach.** Inputs inside `Field` + `FieldLabel` (never hand-wired labels). Keyboard navigation (Tab, Enter, Escape). Focus order is logical. Reduced motion honored (no auto-play, no flash). Semantic HTML preserved (no `<div role='button'>`).
+
+6. **Responsive strategy.** Which sections change layout on mobile vs desktop? (Sidebar becomes hamburger menu? List becomes card grid?) Which props respond to breakpoints (padding, font size, grid columns)? Use `useBreakpoints` / `useMediaQuery`.
+
+7. **Open questions.** Anything missing from Fuselage that the design needs? (New component, new token, new prop?) Surface it as a blocker to be resolved in the Fuselage repo before coding.
+
+## Output
+
+A clear composition plan in text or diagrams. Example:
+
+```
+<Modal>
+  <Box p='x16' bg='surface-light'>
+    <Box fontScale='h2' mb='x16'>Create User</Box>
+    <Field>
+      <FieldLabel>Name</FieldLabel>
+      <FieldRow>
+        <Input placeholder='John Doe' />
+      </FieldRow>
+      <FieldHint>Full name or alias</FieldHint>
+    </Field>
+    <Field>
+      <FieldLabel>Email</FieldLabel>
+      <FieldRow>
+        <Input type='email' />
+      </FieldRow>
+      <FieldError>Invalid email (if error state)</FieldError>
+    </Field>
+    <Box display='flex' mi='x0' gap='x8' mt='x24'>
+      <Button primary>Save</Button>
+      <Button secondary>Cancel</Button>
+    </Box>
+  </Box>
+</Modal>
+```
+
+Include state variations (loading, error, empty) and responsive notes.
+
+## No code, no gate. Hand off to craft.
+
+This command produces a design plan, not product code. When the user confirms the shape, move to craft to build it under the laws.
+
+## Fuselage specifics
+
+Resolve the current vocabulary live: `node skills/fuselage-craft/resolve.mjs all`. Type gate is authoritative for spacing, elevation, radius. This plan uses Box for layout, Button for actions, Field family for inputs, Callout for messages, Modal/Tabs/Table for structure, Avatar/Tile for cards, Throbber for loading, hooks like useBreakpoints, and semantic tokens for color, spacing, type, depth, and corners.

--- a/skills/fuselage-craft/resolve.mjs
+++ b/skills/fuselage-craft/resolve.mjs
@@ -11,7 +11,7 @@
  *   node skills/fuselage-craft/resolve.mjs [category] [--json]
  *
  * Categories: colors, semantic, fontscale, breakpoints, spacing,
- *             elevation, radius, components, forms, hooks, all (default)
+ *             elevation, radius, components, forms, inputs, hooks, all (default)
  *
  * Exports: resolveCategory(category), resolveAll()
  */
@@ -373,7 +373,12 @@ async function resolveColors() {
     'colors.js',
   ]);
   if (hit && Object.keys(hit.value).length > 0) {
-    return { status: 'ok', source: hit.source, data: Object.keys(hit.value) };
+    return {
+      status: 'ok',
+      source: hit.source,
+      warning: '⚠ RAW PALETTE — internal theme values, NOT valid color=/bg= prop values. For product code use the `semantic` category instead.',
+      data: Object.keys(hit.value),
+    };
   }
   return {
     status: 'unavailable',
@@ -451,7 +456,62 @@ async function resolveBreakpoints() {
  * Each sub-object (surfaceColors, textIconColors, ...) is also exported directly.
  * We read the Palette object's type properties, and for each, extract the
  * keys of the corresponding sub-object type.
+ *
+ * Post-processes group keys to strip internal prefixes so the resolver emits
+ * the prop-facing bare value, not the internal token key:
+ *   text (font-*)        → color=  bare name   (transform prepends font-)
+ *   surface (surface-*)  → bg=     bare OR full (transform prepends surface-)
+ *   stroke (stroke-*)    → borderColor= bare    (transform prepends stroke-)
  */
+
+/**
+ * Per-group metadata: which CSS prop accepts these tokens, which prefix does
+ * the Box transform prepend (so we know what to strip), and notes for the user.
+ */
+const SEMANTIC_GROUP_META = {
+  text: {
+    prop: 'color=',
+    prefix: 'font-',
+    note: 'bare name only; Box color= prepends font-',
+  },
+  surface: {
+    prop: 'bg= / backgroundColor=',
+    prefix: 'surface-',
+    note: 'bare OR full surface-* name; Box bg= prepends surface- but also accepts full form',
+  },
+  stroke: {
+    prop: 'borderColor=',
+    prefix: 'stroke-',
+    note: 'bare name only; Box borderColor= prepends stroke-',
+  },
+  // status / statusColor / badge: used bare; leave keys as-is
+};
+
+/**
+ * Strip an expected prefix from a token key. If the key doesn't start with
+ * the prefix, return the key unchanged (resilient — don't crash on unexpected data).
+ */
+function stripPrefix(key, prefix) {
+  if (prefix && key.startsWith(prefix)) return key.slice(prefix.length);
+  return key;
+}
+
+/**
+ * Post-process the raw groups object returned from type extraction.
+ * Returns an array of { groupName, meta, keys } where keys are prop-facing values.
+ */
+function postProcessSemanticGroups(rawGroups) {
+  return Object.entries(rawGroups).map(([groupName, keys]) => {
+    const meta = SEMANTIC_GROUP_META[groupName];
+    if (!meta) {
+      // No special handling — pass through as-is
+      return { groupName, meta: null, keys };
+    }
+    const strippedKeys = keys.map((k) => stripPrefix(k, meta.prefix));
+    return { groupName, meta, keys: strippedKeys };
+  });
+}
+
 async function resolveSemantic() {
   const ts = loadTypeScript();
   if (!ts) return TS_DEGRADED;
@@ -483,20 +543,19 @@ async function resolveSemantic() {
   if (paletteSym) {
     const paletteType = checker.getTypeOfSymbol(paletteSym);
     const groupProps = checker.getPropertiesOfType(paletteType);
-    const groups = {};
+    const rawGroups = {};
     for (const groupProp of groupProps) {
       const groupName = groupProp.getName();
       const groupType = checker.getTypeOfSymbol(groupProp);
       const colorProps = checker.getPropertiesOfType(groupType);
-      const keys = colorProps.map((p) => p.getName()).filter((k) => k.startsWith(groupName.replace('Color', '')) || k.length > 0);
       // Filter to only string keys that look like semantic color names (contain '-')
       const colorKeys = colorProps
         .map((p) => p.getName())
         .filter((k) => typeof k === 'string' && k.includes('-'));
-      if (colorKeys.length > 0) groups[groupName] = colorKeys;
+      if (colorKeys.length > 0) rawGroups[groupName] = colorKeys;
     }
-    if (Object.keys(groups).length > 0) {
-      return { status: 'ok', source: entry.source, data: groups };
+    if (Object.keys(rawGroups).length > 0) {
+      return { status: 'ok', source: entry.source, data: postProcessSemanticGroups(rawGroups) };
     }
   }
 
@@ -512,16 +571,16 @@ async function resolveSemantic() {
     ['shadowColors', 'shadow'],
   ];
 
-  const groups = {};
+  const rawGroups = {};
   for (const [exportName, groupKey] of subObjectMap) {
     const sym = exports.find((s) => s.getName() === exportName);
     if (!sym) continue;
     const keys = extractObjectKeys(ts, checker, sym);
-    if (keys.length > 0) groups[groupKey] = keys;
+    if (keys.length > 0) rawGroups[groupKey] = keys;
   }
 
-  if (Object.keys(groups).length > 0) {
-    return { status: 'ok', source: entry.source, data: groups };
+  if (Object.keys(rawGroups).length > 0) {
+    return { status: 'ok', source: entry.source, data: postProcessSemanticGroups(rawGroups) };
   }
 
   return {
@@ -640,15 +699,139 @@ async function resolveComponents() {
   };
 }
 
-async function resolveForms() {
+/**
+ * Collect the raw source text of the source FILES where a symbol is declared.
+ * For symbols re-exported via barrel index (Alias flags), resolves to the
+ * underlying symbol's declarations first.
+ *
+ * WHY full source file text (not just declaration node text):
+ * Function-form components have a short declaration node:
+ *   export declare function AutoComplete(props: AutoCompleteProps): ReactElement;
+ * The props type (AutoCompleteProps with value?: and onChange:) is a type alias
+ * defined earlier in the SAME file, but not part of the function declaration
+ * node's AST text. Reading the full source file captures these local type
+ * definitions and gives accurate structural signals.
+ *
+ * This approach reads the type as WRITTEN in the .d.ts, not the resolved/flattened
+ * type — preserving the distinction the type system loses after flattening:
+ *   AllHTMLAttributes<HTMLInputElement> → explicit form element → input signal
+ *   AllHTMLAttributes<HTMLElement>      → generic Box base → NOT an input signal
+ */
+function getSourceFileTexts(ts, checker, sym) {
+  const texts = [];
+  try {
+    // Resolve aliases so we get the source file declaration, not the re-export
+    let effective = sym;
+    if (sym.getFlags() & ts.SymbolFlags.Alias) {
+      try { effective = checker.getAliasedSymbol(sym); } catch { /* keep original */ }
+    }
+    const decls = effective.getDeclarations?.() ?? [];
+    const seenFiles = new Set();
+    for (const d of decls) {
+      try {
+        const sf = d.getSourceFile();
+        const fileName = sf.fileName;
+        if (!seenFiles.has(fileName)) {
+          seenFiles.add(fileName);
+          texts.push(sf.getText());
+        }
+      } catch { /* skip unreadable */ }
+    }
+  } catch {
+    // defensive — return empty
+  }
+  return texts;
+}
+
+/**
+ * Classify whether a component export is an INPUT primitive using structural
+ * analysis of its raw declaration text (the .d.ts source).
+ *
+ * This approach reads the type as WRITTEN in the .d.ts, not the resolved/flattened
+ * type. This preserves the distinction the type system loses:
+ *   - AllHTMLAttributes<HTMLInputElement> → explicitly named form element → input
+ *   - AllHTMLAttributes<HTMLElement>      → generic Box base → NOT an input signal
+ *   - RefAttributes<HTMLInputElement>     → input ref type  → input signal
+ *   - value?: Key; onChange?: (k) => any → explicit value contract → input
+ *
+ * SIGNAL A: any declaration text contains HTMLInputElement, HTMLSelectElement,
+ *   or HTMLTextAreaElement (covers CheckBox, RadioButton, ToggleSwitch, TextInput,
+ *   NumberInput, PasswordInput, TelephoneInput, MultiSelect, SelectFiltered,
+ *   SelectLegacy, TextAreaInput, AutoComplete via AllHTMLAttributes<HTMLInputElement>
+ *   or RefAttributes<HTMLInputElement> appearing in the .d.ts).
+ *
+ * SIGNAL B: any declaration text contains BOTH an explicit value property pattern
+ *   (value?: or value:) AND an explicit onChange property pattern (onChange?: or
+ *   onChange:) spelled out in the type literal — NOT through AllHTMLAttributes
+ *   inheritance which writes AllHTMLAttributes<HTMLElement> not value?: directly.
+ *   Catches modern Select and Slider where these props appear in the type body.
+ *
+ * SIGNAL C (InputBox fingerprint): the source text contains `placeholderVisible`.
+ *   This prop is unique to InputBox-derived controls (EmailInput, SelectInput,
+ *   NumberInput, PasswordInput, TelephoneInput, TextInput, TextAreaInput, etc.)
+ *   and is absent from every non-input (Button, Card, Accordion, Banner, Badge,
+ *   Box, Chip, Tabs, …). Catches EmailInput and SelectInput whose ref type is
+ *   RefAttributes<HTMLElement> (generic) so Signal A misses them. SearchInput
+ *   also has this prop but is excluded by the name.startsWith('Search') rule.
+ *
+ * BUTTON EXCLUSION: text contains HTMLButtonElement or HTMLAnchorElement as
+ *   element references, AND neither Signal A, B, nor C applies → not an input
+ *   (covers Button, IconButton, Chip, and anchor-based interactive components).
+ *
+ * Defensive: any exception → false (exclude rather than crash).
+ */
+function isInputByDeclarationText(declTexts) {
+  try {
+    const combined = declTexts.join('\n');
+
+    // Signal A: form HTML element in declaration text
+    const hasFormElement =
+      combined.includes('HTMLInputElement') ||
+      combined.includes('HTMLSelectElement') ||
+      combined.includes('HTMLTextAreaElement');
+
+    // Signal B: explicit value+onChange contract spelled out in the type literal.
+    // The regex looks for `value?:` or `value:` and `onChange?:` or `onChange:`
+    // as property names (with word boundary before, and optional ? before colon).
+    // This does NOT match:
+    //   - AllHTMLAttributes<HTMLElement> (no explicit value?: in text)
+    //   - type references like SelectProps["value"] (has value but as indexer)
+    // It DOES match:
+    //   - value?: Key; (Select)
+    //   - value: T; (Slider)
+    //   - onChange?: ((key: Key) => any) (Select)
+    //   - onChange: (value: T) => void (Slider, AutoComplete)
+    const hasExplicitValue = /\bvalue\s*\??\s*:/.test(combined);
+    const hasExplicitOnChange = /\bonChange\s*\??\s*:/.test(combined);
+    const hasValueContract = hasExplicitValue && hasExplicitOnChange;
+
+    // Signal C: InputBox-family fingerprint — placeholderVisible is exclusive to
+    // InputBox-derived input controls across the entire fuselage component tree.
+    const hasInputBoxFingerprint = combined.includes('placeholderVisible');
+
+    // Button exclusion: anchor/button element present, no input signal of any kind
+    const hasButtonElement =
+      combined.includes('HTMLButtonElement') ||
+      combined.includes('HTMLAnchorElement');
+    if (hasButtonElement && !hasFormElement && !hasValueContract && !hasInputBoxFingerprint) return false;
+
+    return hasFormElement || hasValueContract || hasInputBoxFingerprint;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveInputs() {
+  // Access the TS program directly — resolveComponents() only returns names,
+  // not the symbols needed for structural analysis.
   const ts = loadTypeScript();
   if (!ts) return TS_DEGRADED;
 
-  const entry = resolveTypesEntry('@rocket.chat/fuselage-forms');
+  const entry = resolveTypesEntry('@rocket.chat/fuselage');
   if (!entry) {
     return {
       status: 'unavailable',
-      reason: '@rocket.chat/fuselage-forms not installed and not in monorepo',
+      reason: '@rocket.chat/fuselage not installed and not in monorepo',
       data: [],
     };
   }
@@ -657,7 +840,7 @@ async function resolveForms() {
   if (!prog) {
     return {
       status: 'unavailable',
-      reason: 'Could not build TypeScript program for @rocket.chat/fuselage-forms',
+      reason: 'Could not build TypeScript program for @rocket.chat/fuselage',
       data: [],
     };
   }
@@ -665,10 +848,38 @@ async function resolveForms() {
   const { checker, sourceFile } = prog;
   const exports = getExportedSymbols(checker, sourceFile);
 
-  const names = exports
-    .filter((s) => /^[A-Z]/.test(s.getName()) && isValueDeclaration(ts, s))
-    .map((s) => s.getName())
-    .sort();
+  const names = [];
+  for (const sym of exports) {
+    const name = sym.getName();
+
+    // Only PascalCase value exports (components, not types or hooks)
+    if (!/^[A-Z]/.test(name)) continue;
+    // Accept value declarations; also accept Alias if the aliased symbol is a value.
+    if (!isValueDeclaration(ts, sym)) {
+      if (!(sym.getFlags() & ts.SymbolFlags.Alias)) continue;
+      let resolved = sym;
+      try { resolved = checker.getAliasedSymbol(sym); } catch { continue; }
+      if (!isValueDeclaration(ts, resolved)) continue;
+    }
+
+    // Name-based EXCLUSIONS (structural naming rules — acceptable constants):
+    if (name.startsWith('Field')) continue;   // wrapper family (FieldLabel, FieldGroup, etc.)
+    if (name.startsWith('Search')) continue;  // self-labeling toolbar affordance
+    if (name.endsWith('Option')) continue;    // dropdown sub-part (SelectOption, etc.)
+    if (name.endsWith('Skeleton')) continue;  // loading placeholder
+    if (name.endsWith('Group')) continue;     // container/group
+    if (name.endsWith('Item')) continue;      // list sub-part
+
+    // Structural classification via raw source file text
+    const sourceTexts = getSourceFileTexts(ts, checker, sym);
+    if (sourceTexts.length === 0) continue; // cannot read source → exclude (defensive)
+
+    if (isInputByDeclarationText(sourceTexts)) {
+      names.push(name);
+    }
+  }
+
+  names.sort();
 
   if (names.length > 0) {
     return { status: 'ok', source: entry.source, data: names };
@@ -676,7 +887,71 @@ async function resolveForms() {
 
   return {
     status: 'unavailable',
-    reason: 'No PascalCase value exports found in @rocket.chat/fuselage-forms types',
+    reason: 'No input-primitive components found via structural type analysis in @rocket.chat/fuselage',
+    data: [],
+  };
+}
+
+async function resolveForms() {
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  // Primary: @rocket.chat/fuselage-forms
+  const formsEntry = resolveTypesEntry('@rocket.chat/fuselage-forms');
+  if (formsEntry) {
+    const prog = getTsProgram(formsEntry.path);
+    if (prog) {
+      const { checker, sourceFile } = prog;
+      const exports = getExportedSymbols(checker, sourceFile);
+
+      const names = exports
+        .filter((s) => /^[A-Z]/.test(s.getName()) && isValueDeclaration(ts, s))
+        .map((s) => s.getName())
+        .sort();
+
+      if (names.length > 0) {
+        return { status: 'ok', source: formsEntry.source, data: names };
+      }
+    }
+  }
+
+  // Fallback: Field* components ship in the main @rocket.chat/fuselage package.
+  // Many of these are re-exported via barrel chains (export * from './Field'), so they
+  // arrive as Alias symbols (SymbolFlags.Alias = 2097152) rather than direct value
+  // declarations. Resolve aliases to their underlying symbol before testing value-ness.
+  const mainEntry = resolveTypesEntry('@rocket.chat/fuselage');
+  if (mainEntry) {
+    const prog = getTsProgram(mainEntry.path);
+    if (prog) {
+      const { checker, sourceFile } = prog;
+      const exports = getExportedSymbols(checker, sourceFile);
+
+      const names = exports
+        .filter((s) => {
+          if (!/^Field/.test(s.getName())) return false;
+          // Resolve alias before testing value-ness
+          let effective = s;
+          if (s.getFlags() & ts.SymbolFlags.Alias) {
+            try { effective = checker.getAliasedSymbol(s); } catch { /* keep original */ }
+          }
+          return isValueDeclaration(ts, effective);
+        })
+        .map((s) => s.getName())
+        .sort();
+
+      if (names.length > 0) {
+        return {
+          status: 'ok',
+          source: 'main package (Field*) — @rocket.chat/fuselage-forms not installed',
+          data: names,
+        };
+      }
+    }
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-forms not installed and Field* not found in @rocket.chat/fuselage',
     data: [],
   };
 }
@@ -742,6 +1017,8 @@ export async function resolveCategory(category) {
       return resolveElevation();
     case 'components':
       return resolveComponents();
+    case 'inputs':
+      return resolveInputs();
     case 'forms':
       return resolveForms();
     case 'hooks':
@@ -749,7 +1026,7 @@ export async function resolveCategory(category) {
     case 'spacing':
       return {
         status: 'rule',
-        data: 'Spacing uses the x<N> scale on a 4px grid (x1=4px, x2=8px, x4=16px, x8=32px, …). Type gate is authoritative for valid spacing tokens.',
+        data: "Spacing uses the x<N> token scale where N is pixels: the Box margin/padding transform matches /^(neg-|-)?x(\\d+)$/ and emits (N/16)rem, so x16=1rem=16px, x24=1.5rem=24px, x4=4px. Negative via neg-x<N>. A bare number prop (e.g. p={24}) emits '24px' — identical to x24. Type gate is authoritative for valid spacing tokens.",
       };
     case 'radius':
       return {
@@ -775,6 +1052,7 @@ export async function resolveAll() {
     'breakpoints',
     'semantic',
     'components',
+    'inputs',
     'forms',
     'hooks',
     'spacing',
@@ -829,6 +1107,7 @@ async function main() {
           'breakpoints',
           'semantic',
           'components',
+          'inputs',
           'forms',
           'hooks',
           'spacing',
@@ -845,10 +1124,23 @@ async function main() {
       process.stdout.write(`  unavailable: ${result.reason}\n`);
     } else if (result.status === 'type-only' || result.status === 'rule') {
       process.stdout.write(`  ${result.data}\n`);
+    } else if (cat === 'colors' && result.status === 'ok') {
+      // Print the drift-trap warning before the raw palette
+      if (result.warning) {
+        process.stdout.write(`  ${result.warning}\n\n`);
+      }
+      for (const name of result.data) {
+        process.stdout.write(`  ${name}\n`);
+      }
     } else if (cat === 'semantic' && result.status === 'ok') {
-      // Grouped output
-      for (const [group, keys] of Object.entries(result.data)) {
-        process.stdout.write(`  [${group}]\n`);
+      // Grouped output with prop-usage headers
+      for (const group of result.data) {
+        const { groupName, meta, keys } = group;
+        if (meta) {
+          process.stdout.write(`  [${groupName} → ${meta.prop}  (${meta.note})]\n`);
+        } else {
+          process.stdout.write(`  [${groupName}]\n`);
+        }
         for (const k of keys) {
           process.stdout.write(`    ${k}\n`);
         }

--- a/skills/fuselage-craft/resolve.mjs
+++ b/skills/fuselage-craft/resolve.mjs
@@ -1,0 +1,623 @@
+#!/usr/bin/env node
+/**
+ * resolve.mjs — live source-of-truth resolver for fuselage-craft.
+ *
+ * Reads @rocket.chat/fuselage* packages at runtime from the consumer's
+ * working directory. Zero Fuselage vocabulary is hardcoded here.
+ *
+ * Usage:
+ *   node skills/fuselage-craft/resolve.mjs [category] [--json]
+ *
+ * Categories: colors, semantic, fontscale, breakpoints, spacing,
+ *             elevation, radius, components, forms, hooks, all (default)
+ *
+ * Exports: resolveCategory(category), resolveAll()
+ */
+
+import { createRequire } from 'module';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve as pathResolve, dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ─── Resolution root ──────────────────────────────────────────────────────────
+
+/**
+ * Build a require() anchored to the consumer's working directory.
+ * Falls back to the skill directory if cwd anchor fails.
+ */
+function makeCwdRequire() {
+  const cwd = process.cwd();
+  try {
+    return createRequire(pathToFileURL(join(cwd, 'package.json')).href);
+  } catch {
+    return createRequire(pathToFileURL(join(cwd, '_anchor.js')).href);
+  }
+}
+
+const cwdRequire = makeCwdRequire();
+
+/**
+ * Read the `version` field from a package's package.json.
+ * Tries require resolution, then monorepo source fallback.
+ */
+function readPackageVersion(pkgName) {
+  // Try resolving via node_modules
+  try {
+    const pkgJson = cwdRequire(`${pkgName}/package.json`);
+    if (pkgJson && pkgJson.version) return pkgJson.version;
+  } catch {
+    // fall through
+  }
+  // Monorepo fallback: look in packages/<short-name>/package.json
+  const shortName = pkgName.replace('@rocket.chat/', '');
+  try {
+    const localPath = pathResolve(process.cwd(), 'packages', shortName, 'package.json');
+    const raw = readFileSync(localPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed.version) return parsed.version + ' (monorepo/src)';
+  } catch {
+    // not in monorepo either
+  }
+  return 'unknown';
+}
+
+/**
+ * Collect resolved versions for the header.
+ */
+function collectVersions() {
+  const packages = [
+    '@rocket.chat/fuselage',
+    '@rocket.chat/fuselage-tokens',
+    '@rocket.chat/fuselage-forms',
+    '@rocket.chat/fuselage-hooks',
+  ];
+  const versions = {};
+  for (const pkg of packages) {
+    versions[pkg] = readPackageVersion(pkg);
+  }
+  return versions;
+}
+
+// ─── Monorepo source-scan helpers ────────────────────────────────────────────
+
+/**
+ * Find the local source directory for a package name.
+ * Returns null if not found (consumer install scenario — normal resolution handles it).
+ */
+function findLocalSrcDir(pkgName) {
+  const shortName = pkgName.replace('@rocket.chat/', '');
+  const candidate = pathResolve(process.cwd(), 'packages', shortName, 'src');
+  try {
+    readdirSync(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract capitalized export names from an index.ts/index.js file via regex.
+ * Pattern: `export * from './Foo'` or `export { Foo, Bar }` or `export const Foo`
+ * Returns array of PascalCase or camelCase names matching the filter fn.
+ */
+function extractExportNamesFromSource(filePath, filterFn) {
+  let src;
+  try {
+    src = readFileSync(filePath, 'utf8');
+  } catch {
+    return null; // file not readable
+  }
+
+  const names = new Set();
+
+  // export * from './FooBar' — the path segment is the component name
+  for (const m of src.matchAll(/export \* from ['"]\.\/([^'"]+)['"]/g)) {
+    const segment = m[1];
+    if (filterFn(segment)) names.add(segment);
+  }
+
+  // export { Foo, Bar, ... } — named exports
+  for (const m of src.matchAll(/export \{([^}]+)\}/g)) {
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().split(/\s+as\s+/).pop().trim();
+      if (filterFn(name)) names.add(name);
+    }
+  }
+
+  // export const Foo / export function Foo / export class Foo
+  for (const m of src.matchAll(/export (?:const|function|class) ([A-Za-z_$][A-Za-z0-9_$]*)/g)) {
+    if (filterFn(m[1])) names.add(m[1]);
+  }
+
+  // export default as Foo
+  for (const m of src.matchAll(/export \{ default as ([A-Za-z_$][A-Za-z0-9_$]*)/g)) {
+    if (filterFn(m[1])) names.add(m[1]);
+  }
+
+  return [...names].sort();
+}
+
+/**
+ * Scan a directory for component subdirectory names (PascalCase directories).
+ */
+function scanComponentDirs(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && /^[A-Z]/.test(d.name))
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract string-keyed tokens from a TypeScript source file.
+ * Finds object literals like: export const fooColors = { 'key-name': ..., ... }
+ * Returns a map of exportName -> string[keys].
+ */
+function extractStringKeysFromThemeSrc(filePath) {
+  let src;
+  try {
+    src = readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  // Palette is assembled from named sub-objects in Theme.ts
+  // Regex: export const Palette = { subKey: varName, ... }
+  const paletteMatch = src.match(/export const Palette\s*=\s*\{([^}]+)\}/);
+  if (!paletteMatch) return null;
+
+  const paletteBody = paletteMatch[1];
+  // Extract { surface: surfaceColors, text: textIconColors, ... }
+  const subObjects = {};
+  for (const m of paletteBody.matchAll(/(\w+)\s*:\s*(\w+)/g)) {
+    subObjects[m[1]] = m[2]; // e.g. surface -> surfaceColors
+  }
+
+  const result = {};
+  for (const [paletteKey, varName] of Object.entries(subObjects)) {
+    // Find the object declaration: export const varName = { 'key': ..., }
+    const re = new RegExp(
+      `export const ${varName}\\s*=\\s*\\{([^}]+)\\}`,
+      's',
+    );
+    const match = src.match(re);
+    if (!match) continue;
+
+    const keys = [];
+    // Match string literal keys: 'key-name' or "key-name"
+    for (const km of match[1].matchAll(/['"]([a-z][a-z0-9-]+)['"]\s*:/g)) {
+      keys.push(km[1]);
+    }
+    if (keys.length > 0) result[paletteKey] = keys;
+  }
+
+  return result;
+}
+
+// ─── Category resolvers ───────────────────────────────────────────────────────
+
+async function resolveColors() {
+  // Try: dynamic import from consumer node_modules first
+  try {
+    const cwdStr = process.cwd();
+    const mod = await import(
+      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/colors.mjs`
+    ).catch(() => null);
+    if (mod && mod.default && Object.keys(mod.default).length > 0) {
+      return { status: 'ok', source: 'node_modules (ESM)', data: Object.keys(mod.default) };
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback: import directly from local path
+  const shortName = 'fuselage-tokens';
+  const localMjs = pathResolve(process.cwd(), 'packages', shortName, 'colors.mjs');
+  try {
+    const mod = await import(pathToFileURL(localMjs).href);
+    if (mod && mod.default && Object.keys(mod.default).length > 0) {
+      return { status: 'ok', source: 'monorepo/src', data: Object.keys(mod.default) };
+    }
+  } catch {
+    // fall through
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-tokens/colors.mjs could not be loaded',
+    data: [],
+  };
+}
+
+async function resolveFontScale() {
+  // Try consumer node_modules first
+  try {
+    const mod = await import(
+      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/typography.mjs`
+    ).catch(() => null);
+    if (mod && mod.default && mod.default.fontScales) {
+      return {
+        status: 'ok',
+        source: 'node_modules (ESM)',
+        data: Object.keys(mod.default.fontScales),
+      };
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback
+  const localMjs = pathResolve(process.cwd(), 'packages', 'fuselage-tokens', 'typography.mjs');
+  try {
+    const mod = await import(pathToFileURL(localMjs).href);
+    if (mod && mod.default && mod.default.fontScales) {
+      return {
+        status: 'ok',
+        source: 'monorepo/src',
+        data: Object.keys(mod.default.fontScales),
+      };
+    }
+  } catch {
+    // fall through
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-tokens/typography.mjs could not be loaded',
+    data: [],
+  };
+}
+
+async function resolveBreakpoints() {
+  // Try consumer node_modules first
+  try {
+    const mod = await import(
+      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/breakpoints.mjs`
+    ).catch(() => null);
+    if (mod && mod.default && Object.keys(mod.default).length > 0) {
+      return {
+        status: 'ok',
+        source: 'node_modules (ESM)',
+        data: Object.keys(mod.default),
+      };
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback
+  const localMjs = pathResolve(
+    process.cwd(),
+    'packages',
+    'fuselage-tokens',
+    'breakpoints.mjs',
+  );
+  try {
+    const mod = await import(pathToFileURL(localMjs).href);
+    if (mod && mod.default && Object.keys(mod.default).length > 0) {
+      return {
+        status: 'ok',
+        source: 'monorepo/src',
+        data: Object.keys(mod.default),
+      };
+    }
+  } catch {
+    // fall through
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-tokens/breakpoints.mjs could not be loaded',
+    data: [],
+  };
+}
+
+async function resolveSemantic() {
+  // Try: dynamic import of built @rocket.chat/fuselage and read Palette
+  try {
+    const mod = await import('@rocket.chat/fuselage').catch(() => null);
+    if (mod && mod.Palette && typeof mod.Palette === 'object') {
+      const groups = {};
+      for (const [group, obj] of Object.entries(mod.Palette)) {
+        if (obj && typeof obj === 'object') {
+          groups[group] = Object.keys(obj);
+        }
+      }
+      if (Object.keys(groups).length > 0) {
+        return { status: 'ok', source: 'node_modules (built Palette)', data: groups };
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback: parse Theme.ts source with regex
+  const localTheme = pathResolve(
+    process.cwd(),
+    'packages',
+    'fuselage',
+    'src',
+    'Theme.ts',
+  );
+  try {
+    const groups = extractStringKeysFromThemeSrc(localTheme);
+    if (groups && Object.keys(groups).length > 0) {
+      return { status: 'ok', source: 'monorepo/src (Theme.ts regex)', data: groups };
+    }
+  } catch {
+    // fall through
+  }
+
+  return {
+    status: 'unavailable',
+    reason:
+      'semantic palette unavailable in this environment (package not built or import side-effects); ' +
+      'semantic color/bg names: resolve via the type gate',
+    data: {},
+  };
+}
+
+async function resolveComponents() {
+  // Try: dynamic import of built @rocket.chat/fuselage
+  try {
+    const mod = await import('@rocket.chat/fuselage').catch(() => null);
+    if (mod) {
+      const names = Object.keys(mod).filter((k) => /^[A-Z]/.test(k));
+      if (names.length > 0) {
+        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback: scan packages/fuselage/src/components/ directories
+  const srcDir = findLocalSrcDir('@rocket.chat/fuselage');
+  if (srcDir) {
+    const componentsDir = join(srcDir, 'components');
+    const dirs = scanComponentDirs(componentsDir);
+    if (dirs && dirs.length > 0) {
+      return { status: 'ok', source: 'monorepo/src (dir scan)', data: dirs };
+    }
+    // Also try scanning the components/index.ts for exports
+    const idxPath = join(componentsDir, 'index.ts');
+    const names = extractExportNamesFromSource(idxPath, (n) => /^[A-Z]/.test(n));
+    if (names && names.length > 0) {
+      return { status: 'ok', source: 'monorepo/src (index.ts scan)', data: names };
+    }
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage could not be loaded and no local src found',
+    data: [],
+  };
+}
+
+async function resolveForms() {
+  // Try: dynamic import of built @rocket.chat/fuselage-forms
+  try {
+    const mod = await import('@rocket.chat/fuselage-forms').catch(() => null);
+    if (mod) {
+      const names = Object.keys(mod).filter((k) => /^[A-Z]/.test(k));
+      if (names.length > 0) {
+        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback: scan leaf source files (not re-export index files, which
+  // produce path-segment false positives like "Inputs" or "WrappedInputComponents").
+  const srcDir = findLocalSrcDir('@rocket.chat/fuselage-forms');
+  if (srcDir) {
+    const namesToCheck = new Set();
+
+    // Leaf files that declare the actual exported component names
+    const leafFiles = [
+      join(srcDir, 'Inputs', 'WrappedInputComponents.ts'),
+      join(srcDir, 'Field', 'index.ts'),
+      join(srcDir, 'Field', 'Label', 'index.ts'),
+    ];
+
+    for (const file of leafFiles) {
+      const names = extractExportNamesFromSource(file, (n) => /^[A-Z]/.test(n));
+      if (names) names.forEach((n) => namesToCheck.add(n));
+    }
+
+    const data = [...namesToCheck].sort();
+    if (data.length > 0) {
+      return { status: 'ok', source: 'monorepo/src (leaf-file scan)', data };
+    }
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-forms could not be loaded and no local src found',
+    data: [],
+  };
+}
+
+async function resolveHooks() {
+  // Try: dynamic import of built @rocket.chat/fuselage-hooks
+  try {
+    const mod = await import('@rocket.chat/fuselage-hooks').catch(() => null);
+    if (mod) {
+      const names = Object.keys(mod).filter((k) => /^use[A-Z]/.test(k));
+      if (names.length > 0) {
+        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  // Monorepo fallback: parse src/index.ts
+  const srcDir = findLocalSrcDir('@rocket.chat/fuselage-hooks');
+  if (srcDir) {
+    const indexPath = join(srcDir, 'index.ts');
+    const names = extractExportNamesFromSource(indexPath, (n) => /^use[A-Z]/.test(n));
+    if (names && names.length > 0) {
+      return { status: 'ok', source: 'monorepo/src (index.ts scan)', data: names };
+    }
+  }
+
+  return {
+    status: 'unavailable',
+    reason: '@rocket.chat/fuselage-hooks could not be loaded and no local src found',
+    data: [],
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a single category.
+ * Returns: { status: 'ok'|'unavailable'|'type-only', source?, reason?, data }
+ */
+export async function resolveCategory(category) {
+  switch (category) {
+    case 'colors':
+      return resolveColors();
+    case 'fontscale':
+      return resolveFontScale();
+    case 'breakpoints':
+      return resolveBreakpoints();
+    case 'semantic':
+      return resolveSemantic();
+    case 'components':
+      return resolveComponents();
+    case 'forms':
+      return resolveForms();
+    case 'hooks':
+      return resolveHooks();
+    case 'spacing':
+      return {
+        status: 'rule',
+        data: 'Spacing uses the x<N> scale on a 4px grid (x1=4px, x2=8px, x4=16px, x8=32px, …). Type gate is authoritative for valid spacing tokens.',
+      };
+    case 'elevation':
+      return {
+        status: 'type-only',
+        data: 'type-only; authoritative validation is the type gate (tsc). Values live in src/components/Box/stylingProps.ts.',
+      };
+    case 'radius':
+      return {
+        status: 'type-only',
+        data: 'type-only; authoritative validation is the type gate (tsc). Values live in src/components/Box/stylingProps.ts.',
+      };
+    default:
+      return { status: 'unavailable', reason: `Unknown category: ${category}`, data: [] };
+  }
+}
+
+/**
+ * Resolve all categories.
+ * Returns: { resolvedFrom, versions, categories: { [cat]: result } }
+ */
+export async function resolveAll() {
+  const resolvedFrom = process.cwd();
+  const versions = collectVersions();
+
+  const categoryNames = [
+    'colors',
+    'fontscale',
+    'breakpoints',
+    'semantic',
+    'components',
+    'forms',
+    'hooks',
+    'spacing',
+    'elevation',
+    'radius',
+  ];
+
+  const categories = {};
+  for (const cat of categoryNames) {
+    categories[cat] = await resolveCategory(cat);
+  }
+
+  return { resolvedFrom, versions, categories };
+}
+
+// ─── CLI entry point ──────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const categoryArg = args.find((a) => !a.startsWith('--')) || 'all';
+
+  if (jsonMode) {
+    const result =
+      categoryArg === 'all'
+        ? await resolveAll()
+        : {
+            resolvedFrom: process.cwd(),
+            versions: collectVersions(),
+            categories: { [categoryArg]: await resolveCategory(categoryArg) },
+          };
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+
+  // Human output
+  const resolvedFrom = process.cwd();
+  const versions = collectVersions();
+
+  process.stdout.write('\n═══ fuselage-craft resolver ══════════════════════════\n');
+  process.stdout.write(`Resolved from: ${resolvedFrom}\n`);
+  process.stdout.write('Package versions:\n');
+  for (const [pkg, ver] of Object.entries(versions)) {
+    process.stdout.write(`  ${pkg}: ${ver}\n`);
+  }
+  process.stdout.write('══════════════════════════════════════════════════════\n\n');
+
+  const cats = categoryArg === 'all'
+    ? ['colors', 'fontscale', 'breakpoints', 'semantic', 'components', 'forms', 'hooks', 'spacing', 'elevation', 'radius']
+    : [categoryArg];
+
+  for (const cat of cats) {
+    const result = await resolveCategory(cat);
+    process.stdout.write(`─── ${cat} (${result.source ?? result.status}) ──────────────────────────\n`);
+
+    if (result.status === 'unavailable') {
+      process.stdout.write(`  unavailable: ${result.reason}\n`);
+    } else if (result.status === 'type-only' || result.status === 'rule') {
+      process.stdout.write(`  ${result.data}\n`);
+    } else if (cat === 'semantic' && result.status === 'ok') {
+      // Grouped output
+      for (const [group, keys] of Object.entries(result.data)) {
+        process.stdout.write(`  [${group}]\n`);
+        for (const k of keys) {
+          process.stdout.write(`    ${k}\n`);
+        }
+      }
+    } else if (Array.isArray(result.data)) {
+      for (const name of result.data) {
+        process.stdout.write(`  ${name}\n`);
+      }
+    }
+
+    process.stdout.write('\n');
+  }
+}
+
+// Run CLI only when invoked directly
+const isMain =
+  process.argv[1] &&
+  (process.argv[1] === __filename ||
+    process.argv[1].endsWith('/resolve.mjs'));
+
+if (isMain) {
+  main().catch((err) => {
+    process.stderr.write(`resolve.mjs error: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/skills/fuselage-craft/resolve.mjs
+++ b/skills/fuselage-craft/resolve.mjs
@@ -2,8 +2,10 @@
 /**
  * resolve.mjs — live source-of-truth resolver for fuselage-craft.
  *
- * Reads @rocket.chat/fuselage* packages at runtime from the consumer's
- * working directory. Zero Fuselage vocabulary is hardcoded here.
+ * Reads @rocket.chat/fuselage* packages from the consumer's working directory.
+ * Uses the TypeScript compiler API against installed .d.ts files (consumer) or
+ * monorepo src/*.ts (in the fuselage monorepo itself). Zero Fuselage vocabulary
+ * is hardcoded here.
  *
  * Usage:
  *   node skills/fuselage-craft/resolve.mjs [category] [--json]
@@ -16,7 +18,7 @@
 
 import { createRequire } from 'module';
 import { pathToFileURL, fileURLToPath } from 'url';
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { resolve as pathResolve, dirname, join } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -24,37 +26,30 @@ const __dirname = dirname(__filename);
 
 // ─── Resolution root ──────────────────────────────────────────────────────────
 
+const cwd = process.cwd();
+
 /**
- * Build a require() anchored to the consumer's working directory.
- * Falls back to the skill directory if cwd anchor fails.
+ * Build a require() anchored to a given directory.
  */
-function makeCwdRequire() {
-  const cwd = process.cwd();
-  try {
-    return createRequire(pathToFileURL(join(cwd, 'package.json')).href);
-  } catch {
-    return createRequire(pathToFileURL(join(cwd, '_anchor.js')).href);
-  }
+function makeRequire(dir) {
+  return createRequire(pathToFileURL(join(dir, 'package.json')).href);
 }
 
-const cwdRequire = makeCwdRequire();
+const cwdRequire = makeRequire(cwd);
 
 /**
  * Read the `version` field from a package's package.json.
- * Tries require resolution, then monorepo source fallback.
  */
 function readPackageVersion(pkgName) {
-  // Try resolving via node_modules
   try {
     const pkgJson = cwdRequire(`${pkgName}/package.json`);
     if (pkgJson && pkgJson.version) return pkgJson.version;
   } catch {
     // fall through
   }
-  // Monorepo fallback: look in packages/<short-name>/package.json
   const shortName = pkgName.replace('@rocket.chat/', '');
   try {
-    const localPath = pathResolve(process.cwd(), 'packages', shortName, 'package.json');
+    const localPath = pathResolve(cwd, 'packages', shortName, 'package.json');
     const raw = readFileSync(localPath, 'utf8');
     const parsed = JSON.parse(raw);
     if (parsed.version) return parsed.version + ' (monorepo/src)';
@@ -81,396 +76,648 @@ function collectVersions() {
   return versions;
 }
 
-// ─── Monorepo source-scan helpers ────────────────────────────────────────────
+// ─── TypeScript compiler bootstrap ───────────────────────────────────────────
 
 /**
- * Find the local source directory for a package name.
- * Returns null if not found (consumer install scenario — normal resolution handles it).
+ * Resolve the TypeScript module. Try:
+ *   1. Consumer's cwd node_modules
+ *   2. This skill's own directory (gate/node_modules has typescript)
+ * Returns the ts module or null.
  */
-function findLocalSrcDir(pkgName) {
-  const shortName = pkgName.replace('@rocket.chat/', '');
-  const candidate = pathResolve(process.cwd(), 'packages', shortName, 'src');
+let _ts = null;
+let _tsResolved = false;
+
+function loadTypeScript() {
+  if (_tsResolved) return _ts;
+  _tsResolved = true;
+
+  // 1. Try from cwd
   try {
-    readdirSync(candidate);
-    return candidate;
+    _ts = cwdRequire('typescript');
+    return _ts;
   } catch {
-    return null;
-  }
-}
-
-/**
- * Extract capitalized export names from an index.ts/index.js file via regex.
- * Pattern: `export * from './Foo'` or `export { Foo, Bar }` or `export const Foo`
- * Returns array of PascalCase or camelCase names matching the filter fn.
- */
-function extractExportNamesFromSource(filePath, filterFn) {
-  let src;
-  try {
-    src = readFileSync(filePath, 'utf8');
-  } catch {
-    return null; // file not readable
+    // fall through
   }
 
-  const names = new Set();
-
-  // export * from './FooBar' — the path segment is the component name
-  for (const m of src.matchAll(/export \* from ['"]\.\/([^'"]+)['"]/g)) {
-    const segment = m[1];
-    if (filterFn(segment)) names.add(segment);
-  }
-
-  // export { Foo, Bar, ... } — named exports
-  for (const m of src.matchAll(/export \{([^}]+)\}/g)) {
-    for (const raw of m[1].split(',')) {
-      const name = raw.trim().split(/\s+as\s+/).pop().trim();
-      if (filterFn(name)) names.add(name);
+  // 2. Try from skill dir (gate/node_modules has typescript in the monorepo)
+  const candidates = [
+    join(__dirname, 'gate'), // skills/fuselage-craft/gate
+    __dirname, // skills/fuselage-craft
+  ];
+  for (const dir of candidates) {
+    try {
+      _ts = makeRequire(dir)('typescript');
+      return _ts;
+    } catch {
+      // continue
     }
   }
 
-  // export const Foo / export function Foo / export class Foo
-  for (const m of src.matchAll(/export (?:const|function|class) ([A-Za-z_$][A-Za-z0-9_$]*)/g)) {
-    if (filterFn(m[1])) names.add(m[1]);
-  }
-
-  // export default as Foo
-  for (const m of src.matchAll(/export \{ default as ([A-Za-z_$][A-Za-z0-9_$]*)/g)) {
-    if (filterFn(m[1])) names.add(m[1]);
-  }
-
-  return [...names].sort();
+  _ts = null;
+  return null;
 }
 
-/**
- * Scan a directory for component subdirectory names (PascalCase directories).
- */
-function scanComponentDirs(dir) {
-  try {
-    return readdirSync(dir, { withFileTypes: true })
-      .filter((d) => d.isDirectory() && /^[A-Z]/.test(d.name))
-      .map((d) => d.name)
-      .sort();
-  } catch {
-    return null;
-  }
-}
+const TS_DEGRADED = {
+  status: 'type-only',
+  data: 'typescript not resolvable from cwd; validate via the type gate',
+};
+
+// ─── Package entry resolution ─────────────────────────────────────────────────
+
+const PKG_SHORT = {
+  '@rocket.chat/fuselage': 'fuselage',
+  '@rocket.chat/fuselage-forms': 'fuselage-forms',
+  '@rocket.chat/fuselage-hooks': 'fuselage-hooks',
+};
 
 /**
- * Extract string-keyed tokens from a TypeScript source file.
- * Finds object literals like: export const fooColors = { 'key-name': ..., ... }
- * Returns a map of exportName -> string[keys].
+ * Resolve the TypeScript entry point for a package.
+ * Priority:
+ *   1. Installed package's types field (consumer node_modules .d.ts)
+ *   2. Monorepo src/index.ts (in the fuselage monorepo itself)
+ * Returns { path, source } or null.
  */
-function extractStringKeysFromThemeSrc(filePath) {
-  let src;
+function resolveTypesEntry(pkg) {
+  // 1. Installed node_modules
   try {
-    src = readFileSync(filePath, 'utf8');
-  } catch {
-    return null;
-  }
-
-  // Palette is assembled from named sub-objects in Theme.ts
-  // Regex: export const Palette = { subKey: varName, ... }
-  const paletteMatch = src.match(/export const Palette\s*=\s*\{([^}]+)\}/);
-  if (!paletteMatch) return null;
-
-  const paletteBody = paletteMatch[1];
-  // Extract { surface: surfaceColors, text: textIconColors, ... }
-  const subObjects = {};
-  for (const m of paletteBody.matchAll(/(\w+)\s*:\s*(\w+)/g)) {
-    subObjects[m[1]] = m[2]; // e.g. surface -> surfaceColors
-  }
-
-  const result = {};
-  for (const [paletteKey, varName] of Object.entries(subObjects)) {
-    // Find the object declaration: export const varName = { 'key': ..., }
-    const re = new RegExp(
-      `export const ${varName}\\s*=\\s*\\{([^}]+)\\}`,
-      's',
-    );
-    const match = src.match(re);
-    if (!match) continue;
-
-    const keys = [];
-    // Match string literal keys: 'key-name' or "key-name"
-    for (const km of match[1].matchAll(/['"]([a-z][a-z0-9-]+)['"]\s*:/g)) {
-      keys.push(km[1]);
+    const pkgJsonPath = cwdRequire.resolve(`${pkg}/package.json`);
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+    const typesField = pkgJson.types || pkgJson.typings;
+    if (typesField) {
+      const pkgDir = dirname(pkgJsonPath);
+      const entry = join(pkgDir, typesField);
+      if (existsSync(entry)) {
+        return { path: entry, source: 'installed .d.ts (types)' };
+      }
     }
-    if (keys.length > 0) result[paletteKey] = keys;
+  } catch {
+    // fall through
   }
 
+  // 2. Monorepo src fallback
+  const short = PKG_SHORT[pkg];
+  if (short) {
+    const srcIndex = pathResolve(cwd, 'packages', short, 'src', 'index.ts');
+    if (existsSync(srcIndex)) {
+      return { path: srcIndex, source: 'monorepo src (types)' };
+    }
+  }
+
+  return null;
+}
+
+// ─── TS Program cache ─────────────────────────────────────────────────────────
+
+const _programCache = new Map();
+
+/**
+ * Build (or retrieve cached) a ts.Program for a given entry file.
+ * Returns { program, checker, sourceFile } or null.
+ */
+function getTsProgram(entryPath) {
+  if (_programCache.has(entryPath)) return _programCache.get(entryPath);
+
+  const ts = loadTypeScript();
+  if (!ts) {
+    _programCache.set(entryPath, null);
+    return null;
+  }
+
+  const compilerOptions = {
+    noEmit: true,
+    skipLibCheck: true,
+    types: [],
+    // Use Bundler when available (TS >=5.0), fall back to NodeNext
+    moduleResolution:
+      ts.ModuleResolutionKind.Bundler ?? ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ESNext,
+    allowJs: false,
+    // Allow .d.ts programs to pull in .ts source
+    allowImportingTsExtensions: true,
+    noEmitOnError: false,
+  };
+
+  let program;
+  try {
+    program = ts.createProgram([entryPath], compilerOptions);
+  } catch (e) {
+    _programCache.set(entryPath, null);
+    return null;
+  }
+
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(entryPath);
+  if (!sourceFile) {
+    _programCache.set(entryPath, null);
+    return null;
+  }
+
+  const result = { program, checker, sourceFile };
+  _programCache.set(entryPath, result);
   return result;
+}
+
+// ─── TS extraction helpers ────────────────────────────────────────────────────
+
+/**
+ * Get all exported symbols from a module's source file.
+ */
+function getExportedSymbols(checker, sourceFile) {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return [];
+  return checker.getExportsOfModule(moduleSymbol);
+}
+
+/**
+ * Check if a symbol is a value declaration (function, class, variable, const).
+ */
+function isValueDeclaration(ts, symbol) {
+  const flags = symbol.getFlags();
+  return !!(
+    flags & ts.SymbolFlags.Function ||
+    flags & ts.SymbolFlags.Class ||
+    flags & ts.SymbolFlags.Variable ||
+    flags & ts.SymbolFlags.BlockScopedVariable ||
+    flags & ts.SymbolFlags.FunctionScopedVariable
+  );
+}
+
+/**
+ * Extract string literal members from a type alias union.
+ * e.g. type FontScale = 'hero' | 'h1' | 'h2' | ...
+ */
+function extractUnionStringLiterals(ts, checker, symbol) {
+  const decls = symbol.getDeclarations?.() ?? [];
+  for (const decl of decls) {
+    if (!ts.isTypeAliasDeclaration(decl)) continue;
+    const type = checker.getTypeAtLocation(decl.type);
+    if (type.isUnion()) {
+      const literals = [];
+      for (const t of type.types) {
+        if (t.isStringLiteral()) literals.push(t.value);
+      }
+      if (literals.length > 0) return literals;
+    }
+    // single literal (non-union)
+    if (type.isStringLiteral()) return [type.value];
+  }
+  return null;
+}
+
+/**
+ * Extract the keys of an exported const object symbol.
+ * e.g. export const surfaceColors = { 'surface-light': ..., ... }
+ * Returns an array of string keys.
+ */
+function extractObjectKeys(ts, checker, symbol) {
+  const type = checker.getTypeOfSymbol(symbol);
+  const props = checker.getPropertiesOfType(type);
+  const keys = props.map((p) => p.getName());
+  return keys.filter((k) => typeof k === 'string' && k.length > 0);
+}
+
+/**
+ * Extract string literal union members from the `elevation` property
+ * of the StylingProps type exported by the fuselage entry.
+ * Looks for the StylingProps type alias and reads its `elevation` property.
+ */
+function extractElevationLiterals(ts, checker, exports) {
+  // Find StylingProps type alias in exported symbols
+  const stylingPropsSymbol = exports.find((s) => s.getName() === 'StylingProps');
+  if (stylingPropsSymbol) {
+    const decls = stylingPropsSymbol.getDeclarations?.() ?? [];
+    for (const decl of decls) {
+      if (!ts.isTypeAliasDeclaration(decl)) continue;
+      const type = checker.getTypeAtLocation(decl.type);
+      const elevProp = type.getProperty('elevation');
+      if (elevProp) {
+        const elevType = checker.getTypeOfSymbol(elevProp);
+        const literals = extractUnionFromType(ts, elevType);
+        if (literals && literals.length > 0) return literals;
+      }
+    }
+  }
+
+  // Fallback: search all exported interface/type symbols for one with `elevation`
+  for (const sym of exports) {
+    const decls = sym.getDeclarations?.() ?? [];
+    for (const decl of decls) {
+      if (!ts.isTypeAliasDeclaration(decl) && !ts.isInterfaceDeclaration(decl))
+        continue;
+      const type = checker.getTypeAtLocation(decl);
+      const elevProp = type.getProperty('elevation');
+      if (!elevProp) continue;
+      const elevType = checker.getTypeOfSymbol(elevProp);
+      const literals = extractUnionFromType(ts, elevType);
+      if (literals && literals.length > 0) return literals;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract string literal union values from a type (handles union + single).
+ */
+function extractUnionFromType(ts, type) {
+  if (type.isUnion()) {
+    const lits = [];
+    for (const t of type.types) {
+      if (t.isStringLiteral()) lits.push(t.value);
+    }
+    return lits.length > 0 ? lits : null;
+  }
+  if (type.isStringLiteral()) return [type.value];
+  return null;
+}
+
+// ─── Token data import (cwd-anchored, absolute path) ──────────────────────────
+
+/**
+ * Import a package data file (e.g. colors.mjs) from the CONSUMER's node_modules.
+ * A bare `import('pkg/file')` resolves relative to THIS module (the skill repo),
+ * not the consumer's cwd, so subpath data imports silently fail in a consumer.
+ * Resolve the package dir from cwd and import the absolute file URL instead.
+ * Falls back to the monorepo packages/<short>/ location.
+ * Returns { value, source } or null.
+ */
+async function importPkgData(pkg, files) {
+  const candidates = [];
+  try {
+    const pkgDir = dirname(cwdRequire.resolve(`${pkg}/package.json`));
+    for (const f of files) candidates.push([join(pkgDir, f), 'node_modules (data)']);
+  } catch {
+    // not resolvable via node_modules
+  }
+  const short = pkg.replace('@rocket.chat/', '');
+  for (const f of files) {
+    candidates.push([pathResolve(cwd, 'packages', short, f), 'monorepo (data)']);
+  }
+  for (const [abs, source] of candidates) {
+    if (!existsSync(abs)) continue;
+    try {
+      const mod = await import(pathToFileURL(abs).href);
+      if (mod && mod.default) return { value: mod.default, source };
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
 }
 
 // ─── Category resolvers ───────────────────────────────────────────────────────
 
 async function resolveColors() {
-  // Try: dynamic import from consumer node_modules first
-  try {
-    const mod = await import(
-      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/colors.mjs`
-    ).catch(() => null);
-    if (mod && mod.default && Object.keys(mod.default).length > 0) {
-      return { status: 'ok', source: 'node_modules (ESM)', data: Object.keys(mod.default) };
-    }
-  } catch {
-    // fall through
+  const hit = await importPkgData('@rocket.chat/fuselage-tokens', [
+    'colors.mjs',
+    'colors.js',
+  ]);
+  if (hit && Object.keys(hit.value).length > 0) {
+    return { status: 'ok', source: hit.source, data: Object.keys(hit.value) };
   }
-
-  // Monorepo fallback: import directly from local path
-  const shortName = 'fuselage-tokens';
-  const localMjs = pathResolve(process.cwd(), 'packages', shortName, 'colors.mjs');
-  try {
-    const mod = await import(pathToFileURL(localMjs).href);
-    if (mod && mod.default && Object.keys(mod.default).length > 0) {
-      return { status: 'ok', source: 'monorepo/src', data: Object.keys(mod.default) };
-    }
-  } catch {
-    // fall through
-  }
-
   return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage-tokens/colors.mjs could not be loaded',
+    reason: '@rocket.chat/fuselage-tokens colors data could not be loaded',
     data: [],
   };
 }
 
 async function resolveFontScale() {
-  // Try consumer node_modules first
-  try {
-    const mod = await import(
-      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/typography.mjs`
-    ).catch(() => null);
-    if (mod && mod.default && mod.default.fontScales) {
-      return {
-        status: 'ok',
-        source: 'node_modules (ESM)',
-        data: Object.keys(mod.default.fontScales),
-      };
+  const ts = loadTypeScript();
+
+  if (ts) {
+    // Primary: extract FontScale type alias from the fuselage entry
+    const entry = resolveTypesEntry('@rocket.chat/fuselage');
+    if (entry) {
+      const prog = getTsProgram(entry.path);
+      if (prog) {
+        const { checker, sourceFile } = prog;
+        const exports = getExportedSymbols(checker, sourceFile);
+        const fontScaleSym = exports.find((s) => s.getName() === 'FontScale');
+        if (fontScaleSym) {
+          const literals = extractUnionStringLiterals(ts, checker, fontScaleSym);
+          if (literals && literals.length > 0) {
+            return { status: 'ok', source: entry.source, data: literals };
+          }
+        }
+      }
     }
-  } catch {
-    // fall through
   }
 
-  // Monorepo fallback
-  const localMjs = pathResolve(process.cwd(), 'packages', 'fuselage-tokens', 'typography.mjs');
-  try {
-    const mod = await import(pathToFileURL(localMjs).href);
-    if (mod && mod.default && mod.default.fontScales) {
-      return {
-        status: 'ok',
-        source: 'monorepo/src',
-        data: Object.keys(mod.default.fontScales),
-      };
-    }
-  } catch {
-    // fall through
+  // Data fallback: typography tokens
+  const hit = await importPkgData('@rocket.chat/fuselage-tokens', [
+    'typography.mjs',
+    'typography.js',
+  ]);
+  if (hit && hit.value && hit.value.fontScales) {
+    return {
+      status: 'ok',
+      source: hit.source,
+      data: Object.keys(hit.value.fontScales),
+    };
   }
+
+  if (!ts) return TS_DEGRADED;
 
   return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage-tokens/typography.mjs could not be loaded',
+    reason: 'FontScale type not found and typography data unavailable',
     data: [],
   };
 }
 
 async function resolveBreakpoints() {
-  // Try consumer node_modules first
-  try {
-    const mod = await import(
-      /* @vite-ignore */ `@rocket.chat/fuselage-tokens/breakpoints.mjs`
-    ).catch(() => null);
-    if (mod && mod.default && Object.keys(mod.default).length > 0) {
-      return {
-        status: 'ok',
-        source: 'node_modules (ESM)',
-        data: Object.keys(mod.default),
-      };
-    }
-  } catch {
-    // fall through
-  }
-
-  // Monorepo fallback
-  const localMjs = pathResolve(
-    process.cwd(),
-    'packages',
-    'fuselage-tokens',
+  const hit = await importPkgData('@rocket.chat/fuselage-tokens', [
     'breakpoints.mjs',
-  );
-  try {
-    const mod = await import(pathToFileURL(localMjs).href);
-    if (mod && mod.default && Object.keys(mod.default).length > 0) {
-      return {
-        status: 'ok',
-        source: 'monorepo/src',
-        data: Object.keys(mod.default),
-      };
-    }
-  } catch {
-    // fall through
+    'breakpoints.js',
+  ]);
+  if (hit) {
+    const v = hit.value;
+    const data = Array.isArray(v)
+      ? v.map((b) => b.name).filter(Boolean)
+      : Object.keys(v);
+    if (data.length > 0) return { status: 'ok', source: hit.source, data };
   }
-
   return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage-tokens/breakpoints.mjs could not be loaded',
+    reason: '@rocket.chat/fuselage-tokens breakpoints data could not be loaded',
     data: [],
   };
 }
 
+/**
+ * Semantic color groups: read the exported const sub-objects from Theme.ts.
+ * The Palette export is: { surface: surfaceColors, text: textIconColors, ... }
+ * Each sub-object (surfaceColors, textIconColors, ...) is also exported directly.
+ * We read the Palette object's type properties, and for each, extract the
+ * keys of the corresponding sub-object type.
+ */
 async function resolveSemantic() {
-  // Try: dynamic import of built @rocket.chat/fuselage and read Palette
-  try {
-    const mod = await import('@rocket.chat/fuselage').catch(() => null);
-    if (mod && mod.Palette && typeof mod.Palette === 'object') {
-      const groups = {};
-      for (const [group, obj] of Object.entries(mod.Palette)) {
-        if (obj && typeof obj === 'object') {
-          groups[group] = Object.keys(obj);
-        }
-      }
-      if (Object.keys(groups).length > 0) {
-        return { status: 'ok', source: 'node_modules (built Palette)', data: groups };
-      }
-    }
-  } catch {
-    // fall through
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  const entry = resolveTypesEntry('@rocket.chat/fuselage');
+  if (!entry) {
+    return {
+      status: 'unavailable',
+      reason: '@rocket.chat/fuselage not installed and not in monorepo',
+      data: {},
+    };
   }
 
-  // Monorepo fallback: parse Theme.ts source with regex
-  const localTheme = pathResolve(
-    process.cwd(),
-    'packages',
-    'fuselage',
-    'src',
-    'Theme.ts',
-  );
-  try {
-    const groups = extractStringKeysFromThemeSrc(localTheme);
-    if (groups && Object.keys(groups).length > 0) {
-      return { status: 'ok', source: 'monorepo/src (Theme.ts regex)', data: groups };
+  const prog = getTsProgram(entry.path);
+  if (!prog) {
+    return {
+      status: 'unavailable',
+      reason: 'Could not build TypeScript program for @rocket.chat/fuselage',
+      data: {},
+    };
+  }
+
+  const { checker, sourceFile } = prog;
+  const exports = getExportedSymbols(checker, sourceFile);
+
+  // The Palette const maps group names to sub-object consts.
+  // We can read Palette's type directly: each property's type has the color keys.
+  const paletteSym = exports.find((s) => s.getName() === 'Palette');
+  if (paletteSym) {
+    const paletteType = checker.getTypeOfSymbol(paletteSym);
+    const groupProps = checker.getPropertiesOfType(paletteType);
+    const groups = {};
+    for (const groupProp of groupProps) {
+      const groupName = groupProp.getName();
+      const groupType = checker.getTypeOfSymbol(groupProp);
+      const colorProps = checker.getPropertiesOfType(groupType);
+      const keys = colorProps.map((p) => p.getName()).filter((k) => k.startsWith(groupName.replace('Color', '')) || k.length > 0);
+      // Filter to only string keys that look like semantic color names (contain '-')
+      const colorKeys = colorProps
+        .map((p) => p.getName())
+        .filter((k) => typeof k === 'string' && k.includes('-'));
+      if (colorKeys.length > 0) groups[groupName] = colorKeys;
     }
-  } catch {
-    // fall through
+    if (Object.keys(groups).length > 0) {
+      return { status: 'ok', source: entry.source, data: groups };
+    }
+  }
+
+  // Fallback: read the named sub-object exports directly
+  // Map from export name to palette group key
+  const subObjectMap = [
+    ['surfaceColors', 'surface'],
+    ['textIconColors', 'text'],
+    ['strokeColors', 'stroke'],
+    ['statusBackgroundColors', 'status'],
+    ['statusColors', 'statusColor'],
+    ['badgeBackgroundColors', 'badge'],
+    ['shadowColors', 'shadow'],
+  ];
+
+  const groups = {};
+  for (const [exportName, groupKey] of subObjectMap) {
+    const sym = exports.find((s) => s.getName() === exportName);
+    if (!sym) continue;
+    const keys = extractObjectKeys(ts, checker, sym);
+    if (keys.length > 0) groups[groupKey] = keys;
+  }
+
+  if (Object.keys(groups).length > 0) {
+    return { status: 'ok', source: entry.source, data: groups };
   }
 
   return {
     status: 'unavailable',
-    reason:
-      'semantic palette unavailable in this environment (package not built or import side-effects); ' +
-      'semantic color/bg names: resolve via the type gate',
+    reason: 'Palette and sub-object exports not found in @rocket.chat/fuselage types',
     data: {},
   };
 }
 
-async function resolveComponents() {
-  // Try: dynamic import of built @rocket.chat/fuselage
-  try {
-    const mod = await import('@rocket.chat/fuselage').catch(() => null);
-    if (mod) {
-      const names = Object.keys(mod).filter((k) => /^[A-Z]/.test(k));
-      if (names.length > 0) {
-        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
-      }
-    }
-  } catch {
-    // fall through
+async function resolveElevation() {
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  const entry = resolveTypesEntry('@rocket.chat/fuselage');
+  if (!entry) {
+    return {
+      status: 'type-only',
+      data: 'type-only: @rocket.chat/fuselage not found; values are "0"|"1"|"2"|"1nb"|"2nb" in StylingProps',
+    };
   }
 
-  // Monorepo fallback: scan packages/fuselage/src/components/ directories
-  const srcDir = findLocalSrcDir('@rocket.chat/fuselage');
-  if (srcDir) {
-    const componentsDir = join(srcDir, 'components');
-    const dirs = scanComponentDirs(componentsDir);
-    if (dirs && dirs.length > 0) {
-      return { status: 'ok', source: 'monorepo/src (dir scan)', data: dirs };
-    }
-    // Also try scanning the components/index.ts for exports
-    const idxPath = join(componentsDir, 'index.ts');
-    const names = extractExportNamesFromSource(idxPath, (n) => /^[A-Z]/.test(n));
-    if (names && names.length > 0) {
-      return { status: 'ok', source: 'monorepo/src (index.ts scan)', data: names };
+  const prog = getTsProgram(entry.path);
+  if (!prog) {
+    return {
+      status: 'type-only',
+      data: 'type-only: could not build TypeScript program; validate via the type gate',
+    };
+  }
+
+  const { checker, sourceFile } = prog;
+  const exports = getExportedSymbols(checker, sourceFile);
+
+  const literals = extractElevationLiterals(ts, checker, exports);
+  if (literals && literals.length > 0) {
+    return { status: 'ok', source: entry.source, data: literals };
+  }
+
+  // Second approach: build a separate program targeting stylingProps.ts directly
+  const short = PKG_SHORT['@rocket.chat/fuselage'];
+  const stylingPropsPath = pathResolve(
+    cwd,
+    'packages',
+    short,
+    'src',
+    'components',
+    'Box',
+    'stylingProps.ts',
+  );
+  if (existsSync(stylingPropsPath)) {
+    const prog2 = getTsProgram(stylingPropsPath);
+    if (prog2) {
+      const exports2 = getExportedSymbols(prog2.checker, prog2.sourceFile);
+      const stylingPropsSym = exports2.find((s) => s.getName() === 'StylingProps');
+      if (stylingPropsSym) {
+        const decls = stylingPropsSym.getDeclarations?.() ?? [];
+        for (const decl of decls) {
+          if (!ts.isTypeAliasDeclaration(decl)) continue;
+          const type = prog2.checker.getTypeAtLocation(decl.type);
+          const elevProp = type.getProperty('elevation');
+          if (elevProp) {
+            const elevType = prog2.checker.getTypeOfSymbol(elevProp);
+            const lits = extractUnionFromType(ts, elevType);
+            if (lits && lits.length > 0) {
+              return { status: 'ok', source: 'monorepo src (types)', data: lits };
+            }
+          }
+        }
+      }
     }
   }
 
   return {
+    status: 'type-only',
+    data: 'type-only: elevation literals are "0"|"1"|"2"|"1nb"|"2nb" in StylingProps.elevation; validate via the type gate',
+  };
+}
+
+async function resolveComponents() {
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  const entry = resolveTypesEntry('@rocket.chat/fuselage');
+  if (!entry) {
+    return {
+      status: 'unavailable',
+      reason: '@rocket.chat/fuselage not installed and not in monorepo',
+      data: [],
+    };
+  }
+
+  const prog = getTsProgram(entry.path);
+  if (!prog) {
+    return {
+      status: 'unavailable',
+      reason: 'Could not build TypeScript program for @rocket.chat/fuselage',
+      data: [],
+    };
+  }
+
+  const { checker, sourceFile } = prog;
+  const exports = getExportedSymbols(checker, sourceFile);
+
+  const names = exports
+    .filter((s) => /^[A-Z]/.test(s.getName()) && isValueDeclaration(ts, s))
+    .map((s) => s.getName())
+    .sort();
+
+  if (names.length > 0) {
+    return { status: 'ok', source: entry.source, data: names };
+  }
+
+  return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage could not be loaded and no local src found',
+    reason: 'No PascalCase value exports found in @rocket.chat/fuselage types',
     data: [],
   };
 }
 
 async function resolveForms() {
-  // Try: dynamic import of built @rocket.chat/fuselage-forms
-  try {
-    const mod = await import('@rocket.chat/fuselage-forms').catch(() => null);
-    if (mod) {
-      const names = Object.keys(mod).filter((k) => /^[A-Z]/.test(k));
-      if (names.length > 0) {
-        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
-      }
-    }
-  } catch {
-    // fall through
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  const entry = resolveTypesEntry('@rocket.chat/fuselage-forms');
+  if (!entry) {
+    return {
+      status: 'unavailable',
+      reason: '@rocket.chat/fuselage-forms not installed and not in monorepo',
+      data: [],
+    };
   }
 
-  // Monorepo fallback: scan leaf source files (not re-export index files, which
-  // produce path-segment false positives like "Inputs" or "WrappedInputComponents").
-  const srcDir = findLocalSrcDir('@rocket.chat/fuselage-forms');
-  if (srcDir) {
-    const namesToCheck = new Set();
+  const prog = getTsProgram(entry.path);
+  if (!prog) {
+    return {
+      status: 'unavailable',
+      reason: 'Could not build TypeScript program for @rocket.chat/fuselage-forms',
+      data: [],
+    };
+  }
 
-    // Leaf files that declare the actual exported component names
-    const leafFiles = [
-      join(srcDir, 'Inputs', 'WrappedInputComponents.ts'),
-      join(srcDir, 'Field', 'index.ts'),
-      join(srcDir, 'Field', 'Label', 'index.ts'),
-    ];
+  const { checker, sourceFile } = prog;
+  const exports = getExportedSymbols(checker, sourceFile);
 
-    for (const file of leafFiles) {
-      const names = extractExportNamesFromSource(file, (n) => /^[A-Z]/.test(n));
-      if (names) names.forEach((n) => namesToCheck.add(n));
-    }
+  const names = exports
+    .filter((s) => /^[A-Z]/.test(s.getName()) && isValueDeclaration(ts, s))
+    .map((s) => s.getName())
+    .sort();
 
-    const data = [...namesToCheck].sort();
-    if (data.length > 0) {
-      return { status: 'ok', source: 'monorepo/src (leaf-file scan)', data };
-    }
+  if (names.length > 0) {
+    return { status: 'ok', source: entry.source, data: names };
   }
 
   return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage-forms could not be loaded and no local src found',
+    reason: 'No PascalCase value exports found in @rocket.chat/fuselage-forms types',
     data: [],
   };
 }
 
 async function resolveHooks() {
-  // Try: dynamic import of built @rocket.chat/fuselage-hooks
-  try {
-    const mod = await import('@rocket.chat/fuselage-hooks').catch(() => null);
-    if (mod) {
-      const names = Object.keys(mod).filter((k) => /^use[A-Z]/.test(k));
-      if (names.length > 0) {
-        return { status: 'ok', source: 'node_modules (built)', data: names.sort() };
-      }
-    }
-  } catch {
-    // fall through
+  const ts = loadTypeScript();
+  if (!ts) return TS_DEGRADED;
+
+  const entry = resolveTypesEntry('@rocket.chat/fuselage-hooks');
+  if (!entry) {
+    return {
+      status: 'unavailable',
+      reason: '@rocket.chat/fuselage-hooks not installed and not in monorepo',
+      data: [],
+    };
   }
 
-  // Monorepo fallback: parse src/index.ts
-  const srcDir = findLocalSrcDir('@rocket.chat/fuselage-hooks');
-  if (srcDir) {
-    const indexPath = join(srcDir, 'index.ts');
-    const names = extractExportNamesFromSource(indexPath, (n) => /^use[A-Z]/.test(n));
-    if (names && names.length > 0) {
-      return { status: 'ok', source: 'monorepo/src (index.ts scan)', data: names };
-    }
+  const prog = getTsProgram(entry.path);
+  if (!prog) {
+    return {
+      status: 'unavailable',
+      reason: 'Could not build TypeScript program for @rocket.chat/fuselage-hooks',
+      data: [],
+    };
+  }
+
+  const { checker, sourceFile } = prog;
+  const exports = getExportedSymbols(checker, sourceFile);
+
+  const names = exports
+    .filter((s) => /^use[A-Z]/.test(s.getName()))
+    .map((s) => s.getName())
+    .sort();
+
+  if (names.length > 0) {
+    return { status: 'ok', source: entry.source, data: names };
   }
 
   return {
     status: 'unavailable',
-    reason: '@rocket.chat/fuselage-hooks could not be loaded and no local src found',
+    reason: 'No hook exports found in @rocket.chat/fuselage-hooks types',
     data: [],
   };
 }
@@ -479,7 +726,7 @@ async function resolveHooks() {
 
 /**
  * Resolve a single category.
- * Returns: { status: 'ok'|'unavailable'|'type-only', source?, reason?, data }
+ * Returns: { status: 'ok'|'unavailable'|'type-only'|'rule', source?, reason?, data }
  */
 export async function resolveCategory(category) {
   switch (category) {
@@ -491,6 +738,8 @@ export async function resolveCategory(category) {
       return resolveBreakpoints();
     case 'semantic':
       return resolveSemantic();
+    case 'elevation':
+      return resolveElevation();
     case 'components':
       return resolveComponents();
     case 'forms':
@@ -502,15 +751,10 @@ export async function resolveCategory(category) {
         status: 'rule',
         data: 'Spacing uses the x<N> scale on a 4px grid (x1=4px, x2=8px, x4=16px, x8=32px, …). Type gate is authoritative for valid spacing tokens.',
       };
-    case 'elevation':
-      return {
-        status: 'type-only',
-        data: 'type-only; authoritative validation is the type gate (tsc). Values live in src/components/Box/stylingProps.ts.',
-      };
     case 'radius':
       return {
-        status: 'type-only',
-        data: 'type-only; authoritative validation is the type gate (tsc). Values live in src/components/Box/stylingProps.ts.',
+        status: 'rule',
+        data: 'Border radius is permissive (CSSProperties[\'borderRadius\']); semantic convention is \'none\'|\'full\'|x<N> but this is not enforced by types. Validate via design system conventions.',
       };
     default:
       return { status: 'unavailable', reason: `Unknown category: ${category}`, data: [] };
@@ -522,7 +766,7 @@ export async function resolveCategory(category) {
  * Returns: { resolvedFrom, versions, categories: { [cat]: result } }
  */
 export async function resolveAll() {
-  const resolvedFrom = process.cwd();
+  const resolvedFrom = cwd;
   const versions = collectVersions();
 
   const categoryNames = [
@@ -558,7 +802,7 @@ async function main() {
       categoryArg === 'all'
         ? await resolveAll()
         : {
-            resolvedFrom: process.cwd(),
+            resolvedFrom: cwd,
             versions: collectVersions(),
             categories: { [categoryArg]: await resolveCategory(categoryArg) },
           };
@@ -567,20 +811,31 @@ async function main() {
   }
 
   // Human output
-  const resolvedFrom = process.cwd();
   const versions = collectVersions();
 
   process.stdout.write('\n═══ fuselage-craft resolver ══════════════════════════\n');
-  process.stdout.write(`Resolved from: ${resolvedFrom}\n`);
+  process.stdout.write(`Resolved from: ${cwd}\n`);
   process.stdout.write('Package versions:\n');
   for (const [pkg, ver] of Object.entries(versions)) {
     process.stdout.write(`  ${pkg}: ${ver}\n`);
   }
   process.stdout.write('══════════════════════════════════════════════════════\n\n');
 
-  const cats = categoryArg === 'all'
-    ? ['colors', 'fontscale', 'breakpoints', 'semantic', 'components', 'forms', 'hooks', 'spacing', 'elevation', 'radius']
-    : [categoryArg];
+  const cats =
+    categoryArg === 'all'
+      ? [
+          'colors',
+          'fontscale',
+          'breakpoints',
+          'semantic',
+          'components',
+          'forms',
+          'hooks',
+          'spacing',
+          'elevation',
+          'radius',
+        ]
+      : [categoryArg];
 
   for (const cat of cats) {
     const result = await resolveCategory(cat);
@@ -611,8 +866,7 @@ async function main() {
 // Run CLI only when invoked directly
 const isMain =
   process.argv[1] &&
-  (process.argv[1] === __filename ||
-    process.argv[1].endsWith('/resolve.mjs'));
+  (process.argv[1] === __filename || process.argv[1].endsWith('/resolve.mjs'));
 
 if (isMain) {
   main().catch((err) => {

--- a/skills/fuselage-craft/resolve.mjs
+++ b/skills/fuselage-craft/resolve.mjs
@@ -205,7 +205,6 @@ function extractStringKeysFromThemeSrc(filePath) {
 async function resolveColors() {
   // Try: dynamic import from consumer node_modules first
   try {
-    const cwdStr = process.cwd();
     const mod = await import(
       /* @vite-ignore */ `@rocket.chat/fuselage-tokens/colors.mjs`
     ).catch(() => null);


### PR DESCRIPTION
## What

A Claude Code skill suite (`skills/fuselage-craft/`) for **products that consume `@rocket.chat/fuselage`**. It keeps consumer UI faithful to the design system, treating the installed Fuselage packages as the single source of truth and never copying a Fuselage value or name into product code.

It is the consumer-side counterpart to authoring tools: where authoring *invents* design values, this skill *selects and composes* from the system and refuses to drift from it.

## What's in it

- **`SKILL.md`** — the law layer (*reference, never replicate*) + a command router.
- **9 command references** — `audit`, `migrate`, `polish`, `harden`, `critique`, `clarify`, `adapt`, `shape`, `craft`. Each inherits the laws, resolves vocabulary live, and closes with the gate.
- **`resolve.mjs`** — a live reader of the installed `@rocket.chat/fuselage*` packages (`Object.keys` on the real exports, reports resolved versions). Holds **zero** Fuselage vocabulary; degrades gracefully.
- **`gate/`** — the enforcement layer:
  - **Lint gate**: 5 ESLint rules that ban literal design values (`no-raw-color`, `no-literal-dimension`, `no-literal-shadow`, `require-field-wrapper`, `prefer-box`). **Value-free** — they ban literal patterns, they know no Fuselage values. The live Field-control list is injected from `resolve.mjs`.
  - **Type gate**: runs the consumer's `tsc --noEmit` so emitted JSX is validated against the installed package's own types.
- **`PRODUCT.md` / `DESIGN.md`** — design context; both defer to the package as source of truth (DESIGN.md references token *names* via `resolve.mjs`, never values).

## Source-of-truth guarantees

- No copied **values** (hex / px / shadow) anywhere — lint bans the patterns.
- No copied **API names** as authoritative — resolved live by `resolve.mjs`, enforced by the type gate.
- Three live mechanisms, all reading the installed package: resolver grounds generation, type gate enforces, lint kills literals.

## Notes

- Rules live in the skill for now; graduation path to a published `packages/eslint-plugin-fuselage` is documented in `gate/README.md`.
- `gate/node_modules` is gitignored; deps declared in `gate/package.json`.

## Verification

- `node skills/fuselage-craft/gate/tests/run-tests.mjs` → 5/5 rule suites pass.
- `node skills/fuselage-craft/resolve.mjs all` resolves colors / fontscale / breakpoints / semantic / components / forms / hooks live; `elevation`/`radius` correctly defer to the type gate.

## Install (Claude Code)

This skill installs into Claude Code via **symlink**, so the repo stays the single source of truth and edits apply live. Full steps in [`skills/README.md`](https://github.com/RocketChat/fuselage/blob/feat/fuselage-craft-skill/skills/README.md#install-into-claude-code-symlink).

From the repo root:

```sh
ln -s "$(pwd)/skills/fuselage-craft" ~/.claude/skills/fuselage-craft
```

Restart Claude Code to discover it, then run `/fuselage-craft <command>` (e.g. `/fuselage-craft audit src/**`) in any Fuselage-consuming repo.## Highlights — what each piece does

**The skill** keeps UI in products that *consume* `@rocket.chat/fuselage` faithful to the design system: code references token names, never copies values, and the installed packages are the single source of truth.

**Commands** (`/fuselage-craft <command> <target>`):
- `audit` — conformance scan (lint + type gate drift, then a judgment pass); read-only report
- `critique` — UX heuristic review (hierarchy, cognitive load, IA); read-only
- `shape` — plan the feature as a Fuselage component tree; no code
- `craft` — shape, then build the feature end to end
- `migrate` — convert legacy / raw-CSS UI into Fuselage components + token references (map by role, never by value)
- `clarify` — fix UX copy, labels, error messages
- `adapt` — make it responsive via `fuselage-hooks`, not media-query literals
- `polish` — complete the states: loading, empty, error, focus
- `harden` — edge cases, i18n, RTL, a11y, error/disabled paths

**`resolve.mjs`** — reads the installed Fuselage packages live (tokens, components, hooks, fontScale) so the skill bakes in zero vocabulary.

**`gate/`** — lint gate bans literal design values (value-free rules); type gate validates emitted JSX against the installed Fuselage types. A change is not done until both pass.

**Docs** — `README.md` (command catalog + "Keeping in sync with Fuselage"), `SKILL.md` (agent contract + laws), `reference/` (per-command flows), `gate/README.md` (gate internals).

**Self-maintaining:** vocabulary tracks Fuselage automatically (resolver + type gate); only a Fuselage *packaging restructure* needs a manual touch, and that fails safe.