### PR TITLE
refactor: Prepare types for React 19

### DIFF
--- a/packages/fuselage-forms/src/Inputs/withLabelHelpers.tsx
+++ b/packages/fuselage-forms/src/Inputs/withLabelHelpers.tsx
@@ -1,12 +1,7 @@
 // Disabled this flag since we need to wrap multiple components
 /* eslint-disable react/no-multi-comp */
 import { useMergedRefs } from '@rocket.chat/fuselage-hooks';
-import type {
-  ReactNode,
-  ForwardRefExoticComponent,
-  Ref,
-  RefAttributes,
-} from 'react';
+import type { ReactNode, ComponentType, Ref, RefAttributes } from 'react';
 import { forwardRef } from 'react';
 import { VisuallyHidden } from 'react-aria';
 
@@ -20,9 +15,7 @@ import {
 type WithLabelId = { id?: string };
 
 function withLabelId<TProps, TRef>(
-  Component: ForwardRefExoticComponent<
-    TProps & WithLabelId & RefAttributes<TRef>
-  >,
+  Component: ComponentType<TProps & WithLabelId & RefAttributes<TRef>>,
 ) {
   const WrappedComponent = forwardRef<TRef, TProps>(function (props, ref) {
     const labelProps = useFieldReferencedByInput();
@@ -43,9 +36,7 @@ function withLabelId<TProps, TRef>(
 type WithLabelledBy = { 'aria-labelledby'?: string };
 
 function withAriaLabelledBy<TProps, TRef>(
-  Component: ForwardRefExoticComponent<
-    TProps & WithLabelledBy & RefAttributes<TRef>
-  >,
+  Component: ComponentType<TProps & WithLabelledBy & RefAttributes<TRef>>,
 ) {
   const WrappedComponent = forwardRef<TRef, TProps>(function (props, ref) {
     const labelProps = useFieldReferencedByLabel();
@@ -66,9 +57,7 @@ function withAriaLabelledBy<TProps, TRef>(
 type WithLabelledByAndId = { 'aria-labelledby'?: string; 'id'?: string };
 
 function withAriaLabelledByAndId<TProps, TRef>(
-  Component: ForwardRefExoticComponent<
-    TProps & WithLabelledByAndId & RefAttributes<TRef>
-  >,
+  Component: ComponentType<TProps & WithLabelledByAndId & RefAttributes<TRef>>,
 ) {
   const WrappedComponent = forwardRef<TRef, TProps>(function (props, ref) {
     const labelProps = useFieldReferencedByLabelWithId();
@@ -89,9 +78,7 @@ function withAriaLabelledByAndId<TProps, TRef>(
 type WithChildrenLabel = { labelChildren: ReactNode };
 
 function withVisuallyHiddenLabel<TProps, TRef>(
-  Component: ForwardRefExoticComponent<
-    TProps & WithChildrenLabel & RefAttributes<TRef>
-  >,
+  Component: ComponentType<TProps & WithChildrenLabel & RefAttributes<TRef>>,
 ) {
   const WrappedComponent = forwardRef<TRef, TProps>(function (props, ref) {
     const [label, labelProps, labelRef] = useFieldWrappedByInputLabel();

--- a/packages/fuselage-hooks/src/useDebouncedCallback.ts
+++ b/packages/fuselage-hooks/src/useDebouncedCallback.ts
@@ -21,8 +21,8 @@ export const useDebouncedCallback = <P extends unknown[]>(
   // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/rules-of-hooks
   const effectiveCallback = deps ? useMemo(() => callback, deps) : callback;
 
-  const timerCallbackRef = useRef<() => void>();
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerCallbackRef = useRef<() => void>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const debouncedCallback = useCallback(
     (...args: P) => {

--- a/packages/fuselage-hooks/src/useElementIsVisible.ts
+++ b/packages/fuselage-hooks/src/useElementIsVisible.ts
@@ -14,7 +14,7 @@ export const useElementIsVisible = <T extends Element>(): [
   ref: RefObject<T>,
   isVisible: boolean,
 ] => {
-  const innerRef = useRef<T>();
+  const innerRef = useRef<T>(undefined);
 
   const [menuVisibility, setMenuVisibility] = useSafely(
     useDebouncedState(false, 100),

--- a/packages/fuselage-hooks/src/useMergedRefs.ts
+++ b/packages/fuselage-hooks/src/useMergedRefs.ts
@@ -5,7 +5,7 @@ import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 const isRefCallback = <T>(x: unknown): x is RefCallback<T> =>
   typeof x === 'function';
-const isMutableRefObject = <T>(x: unknown): x is MutableRefObject<T> =>
+const isRefObject = <T>(x: unknown): x is MutableRefObject<T> =>
   typeof x === 'object';
 
 /**
@@ -32,7 +32,7 @@ export const useMergedRefs = <T>(...refs: Ref<T>[]): RefCallback<T> => {
         return;
       }
 
-      if (isMutableRefObject<T>(ref)) {
+      if (isRefObject<T>(ref)) {
         ref.current = refValue;
       }
     });

--- a/packages/fuselage-hooks/src/usePrevious.ts
+++ b/packages/fuselage-hooks/src/usePrevious.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 export const usePrevious = <T>(value: T): T | undefined => {
-  const ref = useRef<T>();
+  const ref = useRef<T>(undefined);
 
   useEffect(() => {
     ref.current = value;

--- a/packages/fuselage-toastbar/fuselage-toastbar.api.md
+++ b/packages/fuselage-toastbar/fuselage-toastbar.api.md
@@ -5,8 +5,8 @@
 ```ts
 
 import { Context } from 'react';
+import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { MemoExoticComponent } from 'react';
-import type { ReactElement } from 'react';
 import type { ReactNode } from 'react';
 import { ToastBar } from '@rocket.chat/fuselage';
 
@@ -40,7 +40,7 @@ export type ToastBarProps = {
 };
 
 // @public (undocumented)
-export const ToastBarProvider: MemoExoticComponent<(input: ToastBarProps) => ReactElement>;
+export const ToastBarProvider: MemoExoticComponent<(input: ToastBarProps) => JSX_2.Element>;
 
 // @public (undocumented)
 export const useToastBarDismiss: () => ToastBarContextValue["dismiss"];

--- a/packages/fuselage-toastbar/src/ToastBarPersistent.tsx
+++ b/packages/fuselage-toastbar/src/ToastBarPersistent.tsx
@@ -1,14 +1,8 @@
 import { ToastBar } from '@rocket.chat/fuselage';
-import type { ReactElement } from 'react';
 
 import type { ToastBarPayload } from './ToastBarContext';
 
-const ToastBarPersistent = ({
-  type,
-  message,
-  title,
-  id,
-}: ToastBarPayload): ReactElement => {
+const ToastBarPersistent = ({ type, message, title, id }: ToastBarPayload) => {
   return (
     <ToastBar variant={type} id={id} isPaused>
       {title}

--- a/packages/fuselage-toastbar/src/ToastBarPortal.ts
+++ b/packages/fuselage-toastbar/src/ToastBarPortal.ts
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { memo, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -46,7 +46,7 @@ type ToastBarPortalProps = {
   children?: ReactNode;
 };
 
-const ToastBarPortal = ({ children }: ToastBarPortalProps): ReactElement => {
+const ToastBarPortal = ({ children }: ToastBarPortalProps) => {
   const toastBarRoot = ensureAnchorElement('toastBarRoot');
 
   useLayoutEffect(() => {

--- a/packages/fuselage-toastbar/src/ToastBarProvider.tsx
+++ b/packages/fuselage-toastbar/src/ToastBarProvider.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ReactElement } from 'react';
+import type { ReactNode } from 'react';
 import { useState, memo, useCallback } from 'react';
 
 import type { ToastBarPayload } from './ToastBarContext';
@@ -12,7 +12,7 @@ export type ToastBarProps = {
   children?: ReactNode;
 };
 
-const ToastBarProvider = ({ children }: ToastBarProps): ReactElement => {
+const ToastBarProvider = ({ children }: ToastBarProps) => {
   const [toasts, setToasts] = useState<ToastBarPayload[]>([]);
 
   const contextValue = {

--- a/packages/fuselage-toastbar/src/ToastBarTimed.tsx
+++ b/packages/fuselage-toastbar/src/ToastBarTimed.tsx
@@ -1,17 +1,10 @@
 import { ToastBar } from '@rocket.chat/fuselage';
-import type { ReactElement } from 'react';
 import { useCountdown } from 'react-timing-hooks';
 
 import type { ToastBarPayload } from './ToastBarContext';
 import { useToastBarDismiss } from './ToastBarContext';
 
-const ToastBarTimed = ({
-  time,
-  type,
-  id,
-  message,
-  title,
-}: ToastBarPayload): ReactElement => {
+const ToastBarTimed = ({ time, type, id, message, title }: ToastBarPayload) => {
   const dismissToastMessage = useToastBarDismiss();
 
   const [, { isPaused, pause, resume }] = useCountdown(time, 0, {

--- a/packages/fuselage-toastbar/src/ToastBarZone.tsx
+++ b/packages/fuselage-toastbar/src/ToastBarZone.tsx
@@ -1,5 +1,5 @@
 import styled from '@rocket.chat/styled';
-import type { ReactNode, ReactElement } from 'react';
+import type { ReactNode } from 'react';
 
 import type { ToastBarPayload } from './ToastBarContext';
 
@@ -46,7 +46,7 @@ type ToastBarZoneProps = {
 const ToastBarZone = ({
   children,
   position = 'top-end',
-}: ToastBarZoneProps): ReactElement => (
+}: ToastBarZoneProps) => (
   <ToastBarContainer position={position}>{children}</ToastBarContainer>
 );
 

--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -145,8 +145,8 @@ export type AudioPlayerProps = {
 };
 
 // @public (undocumented)
-export const AutoComplete: ForwardRefExoticComponent<AutoCompleteProps> & {
-    <TLabel = ReactNode>(props: AutoCompleteProps<TLabel> & RefAttributes<HTMLInputElement>): ReactElement;
+export const AutoComplete: Pick<ForwardRefExoticComponent<AutoCompleteProps>, keyof ForwardRefExoticComponent<AutoCompleteProps>> & {
+    <TLabel = ReactNode>(props: AutoCompleteProps<TLabel> & RefAttributes<HTMLInputElement>): ReactNode;
 };
 
 // @public (undocumented)
@@ -351,7 +351,7 @@ export type CalloutProps = Omit<BoxProps, 'type' | 'name'> & {
     title?: ReactNode;
     children?: ReactNode;
     icon?: IconProps['name'];
-    actions?: ReactElement;
+    actions?: ReactNode;
 };
 
 // @public (undocumented)
@@ -859,7 +859,7 @@ size?: BoxProps["width"];
 
 // @public (undocumented)
 export const IconButton: ForwardRefExoticComponent<    {
-icon: Keys | ReactElement;
+icon: Keys | ReactElement<any>;
 primary?: boolean;
 secondary?: boolean;
 info?: boolean;
@@ -871,7 +871,7 @@ pressed?: boolean;
 
 // @public (undocumented)
 export type IconButtonProps = {
-    icon: Keys | ReactElement;
+    icon: Keys | ReactElement<any>;
     primary?: boolean;
     secondary?: boolean;
     info?: boolean;
@@ -988,7 +988,7 @@ export type MenuItemProps<T> = ItemProps<T>;
 // @public (undocumented)
 export interface MenuProps<T> extends AriaMenuProps<T>, MenuTriggerProps {
     // (undocumented)
-    button?: ReactElement;
+    button?: ReactElement<any>;
     // (undocumented)
     className?: BoxProps['className'];
     // (undocumented)
@@ -1102,7 +1102,7 @@ export const MessageGenericPreviewContent: (input: MessageGenericPreviewContentP
 // @public (undocumented)
 export type MessageGenericPreviewContentProps = {
     children?: ReactNode;
-    thumb?: ReactElement;
+    thumb?: ReactNode;
 };
 
 // @public (undocumented)
@@ -1206,7 +1206,7 @@ export const MessageMetricsFollowing: (input: MessageMetricsFollowingProps) => J
 // @public (undocumented)
 export type MessageMetricsFollowingProps = {
     name: 'bell' | 'bell-off';
-    badge?: ReactElement;
+    badge?: ReactNode;
 } & Omit<IconButtonProps, 'icon'>;
 
 // @public (undocumented)
@@ -1426,7 +1426,7 @@ large?: boolean;
 
 // @public (undocumented)
 export const MessageToolbarItem: ForwardRefExoticComponent<    {
-icon: Keys | ReactElement;
+icon: Keys | ReactElement<any>;
 primary?: boolean;
 secondary?: boolean;
 info?: boolean;
@@ -2056,7 +2056,7 @@ export interface PartialNode<T> {
     // (undocumented)
     'childNodes'?: () => IterableIterator<PartialNode<T>>;
     // (undocumented)
-    'element'?: ReactElement;
+    'element'?: ReactNode;
     // (undocumented)
     'hasChildNodes'?: boolean;
     // (undocumented)
@@ -2068,7 +2068,7 @@ export interface PartialNode<T> {
     // (undocumented)
     'rendered'?: ReactNode;
     // (undocumented)
-    'renderer'?: (item: T) => ReactElement;
+    'renderer'?: (item: T) => ReactNode;
     // (undocumented)
     'shouldInvalidate'?: (context: unknown) => boolean;
     // (undocumented)
@@ -2078,7 +2078,7 @@ export interface PartialNode<T> {
     // (undocumented)
     'value'?: T;
     // (undocumented)
-    'wrapper'?: (element: ReactElement) => ReactElement;
+    'wrapper'?: (element: ReactNode) => ReactNode;
 }
 
 // @public (undocumented)
@@ -2114,7 +2114,7 @@ export type PositionAnimatedProps = {
 // @public (undocumented)
 export type PositionProps = {
     anchor: RefObject<Element>;
-    children: ReactElement;
+    children: ReactElement<any>;
     margin?: number;
     placement?: UsePositionOptions['placement'];
 } & Omit<BoxProps, 'children' | 'margin'>;
@@ -2291,7 +2291,7 @@ export const Sidebar: ((props: SidebarProps) => JSX_2.Element) & {
         large?: boolean;
         } & HTMLAttributes<HTMLDivElement> & RefAttributes<HTMLDivElement>>;
         Action: ForwardRefExoticComponent<    {
-        icon: Keys | ReactElement;
+        icon: Keys | ReactElement<any>;
         primary?: boolean;
         secondary?: boolean;
         info?: boolean;
@@ -2547,7 +2547,7 @@ export const SidebarTopBar: ((input: TopBarProps) => JSX_2.Element) & {
     large?: boolean;
     } & HTMLAttributes<HTMLDivElement> & RefAttributes<HTMLDivElement>>;
     Action: ForwardRefExoticComponent<    {
-    icon: Keys | ReactElement;
+    icon: Keys | ReactElement<any>;
     primary?: boolean;
     secondary?: boolean;
     info?: boolean;
@@ -2588,7 +2588,7 @@ export type SidebarV2AccordionProps = HTMLAttributes<HTMLDivElement>;
 
 // @public (undocumented)
 export const SidebarV2Action: ForwardRefExoticComponent<    {
-icon: Keys | ReactElement;
+icon: Keys | ReactElement<any>;
 primary?: boolean;
 secondary?: boolean;
 info?: boolean;
@@ -2694,7 +2694,7 @@ export const SidebarV2ItemIcon: (input: SidebarV2ItemIconProps) => JSX_2.Element
 
 // @public (undocumented)
 export type SidebarV2ItemIconProps = Omit<IconProps, 'name'> & {
-    icon: Keys | ReactElement;
+    icon: Keys | ReactElement<any>;
     highlighted?: boolean;
 };
 
@@ -3341,7 +3341,7 @@ export const TopBar: (input: TopBarProps) => JSX_2.Element;
 
 // @public (undocumented)
 export const TopBarAction: ForwardRefExoticComponent<    {
-icon: Keys | ReactElement;
+icon: Keys | ReactElement<any>;
 primary?: boolean;
 secondary?: boolean;
 info?: boolean;

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -10,7 +10,6 @@ import type {
   FocusEvent,
   ForwardRefExoticComponent,
   MouseEvent,
-  ReactElement,
   ReactNode,
   Ref,
   RefAttributes,
@@ -269,10 +268,13 @@ const AutoComplete = forwardRef(function AutoComplete<TLabel = ReactNode>(
       </PositionAnimated>
     </Box>
   );
-}) as ForwardRefExoticComponent<AutoCompleteProps> & {
+}) as Pick<
+  ForwardRefExoticComponent<AutoCompleteProps>,
+  keyof ForwardRefExoticComponent<AutoCompleteProps>
+> & {
   <TLabel = ReactNode>(
     props: AutoCompleteProps<TLabel> & RefAttributes<HTMLInputElement>,
-  ): ReactElement;
+  ): ReactNode;
 };
 
 export default AutoComplete;

--- a/packages/fuselage/src/components/Banner/Banner.tsx
+++ b/packages/fuselage/src/components/Banner/Banner.tsx
@@ -58,7 +58,7 @@ const Banner = ({
   variant = 'neutral',
   ...props
 }: BannerProps) => {
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const { inlineSize } = useBorderBoxSize(ref, {
     debounceDelay: 70,
   });

--- a/packages/fuselage/src/components/Button/IconButton.tsx
+++ b/packages/fuselage/src/components/Button/IconButton.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { isValidElement, useMemo, forwardRef } from 'react';
 
 import { Box, type BoxProps } from '../Box';
-import { Icon, type IconProps } from '../Icon';
+import { Icon } from '../Icon';
 
 export type IconButtonSize = {
   large?: boolean;
@@ -14,7 +14,7 @@ export type IconButtonSize = {
 };
 
 export type IconButtonProps = {
-  icon: IconName | ReactElement;
+  icon: IconName | ReactElement<any>;
   primary?: boolean;
   secondary?: boolean;
   info?: boolean;
@@ -124,10 +124,10 @@ const IconButton = forwardRef<HTMLElement, IconButtonProps>(
         ref={ref}
         {...props}
       >
-        {isValidElement(icon) ? (
+        {isValidElement<any>(icon) ? (
           icon
         ) : (
-          <Icon name={icon as IconProps['name']} size={getIconSize()} />
+          <Icon name={icon} size={getIconSize()} />
         )}
         {children}
       </Box>

--- a/packages/fuselage/src/components/Callout/Callout.tsx
+++ b/packages/fuselage/src/components/Callout/Callout.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver } from '@rocket.chat/fuselage-hooks';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 import { Icon, type IconProps } from '../Icon';
@@ -9,7 +9,7 @@ export type CalloutProps = Omit<BoxProps, 'type' | 'name'> & {
   title?: ReactNode;
   children?: ReactNode;
   icon?: IconProps['name'];
-  actions?: ReactElement;
+  actions?: ReactNode;
 };
 
 const WRAPPER_LIMIT_SIZE = 420;

--- a/packages/fuselage/src/components/CheckBox/CheckBox.tsx
+++ b/packages/fuselage/src/components/CheckBox/CheckBox.tsx
@@ -1,5 +1,5 @@
 import { useMergedRefs } from '@rocket.chat/fuselage-hooks';
-import type { FormEvent, AllHTMLAttributes, ReactNode } from 'react';
+import type { AllHTMLAttributes, ChangeEvent, ReactNode } from 'react';
 import { forwardRef, useLayoutEffect, useRef, useCallback } from 'react';
 
 import { Box, type BoxProps } from '../Box';
@@ -23,7 +23,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   }, [innerRef, indeterminate]);
 
   const handleChange = useCallback(
-    (event: FormEvent<HTMLInputElement>) => {
+    (event: ChangeEvent<HTMLInputElement>) => {
       if (innerRef && innerRef.current && indeterminate !== undefined) {
         innerRef.current.indeterminate = indeterminate;
       }

--- a/packages/fuselage/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/fuselage/src/components/Dropdown/Dropdown.stories.tsx
@@ -13,8 +13,8 @@ export default {
 } satisfies Meta<typeof Dropdown>;
 
 export const Default: StoryFn<typeof Dropdown> = () => {
-  const anchor = useRef(null);
-  const target = useRef(null);
+  const anchor = useRef<HTMLElement>(null);
+  const target = useRef<HTMLElement>(null);
 
   const list = Array.from(new Array(20));
 

--- a/packages/fuselage/src/components/InputBox/InputBox.tsx
+++ b/packages/fuselage/src/components/InputBox/InputBox.tsx
@@ -1,5 +1,5 @@
 import { useMergedRefs } from '@rocket.chat/fuselage-hooks';
-import type { FormEvent, ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 import { forwardRef, useCallback, useLayoutEffect, useRef } from 'react';
 
 import type { BoxProps } from '../Box';
@@ -89,7 +89,7 @@ const InputBox = forwardRef<any, InputBoxProps>(function InputBox(
   }, [addon, error]);
 
   const handleChange = useCallback(
-    (event: FormEvent<HTMLElement>) => {
+    (event: ChangeEvent<HTMLElement>) => {
       if (addon && innerRef.current && innerRef.current.parentElement) {
         innerRef.current.parentElement.classList.toggle(
           'invalid',

--- a/packages/fuselage/src/components/Menu/Menu.tsx
+++ b/packages/fuselage/src/components/Menu/Menu.tsx
@@ -50,7 +50,7 @@ const Menu = <T extends object>({
 }: MenuProps<T>) => {
   const state = useMenuTriggerState(props);
 
-  const ref = useRef(null);
+  const ref = useRef<Element>(null);
   const { menuTriggerProps, menuProps } = useMenuTrigger<T>({}, state, ref);
 
   const { buttonProps } = useButton(

--- a/packages/fuselage/src/components/Menu/Menu.tsx
+++ b/packages/fuselage/src/components/Menu/Menu.tsx
@@ -33,7 +33,7 @@ export interface MenuProps<T> extends AriaMenuProps<T>, MenuTriggerProps {
   className?: BoxProps['className'];
   pressed?: boolean;
   maxWidth?: string;
-  button?: ReactElement;
+  button?: ReactElement<any>;
 }
 
 const Menu = <T extends object>({

--- a/packages/fuselage/src/components/Menu/MenuDropdown.tsx
+++ b/packages/fuselage/src/components/Menu/MenuDropdown.tsx
@@ -9,7 +9,7 @@ import MenuSection from './MenuSection';
 function MenuDropDown<T extends object>(props: AriaMenuProps<T>) {
   const state = useTreeState(props);
 
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const { menuProps } = useMenu(props, state, ref);
 
   return (

--- a/packages/fuselage/src/components/Menu/MenuItem.tsx
+++ b/packages/fuselage/src/components/Menu/MenuItem.tsx
@@ -1,4 +1,4 @@
-import type { Node } from '@react-types/shared';
+import type { FocusableElement, Node } from '@react-types/shared';
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
 import { mergeProps, useMenuItem } from 'react-aria';
@@ -17,7 +17,7 @@ type MenuItemProps = {
 };
 
 function MenuItem({ item, state }: MenuItemProps) {
-  const ref = useRef(null);
+  const ref = useRef<FocusableElement>(null);
   const {
     menuItemProps: { onPointerUp, ...menuItemProps },
     isFocused,

--- a/packages/fuselage/src/components/Menu/stately/MenuItem.tsx
+++ b/packages/fuselage/src/components/Menu/stately/MenuItem.tsx
@@ -1,5 +1,5 @@
 import type { ItemProps } from '@react-types/shared';
-import { Children, type ReactElement } from 'react';
+import { Children } from 'react';
 
 import type { PartialNode } from './PartialNode';
 
@@ -48,7 +48,7 @@ MenuItem.getCollectionNode = function* getCollectionNode<T>(
         Children.forEach(children, (child) => {
           items.push({
             type: 'item',
-            element: child as ReactElement,
+            element: child,
           });
         });
 

--- a/packages/fuselage/src/components/Menu/stately/PartialNode.tsx
+++ b/packages/fuselage/src/components/Menu/stately/PartialNode.tsx
@@ -1,16 +1,16 @@
-import { type Key, type ReactElement, type ReactNode } from 'react';
+import { type Key, type ReactNode } from 'react';
 
 export interface PartialNode<T> {
   'type'?: string;
   'key'?: Key;
   'value'?: T;
-  'element'?: ReactElement;
-  'wrapper'?: (element: ReactElement) => ReactElement;
+  'element'?: ReactNode;
+  'wrapper'?: (element: ReactNode) => ReactNode;
   'rendered'?: ReactNode;
   'textValue'?: string;
   'aria-label'?: string;
   'index'?: number;
-  'renderer'?: (item: T) => ReactElement;
+  'renderer'?: (item: T) => ReactNode;
   'hasChildNodes'?: boolean;
   'childNodes'?: () => IterableIterator<PartialNode<T>>;
   'props'?: any;

--- a/packages/fuselage/src/components/Message/MessageGenericPreview/MessageGenericPreviewContent.tsx
+++ b/packages/fuselage/src/components/Message/MessageGenericPreview/MessageGenericPreviewContent.tsx
@@ -1,8 +1,8 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export type MessageGenericPreviewContentProps = {
   children?: ReactNode;
-  thumb?: ReactElement;
+  thumb?: ReactNode;
 };
 
 const MessageGenericPreviewContent = ({

--- a/packages/fuselage/src/components/Message/MessageMetrics/MessageMetricsFollowing.tsx
+++ b/packages/fuselage/src/components/Message/MessageMetrics/MessageMetricsFollowing.tsx
@@ -1,10 +1,10 @@
-import type { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 
 import { IconButton, type IconButtonProps } from '../../Button';
 
 export type MessageMetricsFollowingProps = {
   name: 'bell' | 'bell-off';
-  badge?: ReactElement;
+  badge?: ReactNode;
 } & Omit<IconButtonProps, 'icon'>;
 
 const MessageMetricsFollowing = ({

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedSelectFiltered.tsx
@@ -1,5 +1,5 @@
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
-import type { FormEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { useMemo, forwardRef } from 'react';
 
 import { Input } from '../InputBox';
@@ -32,7 +32,7 @@ const PaginatedSelectFiltered = ({
             ref={ref}
             placeholder={placeholder}
             value={filter}
-            onChange={useStableCallback((e: FormEvent<HTMLInputElement>) => {
+            onChange={useStableCallback((e: ChangeEvent<HTMLInputElement>) => {
               setFilter(e.currentTarget.value);
             })}
             {...props}

--- a/packages/fuselage/src/components/Popover/Popover.stories.tsx
+++ b/packages/fuselage/src/components/Popover/Popover.stories.tsx
@@ -17,7 +17,7 @@ export default {
 } satisfies Meta<typeof Popover>;
 
 const Template: StoryFn<typeof Popover> = (args) => {
-  const ref = useRef(null);
+  const ref = useRef<HTMLAnchorElement | HTMLButtonElement>(null);
   const state = useOverlayTriggerState({});
   const { triggerProps, overlayProps } = useOverlayTrigger(
     { type: 'dialog' },

--- a/packages/fuselage/src/components/Position/Position.tsx
+++ b/packages/fuselage/src/components/Position/Position.tsx
@@ -9,7 +9,7 @@ import type { BoxProps } from '../Box';
 
 export type PositionProps = {
   anchor: RefObject<Element>;
-  children: ReactElement;
+  children: ReactElement<any>;
   margin?: number;
   placement?: UsePositionOptions['placement'];
 } & Omit<BoxProps, 'children' | 'margin'>;

--- a/packages/fuselage/src/components/Position/Position.tsx
+++ b/packages/fuselage/src/components/Position/Position.tsx
@@ -22,7 +22,7 @@ const Position = ({
   className: _className,
   ...props
 }: PositionProps) => {
-  const target = useRef(null);
+  const target = useRef<Element>(null);
   const { style: positionStyle, placement: positionPlacement } =
     usePosition(
       anchor,

--- a/packages/fuselage/src/components/Scrollable/Scrollable.tsx
+++ b/packages/fuselage/src/components/Scrollable/Scrollable.tsx
@@ -52,7 +52,7 @@ const Scrollable = ({
   smooth,
   onScrollContent,
 }: ScrollableProps) => {
-  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const touchingEdgesRef = useRef({});
 
   const handleScroll = useStableCallback((event: MouseEvent) => {

--- a/packages/fuselage/src/components/Select/Listbox.tsx
+++ b/packages/fuselage/src/components/Select/Listbox.tsx
@@ -23,7 +23,7 @@ interface OptionProps {
 }
 
 export function ListBox(props: ListBoxProps) {
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const { listBoxRef = ref, state } = props;
   const { listBoxProps } = useListBox(props, state, listBoxRef);
 

--- a/packages/fuselage/src/components/SelectInput/SelectInput.tsx
+++ b/packages/fuselage/src/components/SelectInput/SelectInput.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent, ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 import { forwardRef, useState, useCallback } from 'react';
 
 import { Icon } from '../Icon';
@@ -27,7 +27,7 @@ const SelectInput = forwardRef<HTMLElement, SelectInputProps>(
       !props.value && !props.defaultValue,
     );
     const handleChange = useCallback(
-      (event: FormEvent<HTMLSelectElement>) => {
+      (event: ChangeEvent<HTMLSelectElement>) => {
         setPlaceholderVisible(!event.currentTarget.value);
         onChange?.call(event.currentTarget, event);
       },

--- a/packages/fuselage/src/components/SidebarV2/SidebarItem/SidebarItemIcon.tsx
+++ b/packages/fuselage/src/components/SidebarV2/SidebarItem/SidebarItemIcon.tsx
@@ -4,7 +4,7 @@ import { isValidElement, type ReactElement } from 'react';
 import { Icon, type IconProps } from '../../Icon';
 
 export type SidebarV2ItemIconProps = Omit<IconProps, 'name'> & {
-  icon: IconKeys | ReactElement;
+  icon: IconKeys | ReactElement<any>;
   highlighted?: boolean;
 };
 

--- a/packages/fuselage/src/components/Slider/Slider.tsx
+++ b/packages/fuselage/src/components/Slider/Slider.tsx
@@ -90,7 +90,7 @@ function Slider<T extends number | [min: number, max: number]>(
     isDisabled: props.disabled,
   } as AriaSliderProps<number | number[]>;
 
-  const trackRef = useRef(null);
+  const trackRef = useRef<HTMLDivElement>(null);
   const numberFormatter = useNumberFormatter(formatOptions);
   const sliderState = useSliderState({
     defaultValue,

--- a/packages/fuselage/src/components/Slider/SliderThumb.tsx
+++ b/packages/fuselage/src/components/Slider/SliderThumb.tsx
@@ -12,7 +12,7 @@ import { useStyle } from '../../hooks/useStyle';
 
 export const SliderThumb = (props: any) => {
   const { state, trackRef, index } = props;
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { thumbProps, inputProps, isDragging } = useSliderThumb(
     {
       index,

--- a/packages/fuselage/src/components/Slider/SliderTrack.tsx
+++ b/packages/fuselage/src/components/Slider/SliderTrack.tsx
@@ -1,5 +1,5 @@
 import { css } from '@rocket.chat/css-in-js';
-import type { DOMAttributes, MutableRefObject, ReactNode } from 'react';
+import type { DOMAttributes, RefObject, ReactNode } from 'react';
 import { useMemo } from 'react';
 import type { SliderState } from 'react-stately';
 
@@ -8,7 +8,7 @@ import { useStyle } from '../../hooks/useStyle';
 
 type SliderTrackProps = {
   trackProps: DOMAttributes<Element>;
-  trackRef: MutableRefObject<null>;
+  trackRef: RefObject<HTMLDivElement>;
   state: SliderState;
   children: ReactNode;
   multiThumb?: boolean;

--- a/packages/fuselage/src/helpers/WithErrorWrapper.tsx
+++ b/packages/fuselage/src/helpers/WithErrorWrapper.tsx
@@ -1,9 +1,9 @@
-import type { Context, ReactElement } from 'react';
+import type { Context, ReactNode } from 'react';
 import { useContext } from 'react';
 
 type WithErrorWrapperProps<T> = {
   context: Context<T>;
-  children: ReactElement;
+  children: ReactNode;
   componentName: string;
   parentComponent: 'Field';
 };

--- a/packages/layout/layout.api.md
+++ b/packages/layout/layout.api.md
@@ -37,7 +37,7 @@ export type ActionLinkProps = {
 
 // @public (undocumented)
 export type AnchorParams = {
-    ref: MutableRefObject<null>;
+    ref: MutableRefObject<Element | null>;
     toggle: Dispatch<SetStateAction<boolean>>;
     id: string;
 };

--- a/packages/layout/layout.api.md
+++ b/packages/layout/layout.api.md
@@ -20,13 +20,13 @@ import { Keys } from '@rocket.chat/icons';
 import { MarginsProps } from '@rocket.chat/fuselage';
 import { MemoExoticComponent } from 'react';
 import type { MutableRefObject } from 'react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RefAttributes } from 'react';
 import type { SetStateAction } from 'react';
 
 // @public (undocumented)
-export const ActionLink: (input: ActionLinkProps) => ReactElement;
+export const ActionLink: (input: ActionLinkProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type ActionLinkProps = {
@@ -48,7 +48,7 @@ justifyContent?: string;
 }, "ref"> & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
-export const BackgroundLayer: (input: BackgroundLayerProps) => ReactElement;
+export const BackgroundLayer: (input: BackgroundLayerProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type BackgroundLayerProps = {
@@ -68,7 +68,7 @@ declare namespace DarkModeProvider {
 export { DarkModeProvider }
 
 // @public (undocumented)
-const DarkModeProvider_2: (input: DarkModeProviderProps) => ReactElement;
+const DarkModeProvider_2: (input: DarkModeProviderProps) => JSX_2.Element;
 
 // @public (undocumented)
 type DarkModeProviderProps = {
@@ -86,7 +86,7 @@ children: ReactNode;
     Header: ForwardRefExoticComponent<Omit<FormHTMLAttributes<HTMLElement>, "is"> & {
     children: ReactNode;
     } & RefAttributes<HTMLElement>>;
-    Steps: (input: FormStepsProps) => ReactElement;
+    Steps: (input: FormStepsProps) => JSX_2.Element;
     Title: ForwardRefExoticComponent<Omit<FormHTMLAttributes<HTMLElement>, "is"> & {
     children: ReactNode;
     } & RefAttributes<HTMLElement>>;
@@ -127,7 +127,7 @@ declare namespace FormPageLayout {
 export { FormPageLayout }
 
 // @public (undocumented)
-export const FormSteps: (input: FormStepsProps) => ReactElement;
+export const FormSteps: (input: FormStepsProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type FormStepsProps = {
@@ -148,40 +148,40 @@ children: ReactNode;
 // @public (undocumented)
 export const HeroLayout: (input: LayoutContextValue & {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HeroLayoutSubtitle: (input: {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HeroLayoutTitle: (input: {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardLayout: (input: LayoutContextValue & {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardLayoutAside: (input: {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardLayoutCaption: (input: {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardLayoutContent: (input: {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
-export const HorizontalWizardLayoutDescription: (props: ComponentProps<typeof FormPageLayout.Description>) => ReactElement;
+export const HorizontalWizardLayoutDescription: (props: ComponentProps<typeof FormPageLayout.Description>) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardLayoutFooter: (input: {
@@ -189,10 +189,10 @@ export const HorizontalWizardLayoutFooter: (input: {
 }) => JSX_2.Element;
 
 // @public (undocumented)
-export const HorizontalWizardLayoutSubtitle: (props: ComponentProps<typeof FormPageLayout.Subtitle>) => ReactElement;
+export const HorizontalWizardLayoutSubtitle: (props: ComponentProps<typeof FormPageLayout.Subtitle>) => JSX_2.Element;
 
 // @public (undocumented)
-export const HorizontalWizardLayoutTitle: (props: ComponentProps<typeof FormPageLayout.Title>) => ReactElement;
+export const HorizontalWizardLayoutTitle: (props: ComponentProps<typeof FormPageLayout.Title>) => JSX_2.Element;
 
 // @public (undocumented)
 export const HorizontalWizardTextHighlight: (props: {
@@ -201,15 +201,15 @@ export const HorizontalWizardTextHighlight: (props: {
 
 // @public (undocumented)
 export type LayoutContextValue = {
-    logo?: ReactElement;
-    logoDark?: ReactElement;
+    logo?: ReactNode;
+    logoDark?: ReactNode;
     background?: string;
     backgroundDark?: string;
     forceDarkMode?: boolean;
 };
 
 // @public (undocumented)
-export const LayoutLogo: () => ReactElement;
+export const LayoutLogo: () => JSX_2.Element;
 
 // @public (undocumented)
 export const List: ((input: {
@@ -230,7 +230,7 @@ export const List: ((input: {
         size?: BoxProps["width"];
         } & RefAttributes<HTMLElement>>>["color"];
         fontScale?: ComponentProps<MemoExoticComponent<ForwardRefExoticComponent<BoxProps & RefAttributes<any>>>>["fontScale"];
-    }) => ReactElement;
+    }) => JSX_2.Element;
 };
 
 // @public (undocumented)
@@ -239,7 +239,7 @@ export const ListItem: (input: {
     icon?: ComponentProps<typeof Icon>["name"];
     iconColor?: ComponentProps<typeof Icon>["color"];
     fontScale?: ComponentProps<typeof Box>["fontScale"];
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 const Logo: ForwardRefExoticComponent<Omit<ClassAttributes<HTMLDivElement> & HTMLAttributes<HTMLDivElement>, "ref"> & RefAttributes<HTMLDivElement>>;
@@ -260,11 +260,11 @@ isDark?: boolean;
 }, "ref"> & RefAttributes<HTMLSpanElement>>;
 
 // @public (undocumented)
-export const TooltipWrapper: (input: TooltipWrapperProps) => ReactElement;
+export const TooltipWrapper: (input: TooltipWrapperProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type TooltipWrapperProps = {
-    children: ReactElement | ((props: AnchorParams) => ReactNode);
+    children: ReactElement<any> | ((props: AnchorParams) => ReactNode);
     text: string;
 };
 
@@ -274,7 +274,7 @@ const useDarkMode: () => boolean;
 // @public (undocumented)
 export const VerticalWizardLayout: (input: LayoutContextValue & {
     children: ReactNode;
-}) => ReactElement;
+}) => JSX_2.Element;
 
 // @public (undocumented)
 export const VerticalWizardLayoutFooter: (input: {

--- a/packages/layout/src/DarkModeProvider.tsx
+++ b/packages/layout/src/DarkModeProvider.tsx
@@ -1,5 +1,5 @@
 import { useDarkMode as useDarkModeFuselage } from '@rocket.chat/fuselage-hooks';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';
 
 const DarkModeContext = createContext(true);
@@ -12,7 +12,7 @@ export type DarkModeProviderProps = {
 const DarkModeProvider = ({
   children,
   forcedDarkMode,
-}: DarkModeProviderProps): ReactElement => {
+}: DarkModeProviderProps) => {
   const value = useDarkModeFuselage(forcedDarkMode);
   return <DarkModeContext.Provider children={children} value={value} />;
 };

--- a/packages/layout/src/components/ActionLink/ActionLink.tsx
+++ b/packages/layout/src/components/ActionLink/ActionLink.tsx
@@ -2,7 +2,6 @@ import { Box } from '@rocket.chat/fuselage';
 import type {
   MouseEvent,
   ComponentProps,
-  ReactElement,
   ReactNode,
   AnchorHTMLAttributes,
 } from 'react';
@@ -19,7 +18,7 @@ const ActionLink = ({
   href = '#',
   onClick,
   ...props
-}: ActionLinkProps): ReactElement => {
+}: ActionLinkProps) => {
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>) => {
       if (onClick) {

--- a/packages/layout/src/components/BackgroundLayer/BackgroundLayer.tsx
+++ b/packages/layout/src/components/BackgroundLayer/BackgroundLayer.tsx
@@ -1,5 +1,5 @@
 import colors from '@rocket.chat/fuselage-tokens/colors.json';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -13,7 +13,7 @@ export type BackgroundLayerProps = {
   children?: ReactNode;
 };
 
-const BackgroundLayer = ({ children }: BackgroundLayerProps): ReactElement => {
+const BackgroundLayer = ({ children }: BackgroundLayerProps) => {
   const { background, backgroundDark = background } = useLayoutContext();
   const darkMode = useDarkMode();
   const backgroundColor = darkMode ? colors.n800 : colors.n200;

--- a/packages/layout/src/components/FormPageLayout/Form.tsx
+++ b/packages/layout/src/components/FormPageLayout/Form.tsx
@@ -1,5 +1,5 @@
 import { Tile } from '@rocket.chat/fuselage';
-import type { ReactElement, FormHTMLAttributes, ReactNode } from 'react';
+import type { FormHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
 const Form = forwardRef<
@@ -7,20 +7,18 @@ const Form = forwardRef<
   Omit<FormHTMLAttributes<HTMLFormElement>, 'is'> & {
     children: ReactNode;
   }
->(
-  ({ ...props }, ref): ReactElement => (
-    <Tile
-      ref={ref}
-      is='form'
-      backgroundColor='light'
-      color='default'
-      padding={40}
-      width='full'
-      maxWidth={576}
-      textAlign='left'
-      {...props}
-    />
-  ),
-);
+>(({ ...props }, ref) => (
+  <Tile
+    ref={ref}
+    is='form'
+    backgroundColor='light'
+    color='default'
+    padding={40}
+    width='full'
+    maxWidth={576}
+    textAlign='left'
+    {...props}
+  />
+));
 
 export default Form;

--- a/packages/layout/src/components/FormPageLayout/FormSteps.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormSteps.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type FormStepsProps = {
@@ -7,10 +6,7 @@ export type FormStepsProps = {
   stepCount: number;
 };
 
-const FormSteps = ({
-  currentStep,
-  stepCount,
-}: FormStepsProps): ReactElement => {
+const FormSteps = ({ currentStep, stepCount }: FormStepsProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/layout/src/components/LayoutLogo/LayoutLogo.tsx
+++ b/packages/layout/src/components/LayoutLogo/LayoutLogo.tsx
@@ -1,11 +1,10 @@
 import { Box } from '@rocket.chat/fuselage';
 import { RocketChatLogo } from '@rocket.chat/logo';
-import type { ReactElement } from 'react';
 
 import { useDarkMode } from '../../DarkModeProvider';
 import { useLayoutContext } from '../../contexts/LayoutContext';
 
-const LayoutLogo = (): ReactElement => {
+const LayoutLogo = () => {
   const { logo, logoDark = logo } = useLayoutContext();
   const isDark = useDarkMode();
   return (

--- a/packages/layout/src/components/List/ListItem.tsx
+++ b/packages/layout/src/components/List/ListItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Icon } from '@rocket.chat/fuselage';
-import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 const ListItem = ({
   children,
@@ -11,7 +11,7 @@ const ListItem = ({
   icon?: ComponentProps<typeof Icon>['name'];
   iconColor?: ComponentProps<typeof Icon>['color'];
   fontScale?: ComponentProps<typeof Box>['fontScale'];
-}): ReactElement => (
+}) => (
   <Box display='flex' is='li' fontScale={fontScale}>
     {icon && <Icon name={icon} color={iconColor} size='x16' mie={4} />}
     {children}

--- a/packages/layout/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/layout/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -23,7 +23,7 @@ import {
 } from 'react';
 
 export type AnchorParams = {
-  ref: MutableRefObject<null>;
+  ref: MutableRefObject<Element | null>;
   toggle: Dispatch<SetStateAction<boolean>>;
   id: string;
 };
@@ -64,7 +64,7 @@ export type TooltipWrapperProps = {
 };
 
 const TooltipWrapper = ({ children, text }: TooltipWrapperProps) => {
-  const anchorRef = useRef(null);
+  const anchorRef = useRef<Element>(null);
   const [open, setOpen] = useDebouncedState(false, 460);
   const toggle = useCallback(
     (open: SetStateAction<boolean>) => {

--- a/packages/layout/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/layout/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -29,7 +29,7 @@ export type AnchorParams = {
 };
 
 const getAnchor = (
-  children: ReactElement | ((props: AnchorParams) => ReactNode),
+  children: ReactElement<any> | ((props: AnchorParams) => ReactNode),
   params: AnchorParams,
 ): ReactNode => {
   if (typeof children === 'function') {
@@ -50,7 +50,7 @@ const getAnchor = (
 const InnerTooltip = forwardRef(function InnerTooltip(
   { style, ...props }: ComponentProps<typeof Tooltip>,
   ref: Ref<HTMLDivElement>,
-): ReactElement {
+) {
   return (
     <div ref={ref} style={style}>
       <Tooltip {...props} />
@@ -59,14 +59,11 @@ const InnerTooltip = forwardRef(function InnerTooltip(
 });
 
 export type TooltipWrapperProps = {
-  children: ReactElement | ((props: AnchorParams) => ReactNode);
+  children: ReactElement<any> | ((props: AnchorParams) => ReactNode);
   text: string;
 };
 
-const TooltipWrapper = ({
-  children,
-  text,
-}: TooltipWrapperProps): ReactElement => {
+const TooltipWrapper = ({ children, text }: TooltipWrapperProps) => {
   const anchorRef = useRef(null);
   const [open, setOpen] = useDebouncedState(false, 460);
   const toggle = useCallback(

--- a/packages/layout/src/contexts/LayoutContext.ts
+++ b/packages/layout/src/contexts/LayoutContext.ts
@@ -1,9 +1,9 @@
-import type { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';
 
 export type LayoutContextValue = {
-  logo?: ReactElement;
-  logoDark?: ReactElement;
+  logo?: ReactNode;
+  logoDark?: ReactNode;
   background?: string;
   backgroundDark?: string;
   forceDarkMode?: boolean;

--- a/packages/layout/src/layouts/HeroLayout/HeroLayout.tsx
+++ b/packages/layout/src/layouts/HeroLayout/HeroLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Margins } from '@rocket.chat/fuselage';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import DarkModeProvider from '../../DarkModeProvider';
 import BackgroundLayer from '../../components/BackgroundLayer';
@@ -13,7 +13,7 @@ const HeroLayout = ({
   ...rest
 }: LayoutContextValue & {
   children: ReactNode;
-}): ReactElement => (
+}) => (
   <DarkModeProvider forcedDarkMode={forceDarkMode}>
     <LayoutContext.Provider value={{ ...rest }}>
       <BackgroundLayer>

--- a/packages/layout/src/layouts/HeroLayout/HeroLayoutSubtitle.tsx
+++ b/packages/layout/src/layouts/HeroLayout/HeroLayoutSubtitle.tsx
@@ -1,10 +1,8 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
-const HeroLayoutSubtitle = ({
-  children,
-}: {
-  children: ReactNode;
-}): ReactElement => <Box fontScale='p1'>{children}</Box>;
+const HeroLayoutSubtitle = ({ children }: { children: ReactNode }) => (
+  <Box fontScale='p1'>{children}</Box>
+);
 
 export default HeroLayoutSubtitle;

--- a/packages/layout/src/layouts/HeroLayout/HeroLayoutTitle.tsx
+++ b/packages/layout/src/layouts/HeroLayout/HeroLayoutTitle.tsx
@@ -1,10 +1,8 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
-const HeroLayoutTitle = ({
-  children,
-}: {
-  children: ReactNode;
-}): ReactElement => <Box fontScale='hero'>{children}</Box>;
+const HeroLayoutTitle = ({ children }: { children: ReactNode }) => (
+  <Box fontScale='hero'>{children}</Box>
+);
 
 export default HeroLayoutTitle;

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayout.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import DarkModeProvider from '../../DarkModeProvider';
 import BackgroundLayer from '../../components/BackgroundLayer';
@@ -12,7 +12,7 @@ const HorizontalWizardLayout = ({
   ...rest
 }: LayoutContextValue & {
   children: ReactNode;
-}): ReactElement => (
+}) => (
   <DarkModeProvider forcedDarkMode={forceDarkMode}>
     <LayoutContext.Provider value={{ ...rest }}>
       <BackgroundLayer>

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutAside.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutAside.tsx
@@ -1,13 +1,9 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import * as FormPageLayout from '../../components/FormPageLayout/FormPageLayout.styles';
 import LayoutLogo from '../../components/LayoutLogo';
 
-const HorizontalWizardLayoutAside = ({
-  children,
-}: {
-  children: ReactNode;
-}): ReactElement => (
+const HorizontalWizardLayoutAside = ({ children }: { children: ReactNode }) => (
   <FormPageLayout.Aside>
     <FormPageLayout.Logo>
       <LayoutLogo />

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutCaption.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutCaption.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { useDarkMode } from '../../DarkModeProvider';
 
@@ -7,7 +7,7 @@ const HorizontalWizardLayoutCaption = ({
   children,
 }: {
   children: ReactNode;
-}): ReactElement => {
+}) => {
   const isDark = useDarkMode();
   return (
     <Box

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutContent.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutContent.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import * as FormPageLayout from '../../components/FormPageLayout/FormPageLayout.styles';
 
@@ -6,6 +6,6 @@ const HorizontalWizardLayoutContent = ({
   children,
 }: {
   children: ReactNode;
-}): ReactElement => <FormPageLayout.Content>{children}</FormPageLayout.Content>;
+}) => <FormPageLayout.Content>{children}</FormPageLayout.Content>;
 
 export default HorizontalWizardLayoutContent;

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutDescription.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutDescription.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 
 import * as FormPageLayout from '../../components/FormPageLayout/FormPageLayout.styles';
 
 const HorizontalWizardLayoutDescription = (
   props: ComponentProps<typeof FormPageLayout.Description>,
-): ReactElement => <FormPageLayout.Description {...props} />;
+) => <FormPageLayout.Description {...props} />;
 
 export default HorizontalWizardLayoutDescription;

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutSubtitle.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutSubtitle.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 
 import * as FormPageLayout from '../../components/FormPageLayout/FormPageLayout.styles';
 
 const HorizontalWizardLayoutSubtitle = (
   props: ComponentProps<typeof FormPageLayout.Subtitle>,
-): ReactElement => <FormPageLayout.Subtitle {...props} />;
+) => <FormPageLayout.Subtitle {...props} />;
 
 export default HorizontalWizardLayoutSubtitle;

--- a/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutTitle.tsx
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/HorizontalWizardLayoutTitle.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 
 import * as FormPageLayout from '../../components/FormPageLayout/FormPageLayout.styles';
 
 const HorizontalWizardLayoutTitle = (
   props: ComponentProps<typeof FormPageLayout.Title>,
-): ReactElement => <FormPageLayout.Title {...props} />;
+) => <FormPageLayout.Title {...props} />;
 
 export default HorizontalWizardLayoutTitle;

--- a/packages/layout/src/layouts/VerticalWizardLayout/VerticalWizardLayout.tsx
+++ b/packages/layout/src/layouts/VerticalWizardLayout/VerticalWizardLayout.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import DarkModeProvider from '../../DarkModeProvider';
 import BackgroundLayer from '../../components/BackgroundLayer';
@@ -13,7 +13,7 @@ const VerticalWizardLayout = ({
   ...rest
 }: LayoutContextValue & {
   children: ReactNode;
-}): ReactElement => (
+}) => (
   <DarkModeProvider forcedDarkMode={forceDarkMode}>
     <LayoutContext.Provider value={{ ...rest }}>
       <BackgroundLayer>

--- a/packages/logo/src/RocketChatLogo/RocketChatLogo.tsx
+++ b/packages/logo/src/RocketChatLogo/RocketChatLogo.tsx
@@ -1,13 +1,11 @@
 import colors from '@rocket.chat/fuselage-tokens/colors.json';
-import { useId, type ReactElement, type SVGAttributes } from 'react';
+import { useId, type SVGAttributes } from 'react';
 
 type RocketChatLogoProps = {
   color?: SVGAttributes<SVGSVGElement>['fill'];
 };
 
-const RocketChatLogo = ({
-  color = colors.r400,
-}: RocketChatLogoProps): ReactElement => {
+const RocketChatLogo = ({ color = colors.r400 }: RocketChatLogoProps) => {
   const titleId = useId();
 
   return (

--- a/packages/logo/src/TaggedRocketChatLogo/TaggedRocketChatLogo.tsx
+++ b/packages/logo/src/TaggedRocketChatLogo/TaggedRocketChatLogo.tsx
@@ -1,5 +1,5 @@
 import colors from '@rocket.chat/fuselage-tokens/colors.json';
-import type { HTMLAttributes, ReactElement } from 'react';
+import type { HTMLAttributes } from 'react';
 
 import RocketChatLogo from '../RocketChatLogo';
 
@@ -16,7 +16,7 @@ const TaggedRocketChatLogo = ({
   tagBackground = colors.r400,
   color = colors.white,
   ...props
-}: TaggedRocketChatLogoProps): ReactElement => (
+}: TaggedRocketChatLogoProps) => (
   <LogoContainer {...props}>
     <RocketChatLogo />
     {tagTitle && (

--- a/packages/onboarding-ui/onboarding-ui.api.md
+++ b/packages/onboarding-ui/onboarding-ui.api.md
@@ -6,14 +6,14 @@
 
 import type { ComponentProps } from 'react';
 import type { FieldPathValue } from 'react-hook-form';
-import type { ReactElement } from 'react';
+import { JSX as JSX_2 } from 'react/jsx-runtime';
 import type { ReactNode } from 'react';
 import type { SelectOption } from '@rocket.chat/fuselage';
 import type { SubmitHandler } from 'react-hook-form';
 import type { Validate } from 'react-hook-form';
 
 // @public (undocumented)
-export const AdminInfoPage: (input: AdminInfoPageProps) => ReactElement;
+export const AdminInfoPage: (input: AdminInfoPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type AdminInfoPageProps = {
@@ -40,7 +40,7 @@ export type AdminInfoPayload = {
 };
 
 // @public (undocumented)
-export const AwaitingConfirmationPage: (input: AwaitingConfirmationPageProps) => ReactElement;
+export const AwaitingConfirmationPage: (input: AwaitingConfirmationPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type AwaitingConfirmationPageProps = {
@@ -55,7 +55,7 @@ export type AwaitingConfirmationPageProps = {
 };
 
 // @public (undocumented)
-export const CheckYourEmailPage: (input: CheckYourEmailPageProps) => ReactElement;
+export const CheckYourEmailPage: (input: CheckYourEmailPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CheckYourEmailPageProps = {
@@ -66,10 +66,10 @@ export type CheckYourEmailPageProps = {
 };
 
 // @public (undocumented)
-export const ConfirmationProcessPage: () => ReactElement;
+export const ConfirmationProcessPage: () => JSX_2.Element;
 
 // @public (undocumented)
-export const CreateCloudWorkspaceForm: (input: CreateCloudWorkspaceFormProps) => ReactElement;
+export const CreateCloudWorkspaceForm: (input: CreateCloudWorkspaceFormProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateCloudWorkspaceFormPayload = {
@@ -95,13 +95,13 @@ export type CreateCloudWorkspaceFormProps = {
 };
 
 // @public (undocumented)
-export const CreateCloudWorkspacePage: (props: CreateCloudWorkspacePageProps) => ReactElement;
+export const CreateCloudWorkspacePage: (props: CreateCloudWorkspacePageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateCloudWorkspacePageProps = ComponentProps<typeof CreateCloudWorkspaceForm>;
 
 // @public (undocumented)
-export const CreateFirstMemberForm: (input: CreateFirstMemberFormProps) => ReactElement;
+export const CreateFirstMemberForm: (input: CreateFirstMemberFormProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateFirstMemberFormPayload = {
@@ -122,13 +122,13 @@ export type CreateFirstMemberFormProps = {
 };
 
 // @public (undocumented)
-export const CreateFirstMemberPage: (props: CreateFirstMemberPageProps) => ReactElement;
+export const CreateFirstMemberPage: (props: CreateFirstMemberPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateFirstMemberPageProps = ComponentProps<typeof CreateFirstMemberForm>;
 
 // @public (undocumented)
-export const CreateNewAccountPage: (input: CreateNewAccountPageProps) => ReactElement;
+export const CreateNewAccountPage: (input: CreateNewAccountPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateNewAccountPageProps = {
@@ -141,7 +141,7 @@ export type CreateNewAccountPageProps = {
 };
 
 // @public (undocumented)
-export const CreateNewPasswordPage: (input: CreateNewPasswordPageProps) => ReactElement;
+export const CreateNewPasswordPage: (input: CreateNewPasswordPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type CreateNewPasswordPageProps = {
@@ -159,10 +159,10 @@ export type CreateNewPasswordPayload = {
 };
 
 // @public (undocumented)
-export const EmailConfirmedPage: () => ReactElement;
+export const EmailConfirmedPage: () => JSX_2.Element;
 
 // @public (undocumented)
-export const InformationPage: (input: InformationPageProps) => ReactElement;
+export const InformationPage: (input: InformationPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type InformationPageProps = {
@@ -171,7 +171,7 @@ export type InformationPageProps = {
 };
 
 // @public (undocumented)
-export const InvalidLinkPage: (input: InvalidLinkPageProps) => ReactElement;
+export const InvalidLinkPage: (input: InvalidLinkPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type InvalidLinkPageProps = {
@@ -179,7 +179,7 @@ export type InvalidLinkPageProps = {
 };
 
 // @public (undocumented)
-export const LoaderPage: (input: LoaderPageProps) => ReactElement;
+export const LoaderPage: (input: LoaderPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type LoaderPageProps = {
@@ -196,7 +196,7 @@ export type LoginFormPayload = {
 };
 
 // @public (undocumented)
-export const LoginLinkEmailPage: (input: LoginLinkEmailProps) => ReactElement;
+export const LoginLinkEmailPage: (input: LoginLinkEmailProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type LoginLinkEmailProps = {
@@ -205,7 +205,7 @@ export type LoginLinkEmailProps = {
 };
 
 // @public (undocumented)
-export const LoginPage: (input: LoginPageProps) => ReactElement;
+export const LoginPage: (input: LoginPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type LoginPageProps = {
@@ -230,7 +230,7 @@ export type NewAccountPayload = {
 };
 
 // @public (undocumented)
-export const OauthAuthorizationPage: (input: OauthAuthorizationPageProps) => ReactElement;
+export const OauthAuthorizationPage: (input: OauthAuthorizationPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type OauthAuthorizationPageProps = {
@@ -243,7 +243,7 @@ export type OauthAuthorizationPageProps = {
 };
 
 // @public (undocumented)
-export const OrganizationInfoPage: (input: OrganizationInfoPageProps) => ReactElement;
+export const OrganizationInfoPage: (input: OrganizationInfoPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type OrganizationInfoPageProps = {
@@ -271,7 +271,7 @@ export type OrganizationInfoPayload = {
 };
 
 // @public (undocumented)
-export const RedirectPage: (input: RedirectPageProps) => ReactElement;
+export const RedirectPage: (input: RedirectPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type RedirectPageProps = {
@@ -281,7 +281,7 @@ export type RedirectPageProps = {
 };
 
 // @public (undocumented)
-export const RegisterOfflinePage: (props: RegisterOfflinePageProps) => ReactElement;
+export const RegisterOfflinePage: (props: RegisterOfflinePageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type RegisterOfflinePageProps = {
@@ -300,7 +300,7 @@ export type RegisterOfflinePayload = {
 };
 
 // @public (undocumented)
-export const RegisterServerPage: (props: RegisterServerPageProps) => ReactElement;
+export const RegisterServerPage: (props: RegisterServerPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type RegisterServerPageProps = {
@@ -323,7 +323,7 @@ export type RegisterServerPayload = {
 };
 
 // @public (undocumented)
-export const RequestTrialForm: (input: RequestTrialFormProps) => ReactElement;
+export const RequestTrialForm: (input: RequestTrialFormProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type RequestTrialFormProps = {
@@ -338,7 +338,7 @@ export type RequestTrialFormProps = {
 };
 
 // @public (undocumented)
-export const RequestTrialPage: (props: RequestTrialPageProps) => ReactElement;
+export const RequestTrialPage: (props: RequestTrialPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type RequestTrialPageProps = ComponentProps<typeof RequestTrialForm>;
@@ -354,7 +354,7 @@ export type RequestTrialPayload = {
 };
 
 // @public (undocumented)
-export const ResetPasswordConfirmationPage: () => ReactElement;
+export const ResetPasswordConfirmationPage: () => JSX_2.Element;
 
 // @public (undocumented)
 export type ResetPasswordFormPayload = {
@@ -362,7 +362,7 @@ export type ResetPasswordFormPayload = {
 };
 
 // @public (undocumented)
-export const ResetPasswordPage: (input: ResetPasswordPageProps) => ReactElement;
+export const ResetPasswordPage: (input: ResetPasswordPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type ResetPasswordPageProps = {
@@ -373,7 +373,7 @@ export type ResetPasswordPageProps = {
 };
 
 // @public (undocumented)
-export const SomethingWentWrongPage: (input: SomethingWentWrongPageProps) => ReactElement;
+export const SomethingWentWrongPage: (input: SomethingWentWrongPageProps) => JSX_2.Element;
 
 // @public (undocumented)
 export type SomethingWentWrongPageProps = {

--- a/packages/onboarding-ui/src/common/EmailCodeFallback.tsx
+++ b/packages/onboarding-ui/src/common/EmailCodeFallback.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@rocket.chat/fuselage';
 import { ActionLink } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans } from 'react-i18next';
 
 type EmailCodeFallbackProps = {
@@ -11,7 +10,7 @@ type EmailCodeFallbackProps = {
 const EmailCodeFallback = ({
   onResendEmailRequest,
   onChangeEmailRequest,
-}: EmailCodeFallbackProps): ReactElement => (
+}: EmailCodeFallbackProps) => (
   <Box fontScale='p2'>
     <Trans i18nKey='component.emailCodeFallback'>
       Didn’t receive email?

--- a/packages/onboarding-ui/src/common/FormPageLayout.tsx
+++ b/packages/onboarding-ui/src/common/FormPageLayout.tsx
@@ -6,7 +6,7 @@ import {
   HorizontalWizardLayoutDescription,
   HorizontalWizardLayoutContent,
 } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // import { OnboardingLogo } from './OnboardingLogo';
@@ -27,7 +27,7 @@ const FormPageLayoutOnboard = ({
   subtitle,
   description,
   children,
-}: FormPageLayoutProps): ReactElement => {
+}: FormPageLayoutProps) => {
   const { t } = useTranslation();
   return (
     <HorizontalWizardLayout>

--- a/packages/onboarding-ui/src/common/InformationTooltipTrigger.tsx
+++ b/packages/onboarding-ui/src/common/InformationTooltipTrigger.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '@rocket.chat/fuselage';
 import { TooltipWrapper } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 
 type InformationTooltipTriggerProps = {
   text: string;
@@ -8,7 +7,7 @@ type InformationTooltipTriggerProps = {
 
 const InformationTooltipTrigger = ({
   text,
-}: InformationTooltipTriggerProps): ReactElement => (
+}: InformationTooltipTriggerProps) => (
   <TooltipWrapper text={text}>
     <Icon name='info' />
   </TooltipWrapper>

--- a/packages/onboarding-ui/src/common/PlanFeatureIcon.tsx
+++ b/packages/onboarding-ui/src/common/PlanFeatureIcon.tsx
@@ -1,6 +1,4 @@
-import type { ReactElement } from 'react';
-
-const PlanFeatureIcon = ({ color }: { color: string }): ReactElement => (
+const PlanFeatureIcon = ({ color }: { color: string }) => (
   <svg
     width='13'
     height='auto'

--- a/packages/onboarding-ui/src/forms/AdminInfoForm/AdminInfoForm.tsx
+++ b/packages/onboarding-ui/src/forms/AdminInfoForm/AdminInfoForm.tsx
@@ -14,7 +14,6 @@ import {
   FieldHint,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useRef, useEffect, useId } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm, Controller } from 'react-hook-form';
@@ -59,7 +58,7 @@ const AdminInfoForm = ({
   validatePassword,
   keepPosted = false,
   onSubmit,
-}: AdminInfoFormProps): ReactElement => {
+}: AdminInfoFormProps) => {
   const { t } = useTranslation();
 
   const formId = useId();

--- a/packages/onboarding-ui/src/forms/AwaitConfirmationForm/AwaitConfirmationForm.tsx
+++ b/packages/onboarding-ui/src/forms/AwaitConfirmationForm/AwaitConfirmationForm.tsx
@@ -1,6 +1,5 @@
 import { Box, Label } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import EmailCodeFallback from '../../common/EmailCodeFallback';
@@ -21,7 +20,7 @@ const AwaitingConfirmationForm = ({
   emailAddress,
   onResendEmailRequest,
   onChangeEmailRequest,
-}: AwaitingConfirmationFormProps): ReactElement => {
+}: AwaitingConfirmationFormProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/forms/CreateCloudWorkspaceForm/CreateCloudWorkspaceForm.tsx
+++ b/packages/onboarding-ui/src/forms/CreateCloudWorkspaceForm/CreateCloudWorkspaceForm.tsx
@@ -16,7 +16,7 @@ import {
   Grid,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement, FocusEvent } from 'react';
+import type { FocusEvent } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation, Trans } from 'react-i18next';
@@ -61,7 +61,7 @@ export const CreateCloudWorkspaceForm = ({
   onBackButtonClick,
   validateUrl,
   validateEmail,
-}: CreateCloudWorkspaceFormProps): ReactElement => {
+}: CreateCloudWorkspaceFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/CreateFirstMemberForm/CreateFirstMemberForm.tsx
+++ b/packages/onboarding-ui/src/forms/CreateFirstMemberForm/CreateFirstMemberForm.tsx
@@ -12,7 +12,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -48,7 +47,7 @@ export const CreateFirstMemberForm = ({
   onBackButtonClick,
   validateUsername,
   validatePassword,
-}: CreateFirstMemberFormProps): ReactElement => {
+}: CreateFirstMemberFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/CreateNewPassword/CreateNewPassword.tsx
+++ b/packages/onboarding-ui/src/forms/CreateNewPassword/CreateNewPassword.tsx
@@ -9,7 +9,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -37,7 +36,7 @@ const CreateNewPassword = ({
   validatePassword,
   validatePasswordConfirmation,
   initialValues,
-}: CreateNewPasswordProps): ReactElement => {
+}: CreateNewPasswordProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/LoginForm/LoginForm.tsx
+++ b/packages/onboarding-ui/src/forms/LoginForm/LoginForm.tsx
@@ -10,7 +10,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { Form, ActionLink } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
@@ -38,7 +37,7 @@ const LoginForm = ({
   onChangeForm,
   onResetPassword,
   formError,
-}: LoginFormProps): ReactElement => {
+}: LoginFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/NewAccountForm/NewAccountForm.tsx
+++ b/packages/onboarding-ui/src/forms/NewAccountForm/NewAccountForm.tsx
@@ -13,7 +13,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useEffect } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
@@ -49,7 +48,7 @@ const NewAccountForm = ({
   validatePassword,
   validateConfirmationPassword,
   onSubmit,
-}: NewAccountFormProps): ReactElement => {
+}: NewAccountFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/OrganizationInfoForm/OrganizationInfoForm.tsx
+++ b/packages/onboarding-ui/src/forms/OrganizationInfoForm/OrganizationInfoForm.tsx
@@ -13,7 +13,7 @@ import {
 } from '@rocket.chat/fuselage';
 import { useBreakpoints } from '@rocket.chat/fuselage-hooks';
 import { ActionLink, Form } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useRef, useEffect, useId } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm, Controller } from 'react-hook-form';
@@ -50,7 +50,7 @@ const OrganizationInfoForm = ({
   onSubmit,
   onBackButtonClick,
   onClickSkip,
-}: OrganizationInfoFormProps): ReactElement => {
+}: OrganizationInfoFormProps) => {
   const { t } = useTranslation();
   const breakpoints = useBreakpoints();
   const isMobile = !breakpoints.includes('md');

--- a/packages/onboarding-ui/src/forms/RegisterOfflineForm/RegisterOfflineForm.tsx
+++ b/packages/onboarding-ui/src/forms/RegisterOfflineForm/RegisterOfflineForm.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@rocket.chat/layout';
-import { useState, type ReactElement } from 'react';
+import { useState } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -33,7 +33,7 @@ const RegisterOfflineForm = ({
   onSubmit,
   onCopySecurityCode,
   onBackButtonClick,
-}: RegisterOfflineFormProps): ReactElement => {
+}: RegisterOfflineFormProps) => {
   const { t } = useTranslation();
 
   const [step, setStep] = useState(Steps.COPY);

--- a/packages/onboarding-ui/src/forms/RegisterOfflineForm/steps/CopyStep.tsx
+++ b/packages/onboarding-ui/src/forms/RegisterOfflineForm/steps/CopyStep.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, ButtonGroup, Scrollable } from '@rocket.chat/fuselage';
 import { useBreakpoints, useClipboard } from '@rocket.chat/fuselage-hooks';
 import { Form } from '@rocket.chat/layout';
-import { useId, type ReactElement } from 'react';
+import { useId } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -24,7 +24,7 @@ const CopyStep = ({
   setStep,
   onCopySecurityCode,
   onBackButtonClick,
-}: CopyStepProps): ReactElement => {
+}: CopyStepProps) => {
   const { t } = useTranslation();
   const agreementField = useId();
   const breakpoints = useBreakpoints();

--- a/packages/onboarding-ui/src/forms/RegisterOfflineForm/steps/PasteStep.tsx
+++ b/packages/onboarding-ui/src/forms/RegisterOfflineForm/steps/PasteStep.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, ButtonGroup, Scrollable } from '@rocket.chat/fuselage';
 import { useBreakpoints } from '@rocket.chat/fuselage-hooks';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -11,7 +10,7 @@ type PasteStepProps = {
   setStep: (step: string) => void;
 };
 
-const PasteStep = ({ setStep }: PasteStepProps): ReactElement => {
+const PasteStep = ({ setStep }: PasteStepProps) => {
   const { t } = useTranslation();
   const breakpoints = useBreakpoints();
   const isMobile = !breakpoints.includes('md');

--- a/packages/onboarding-ui/src/forms/RegisterServerForm/RegisterServerForm.tsx
+++ b/packages/onboarding-ui/src/forms/RegisterServerForm/RegisterServerForm.tsx
@@ -11,7 +11,6 @@ import {
 } from '@rocket.chat/fuselage';
 import { useBreakpoints } from '@rocket.chat/fuselage-hooks';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useEffect, useId, useRef } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { Controller, useForm, FormProvider } from 'react-hook-form';
@@ -50,7 +49,7 @@ const RegisterServerForm = ({
   termsHref = 'https://rocket.chat/terms',
   policyHref = 'https://rocket.chat/privacy',
   onClickRegisterOffline,
-}: RegisterServerFormProps): ReactElement => {
+}: RegisterServerFormProps) => {
   const { t } = useTranslation();
 
   const formId = useId();

--- a/packages/onboarding-ui/src/forms/RequestTrialForm/RequestTrialForm.tsx
+++ b/packages/onboarding-ui/src/forms/RequestTrialForm/RequestTrialForm.tsx
@@ -15,7 +15,6 @@ import {
   SelectFiltered,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation, Trans } from 'react-i18next';
@@ -51,7 +50,7 @@ export const RequestTrialForm = ({
   validateEmail,
   termsHref = 'https://rocket.chat/terms',
   policyHref = 'https://rocket.chat/privacy',
-}: RequestTrialFormProps): ReactElement => {
+}: RequestTrialFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/packages/onboarding-ui/src/forms/ResetPasswordForm/ResetPasswordForm.tsx
@@ -10,7 +10,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -32,7 +31,7 @@ const ResetPasswordForm = ({
   onSubmit,
   validateEmail,
   initialValues,
-}: ResetPasswordFormProps): ReactElement => {
+}: ResetPasswordFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/forms/TotpForm/TotpForm.tsx
+++ b/packages/onboarding-ui/src/forms/TotpForm/TotpForm.tsx
@@ -9,7 +9,6 @@ import {
   FieldError,
 } from '@rocket.chat/fuselage';
 import { ActionLink, Form } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +33,7 @@ const TotpForm = ({
   initialValues,
   isBackupCode = false,
   onChangeTotpForm,
-}: TotpFormProps): ReactElement => {
+}: TotpFormProps) => {
   const { t } = useTranslation();
 
   const {

--- a/packages/onboarding-ui/src/pages/AdminInfoPage/AdminInfoPage.tsx
+++ b/packages/onboarding-ui/src/pages/AdminInfoPage/AdminInfoPage.tsx
@@ -1,5 +1,5 @@
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
@@ -38,7 +38,7 @@ const AdminInfoPage = ({
   title,
   description,
   ...props
-}: AdminInfoPageProps): ReactElement => (
+}: AdminInfoPageProps) => (
   <BackgroundLayer>
     <FormPageLayout
       title={title}

--- a/packages/onboarding-ui/src/pages/AwaitingConfirmationPage/AwaitingConfirmationPage.tsx
+++ b/packages/onboarding-ui/src/pages/AwaitingConfirmationPage/AwaitingConfirmationPage.tsx
@@ -1,5 +1,5 @@
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
 import FormPageLayout from '../../common/FormPageLayout';
@@ -29,7 +29,7 @@ const AwaitingConfirmationPage = ({
   emailAddress,
   onResendEmailRequest,
   onChangeEmailRequest,
-}: AwaitingConfirmationPageProps): ReactElement => (
+}: AwaitingConfirmationPageProps) => (
   <BackgroundLayer>
     <FormPageLayout
       title={title}

--- a/packages/onboarding-ui/src/pages/CheckYourEmailPage/CheckYourEmailPage.tsx
+++ b/packages/onboarding-ui/src/pages/CheckYourEmailPage/CheckYourEmailPage.tsx
@@ -3,7 +3,7 @@ import {
   HeroLayoutTitle,
   HeroLayoutSubtitle,
 } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
 import EmailCodeFallback from '../../common/EmailCodeFallback';
@@ -28,7 +28,7 @@ const CheckYourEmailPage = ({
   children,
   onResendEmailRequest,
   onChangeEmailRequest,
-}: CheckYourEmailPageProps): ReactElement => {
+}: CheckYourEmailPageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/ConfirmationProcessPage/ConfirmationProcessPage.tsx
+++ b/packages/onboarding-ui/src/pages/ConfirmationProcessPage/ConfirmationProcessPage.tsx
@@ -1,9 +1,8 @@
 import { Throbber } from '@rocket.chat/fuselage';
 import { HeroLayout, HeroLayoutTitle } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const ConfirmationProcessPage = (): ReactElement => {
+const ConfirmationProcessPage = () => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/CreateCloudWorkspacePage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/CreateCloudWorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@rocket.chat/fuselage';
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
 import FormPageLayout from '../../common/FormPageLayout';
@@ -13,9 +13,7 @@ export type CreateCloudWorkspacePageProps = ComponentProps<
   typeof CreateCloudWorkspaceForm
 >;
 
-const CreateCloudWorkspacePage = (
-  props: CreateCloudWorkspacePageProps,
-): ReactElement => {
+const CreateCloudWorkspacePage = (props: CreateCloudWorkspacePageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/Description.tsx
+++ b/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/Description.tsx
@@ -1,14 +1,13 @@
 import { Box, Icon } from '@rocket.chat/fuselage';
 import colors from '@rocket.chat/fuselage-tokens/colors.json';
 import { List, DarkModeProvider } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 
 import PlanFeatureIcon from '../../common/PlanFeatureIcon';
 
-const Description = (): ReactElement => {
+const Description = () => {
   const isDarkMode = DarkModeProvider.useDarkMode();
   const color = isDarkMode ? colors.white : colors.n900;
   const { t } = useTranslation();

--- a/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/TitleCreateCloudPage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateCloudWorkspacePage/TitleCreateCloudPage.tsx
@@ -1,8 +1,7 @@
 import { FormPageLayout } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans } from 'react-i18next';
 
-const TitleCreateCloudPage = (): ReactElement => (
+const TitleCreateCloudPage = () => (
   <Trans i18nKey='page.createCloudWorkspace.title'>
     Launch new workspace and
     <FormPageLayout.TitleHighlight>30-day trial</FormPageLayout.TitleHighlight>

--- a/packages/onboarding-ui/src/pages/CreateFirstMemberPage/CreateFirstMemberPage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateFirstMemberPage/CreateFirstMemberPage.tsx
@@ -1,5 +1,5 @@
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
 import FormPageLayout from '../../common/FormPageLayout';
@@ -11,9 +11,7 @@ export type CreateFirstMemberPageProps = ComponentProps<
   typeof CreateFirstMemberForm
 >;
 
-const CreateFirstMemberPage = (
-  props: CreateFirstMemberPageProps,
-): ReactElement => {
+const CreateFirstMemberPage = (props: CreateFirstMemberPageProps) => {
   const pageLayoutStyleProps: FormPageLayoutStyleProps = {
     justifyContent: 'center',
   };

--- a/packages/onboarding-ui/src/pages/CreateFirstMemberPage/TitleCreateFirstMemberPage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateFirstMemberPage/TitleCreateFirstMemberPage.tsx
@@ -1,8 +1,7 @@
 import { FormPageLayout } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans } from 'react-i18next';
 
-const TitleCreateFirstMemberPage = (): ReactElement => (
+const TitleCreateFirstMemberPage = () => (
   <Trans i18nKey='page.createFirstMember.title'>
     Create first
     <FormPageLayout.TitleHighlight>

--- a/packages/onboarding-ui/src/pages/CreateNewAccountPage/CreateNewAccountPage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateNewAccountPage/CreateNewAccountPage.tsx
@@ -5,7 +5,6 @@ import {
   VerticalWizardLayoutForm,
   VerticalWizardLayoutTitle,
 } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -33,7 +32,7 @@ export type CreateNewAccountPageProps = {
 const CreateNewAccountPage = ({
   onLogin,
   ...props
-}: CreateNewAccountPageProps): ReactElement => {
+}: CreateNewAccountPageProps) => {
   const { t } = useTranslation();
   return (
     <VerticalWizardLayout>

--- a/packages/onboarding-ui/src/pages/CreateNewPasswordPage/CreateNewPasswordPage.tsx
+++ b/packages/onboarding-ui/src/pages/CreateNewPasswordPage/CreateNewPasswordPage.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@rocket.chat/fuselage';
 import { ActionLink } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -30,7 +29,7 @@ const pageLayoutStyleProps: FormPageLayoutStyleProps = {
 const ResetPasswordPage = ({
   onLogin,
   ...props
-}: CreateNewPasswordPageProps): ReactElement => {
+}: CreateNewPasswordPageProps) => {
   const { t } = useTranslation();
   return (
     <FormPageLayout

--- a/packages/onboarding-ui/src/pages/EmailConfirmedPage/EmailConfirmedPage.tsx
+++ b/packages/onboarding-ui/src/pages/EmailConfirmedPage/EmailConfirmedPage.tsx
@@ -3,10 +3,9 @@ import {
   HeroLayoutSubtitle,
   HeroLayoutTitle,
 } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const EmailConfirmedPage = (): ReactElement => {
+const EmailConfirmedPage = () => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/InformationPage/InformationPage.tsx
+++ b/packages/onboarding-ui/src/pages/InformationPage/InformationPage.tsx
@@ -3,17 +3,14 @@ import {
   HeroLayoutSubtitle,
   HeroLayoutTitle,
 } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export type InformationPageProps = {
   title: string;
   description?: ReactNode;
 };
 
-const InformationPage = ({
-  title,
-  description,
-}: InformationPageProps): ReactElement => (
+const InformationPage = ({ title, description }: InformationPageProps) => (
   <HeroLayout>
     <HeroLayoutTitle>{title}</HeroLayoutTitle>
     {description && <HeroLayoutSubtitle>{description}</HeroLayoutSubtitle>}

--- a/packages/onboarding-ui/src/pages/InvalidLinkPage/InvalidLinkPage.tsx
+++ b/packages/onboarding-ui/src/pages/InvalidLinkPage/InvalidLinkPage.tsx
@@ -1,15 +1,12 @@
 import { Box, Margins, Button } from '@rocket.chat/fuselage';
 import { BackgroundLayer, LayoutLogo } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type InvalidLinkPageProps = {
   onRequestNewLink: () => void;
 };
 
-const InvalidLinkPage = ({
-  onRequestNewLink,
-}: InvalidLinkPageProps): ReactElement => {
+const InvalidLinkPage = ({ onRequestNewLink }: InvalidLinkPageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/LoaderPage/LoaderPage.tsx
+++ b/packages/onboarding-ui/src/pages/LoaderPage/LoaderPage.tsx
@@ -1,6 +1,5 @@
 import { Box, Margins, ProgressBar } from '@rocket.chat/fuselage';
 import { BackgroundLayer, LayoutLogo } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
 
 export type LoaderPageProps = {
@@ -15,7 +14,7 @@ const LoaderPage = ({
   subtitles,
   isReady = false,
   loadingSeconds = 90,
-}: LoaderPageProps): ReactElement => {
+}: LoaderPageProps) => {
   const timeFraction = 100 / subtitles.length;
 
   const [percentage, setPercentage] = useState(() => (isReady ? 100 : 0));

--- a/packages/onboarding-ui/src/pages/LoginLinkEmailPage/LoginLinkEmailPage.tsx
+++ b/packages/onboarding-ui/src/pages/LoginLinkEmailPage/LoginLinkEmailPage.tsx
@@ -1,6 +1,5 @@
 import { Box, Margins } from '@rocket.chat/fuselage';
 import { BackgroundLayer, LayoutLogo } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import EmailCodeFallback from '../../common/EmailCodeFallback';
@@ -13,7 +12,7 @@ export type LoginLinkEmailProps = {
 const LoginLinkEmailPage = ({
   onResendEmailRequest,
   onChangeEmailRequest,
-}: LoginLinkEmailProps): ReactElement => {
+}: LoginLinkEmailProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/onboarding-ui/src/pages/LoginPage/LoginPage.tsx
@@ -5,7 +5,6 @@ import {
   VerticalWizardLayoutForm,
   VerticalWizardLayoutFooter,
 } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -34,10 +33,7 @@ export type LoginPageProps = {
   onSubmit: SubmitHandler<LoginFormPayload>;
 };
 
-const LoginPage = ({
-  onCreateAccount,
-  ...props
-}: LoginPageProps): ReactElement => {
+const LoginPage = ({ onCreateAccount, ...props }: LoginPageProps) => {
   const { t } = useTranslation();
   const { isMfa, mfaProps } = props;
 

--- a/packages/onboarding-ui/src/pages/OauthAuthorizationPage/OauthAuthorizationPage.tsx
+++ b/packages/onboarding-ui/src/pages/OauthAuthorizationPage/OauthAuthorizationPage.tsx
@@ -5,7 +5,6 @@ import {
   VerticalWizardLayoutTitle,
   VerticalWizardLayoutForm,
 } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 export type OauthAuthorizationPageProps = {
@@ -21,7 +20,7 @@ const OauthAuthorizationPage = ({
   clientName,
   onClickAuthorizeOAuth,
   error,
-}: OauthAuthorizationPageProps): ReactElement => {
+}: OauthAuthorizationPageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/OrganizationInfoPage/OrganizationInfoPage.tsx
+++ b/packages/onboarding-ui/src/pages/OrganizationInfoPage/OrganizationInfoPage.tsx
@@ -1,6 +1,6 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
@@ -28,7 +28,7 @@ const OrganizationInfoPage = ({
   title,
   description,
   ...props
-}: OrganizationInfoPageProps): ReactElement => {
+}: OrganizationInfoPageProps) => {
   const pageLayoutStyleProps: FormPageLayoutStyleProps = {
     justifyContent: 'center',
     subTitleProps: {

--- a/packages/onboarding-ui/src/pages/OrganizationInfoPage/TitleOrganizationInfoPage.tsx
+++ b/packages/onboarding-ui/src/pages/OrganizationInfoPage/TitleOrganizationInfoPage.tsx
@@ -1,8 +1,7 @@
 import { FormPageLayout } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { Trans } from 'react-i18next';
 
-const TitleOrganizationInfoPage = (): ReactElement => (
+const TitleOrganizationInfoPage = () => (
   <Trans i18nKey='page.cloudDescription.title'>
     Let's launch your workspace and
     <FormPageLayout.TitleHighlight>

--- a/packages/onboarding-ui/src/pages/RedirectPage/RedirectPage.tsx
+++ b/packages/onboarding-ui/src/pages/RedirectPage/RedirectPage.tsx
@@ -1,6 +1,5 @@
 import { Box, Margins } from '@rocket.chat/fuselage';
 import { ActionLink, LayoutLogo, BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
@@ -14,7 +13,7 @@ const RedirectPage = ({
   title,
   countDownSeconds,
   onRedirect,
-}: RedirectPageProps): ReactElement => {
+}: RedirectPageProps) => {
   const { t } = useTranslation();
 
   const [seconds, setSeconds] = useState(countDownSeconds);

--- a/packages/onboarding-ui/src/pages/RegisterOfflinePage/RegisterOfflinePage.tsx
+++ b/packages/onboarding-ui/src/pages/RegisterOfflinePage/RegisterOfflinePage.tsx
@@ -1,5 +1,4 @@
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
@@ -20,7 +19,7 @@ const pageLayoutStyleProps: FormPageLayoutStyleProps = {
   justifyContent: 'center',
 };
 
-const RegisterOfflinePage = (props: RegisterOfflinePageProps): ReactElement => (
+const RegisterOfflinePage = (props: RegisterOfflinePageProps) => (
   <BackgroundLayer>
     <FormPageLayout styleProps={pageLayoutStyleProps}>
       <RegisterOfflineForm {...props} />

--- a/packages/onboarding-ui/src/pages/RegisterServerPage/RegisterServerPage.tsx
+++ b/packages/onboarding-ui/src/pages/RegisterServerPage/RegisterServerPage.tsx
@@ -1,5 +1,4 @@
 import { BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 
 import type { FormPageLayoutStyleProps } from '../../Types';
@@ -26,7 +25,7 @@ const pageLayoutStyleProps: FormPageLayoutStyleProps = {
   justifyContent: 'center',
 };
 
-const RegisterServerPage = (props: RegisterServerPageProps): ReactElement => (
+const RegisterServerPage = (props: RegisterServerPageProps) => (
   <BackgroundLayer>
     <FormPageLayout styleProps={pageLayoutStyleProps}>
       <RegisterServerForm {...props} />

--- a/packages/onboarding-ui/src/pages/RequestTrialPage/Description.tsx
+++ b/packages/onboarding-ui/src/pages/RequestTrialPage/Description.tsx
@@ -1,13 +1,12 @@
 import colors from '@rocket.chat/fuselage-tokens/colors.json';
 import { List, DarkModeProvider } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 
 import PlanFeatureIcon from '../../common/PlanFeatureIcon';
 
-const Description = (): ReactElement => {
+const Description = () => {
   const isDarkMode = DarkModeProvider.useDarkMode();
   const color = isDarkMode ? colors.white : colors.n900;
   const { t } = useTranslation();

--- a/packages/onboarding-ui/src/pages/RequestTrialPage/RequestTrialPage.tsx
+++ b/packages/onboarding-ui/src/pages/RequestTrialPage/RequestTrialPage.tsx
@@ -2,7 +2,7 @@ import {
   BackgroundLayer,
   FormPageLayout as FormLayout,
 } from '@rocket.chat/layout';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
 import FormPageLayout from '../../common/FormPageLayout';
@@ -12,7 +12,7 @@ import Description from './Description';
 
 export type RequestTrialPageProps = ComponentProps<typeof RequestTrialForm>;
 
-const RequestTrialPage = (props: RequestTrialPageProps): ReactElement => {
+const RequestTrialPage = (props: RequestTrialPageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/onboarding-ui/src/pages/ResetPasswordConfirmationPage/ResetPasswordConfirmationPage.tsx
+++ b/packages/onboarding-ui/src/pages/ResetPasswordConfirmationPage/ResetPasswordConfirmationPage.tsx
@@ -1,9 +1,8 @@
 import { Box, Margins } from '@rocket.chat/fuselage';
 import { BackgroundLayer, LayoutLogo } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const ResetPasswordConfirmationPage = (): ReactElement => {
+const ResetPasswordConfirmationPage = () => {
   const { t } = useTranslation();
   return (
     <BackgroundLayer>

--- a/packages/onboarding-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/packages/onboarding-ui/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@rocket.chat/fuselage';
 import { ActionLink, BackgroundLayer } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import type { FieldPathValue, SubmitHandler, Validate } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -23,10 +22,7 @@ const pageLayoutStyleProps: FormPageLayoutStyleProps = {
   justifyContent: 'center',
 };
 
-const ResetPasswordPage = ({
-  onLogin,
-  ...props
-}: ResetPasswordPageProps): ReactElement => {
+const ResetPasswordPage = ({ onLogin, ...props }: ResetPasswordPageProps) => {
   const { t } = useTranslation();
   return (
     <BackgroundLayer>

--- a/packages/onboarding-ui/src/pages/SomethingWentWrongPage/SomethingWentWrongPage.tsx
+++ b/packages/onboarding-ui/src/pages/SomethingWentWrongPage/SomethingWentWrongPage.tsx
@@ -1,6 +1,5 @@
 import { Box, Margins } from '@rocket.chat/fuselage';
 import { BackgroundLayer, LayoutLogo } from '@rocket.chat/layout';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type SomethingWentWrongPageProps = {
@@ -9,7 +8,7 @@ export type SomethingWentWrongPageProps = {
 
 const SomethingWentWrongPage = ({
   requestId = undefined,
-}: SomethingWentWrongPageProps): ReactElement => {
+}: SomethingWentWrongPageProps) => {
   const { t } = useTranslation();
 
   return (

--- a/packages/styled/src/styled.ts
+++ b/packages/styled/src/styled.ts
@@ -13,6 +13,7 @@ import type {
   PropsWithoutRef,
   RefAttributes,
   SVGProps,
+  JSX,
 } from 'react';
 import {
   createElement,

--- a/packages/styled/styled.api.md
+++ b/packages/styled/styled.api.md
@@ -8,6 +8,7 @@ import { Context } from 'react';
 import type { DetailedHTMLProps } from 'react';
 import type { ForwardRefExoticComponent } from 'react';
 import type { HTMLAttributes } from 'react';
+import type { JSX as JSX_2 } from 'react';
 import type { PropsWithoutRef } from 'react';
 import type { RefAttributes } from 'react';
 import type { SVGProps } from 'react';
@@ -19,11 +20,11 @@ document: Document;
 
 // @public (undocumented)
 export type RefTypes = {
-    [K in keyof JSX.IntrinsicElements]: JSX.IntrinsicElements[K] extends DetailedHTMLProps<HTMLAttributes<infer T>, any> ? T : JSX.IntrinsicElements[K] extends SVGProps<infer T> ? T : never;
+    [K in keyof JSX_2.IntrinsicElements]: JSX_2.IntrinsicElements[K] extends DetailedHTMLProps<HTMLAttributes<infer T>, any> ? T : JSX_2.IntrinsicElements[K] extends SVGProps<infer T> ? T : never;
 };
 
 // @public (undocumented)
-const styled: <K extends keyof JSX.IntrinsicElements, P>(type: K, filter?: (p: PropsWithoutRef<JSX.IntrinsicElements[K] & P>) => JSX.IntrinsicElements[K]) => (slices: TemplateStringsArray, ...values: readonly (string | ((props: P) => string))[]) => ForwardRefExoticComponent<PropsWithoutRef<JSX.IntrinsicElements[K] & P> & RefAttributes<RefTypes[K]>>;
+const styled: <K extends keyof JSX_2.IntrinsicElements, P>(type: K, filter?: (p: PropsWithoutRef<JSX_2.IntrinsicElements[K] & P>) => JSX_2.IntrinsicElements[K]) => (slices: TemplateStringsArray, ...values: readonly (string | ((props: P) => string))[]) => ForwardRefExoticComponent<PropsWithoutRef<JSX_2.IntrinsicElements[K] & P> & RefAttributes<RefTypes[K]>>;
 export default styled;
 
 // @public (undocumented)


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
This pull request focuses on improving type safety and consistency across several packages by refining React type usage, particularly around `ReactNode`, `ReactElement`, and forward refs. It also includes minor internal refactoring for clarity and correctness in React hook implementations.

**Type Safety and API Consistency Improvements:**

- Updated various component props and exported types to use `ReactNode` or `ReactElement<any>` instead of the less specific `ReactElement`, improving compatibility with React 18+ and supporting a wider range of valid children and icon types. This affects components such as `AutoComplete`, `Callout`, `IconButton`, `Menu`, `MessageGenericPreviewContent`, `MessageMetricsFollowing`, `MessageToolbarItem`, `Sidebar`, `SidebarTopBar`, and related types in `fuselage.api.md`. [[1]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL148-R149) [[2]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL354-R354) [[3]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL862-R862) [[4]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL874-R874) [[5]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL991-R991) [[6]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL1105-R1105) [[7]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL1209-R1209) [[8]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL1429-R1429) [[9]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2059-R2059) [[10]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2071-R2071) [[11]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2081-R2081) [[12]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2117-R2117) [[13]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2294-R2294) [[14]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2550-R2550) [[15]](diffhunk://#diff-217114c2c722f7f56a13c76144a36631b2b3173a8d3fb470620cc97ba6436acdL2591-R2591)

**React Forward Ref and HOC Improvements:**

- Refactored higher-order components in `withLabelHelpers.tsx` to accept `ComponentType` instead of `ForwardRefExoticComponent`, making them more flexible and compatible with a broader range of components. [[1]](diffhunk://#diff-af86a427a4c0b4a4d1a34faa9b17dc32276aa4c5147f000480c07ad230d1ca49L4-R4) [[2]](diffhunk://#diff-af86a427a4c0b4a4d1a34faa9b17dc32276aa4c5147f000480c07ad230d1ca49L23-R18) [[3]](diffhunk://#diff-af86a427a4c0b4a4d1a34faa9b17dc32276aa4c5147f000480c07ad230d1ca49L46-R39) [[4]](diffhunk://#diff-af86a427a4c0b4a4d1a34faa9b17dc32276aa4c5147f000480c07ad230d1ca49L69-R60) [[5]](diffhunk://#diff-af86a427a4c0b4a4d1a34faa9b17dc32276aa4c5147f000480c07ad230d1ca49L92-R81)

**React Hook and Refactoring Enhancements:**

- Standardized the initialization of refs in custom hooks (`useDebouncedCallback`, `useElementIsVisible`, `usePrevious`) to explicitly use `undefined` as the initial value, improving type safety and clarity. [[1]](diffhunk://#diff-eeb9d63fedfca5663f643b3d6c9d5d06ba524896da1669aba77d8824ea66da3aL24-R25) [[2]](diffhunk://#diff-a9d95ad66c9da47a4d08c3f7fc9b60e601830dd49ccfa2be6c6aa0baf36565d3L17-R17) [[3]](diffhunk://#diff-99cc0b7339d834807fe7b0c3a3335e10b6ae4d47298d870365cae3f1fedbe831L4-R4)
- Renamed `isMutableRefObject` to `isRefObject` in `useMergedRefs.ts` for clearer intent and updated its usage. [[1]](diffhunk://#diff-233395edc4a0bb67e1b1217010ac7647e46c534186b0164897bdd03a349d1515L8-R8) [[2]](diffhunk://#diff-233395edc4a0bb67e1b1217010ac7647e46c534186b0164897bdd03a349d1515L35-R35)

**ToastBar Component and API Cleanup:**

- Removed unnecessary `ReactElement` type annotations from ToastBar-related components and updated the API documentation to use `JSX.Element` or omit explicit return types, aligning with modern React best practices. [[1]](diffhunk://#diff-bc56a2ce9acba1d5f0ed4a0eba89cff0834850f625de52b391616022162d0886R8-L9) [[2]](diffhunk://#diff-bc56a2ce9acba1d5f0ed4a0eba89cff0834850f625de52b391616022162d0886L43-R43) [[3]](diffhunk://#diff-8266bcff417a455e95bb91b35841063d412c60c2ef75936b804a664cfb78a450L2-R5) [[4]](diffhunk://#diff-ac07247f16a717c6f8424285104163da3bfd5886d401571629de32293903f4aaL1-R1) [[5]](diffhunk://#diff-ac07247f16a717c6f8424285104163da3bfd5886d401571629de32293903f4aaL49-R49) [[6]](diffhunk://#diff-5a7c2d6355bae51cb5164099e098777263d304ae6c48f47184a802368da195c0L1-R1) [[7]](diffhunk://#diff-5a7c2d6355bae51cb5164099e098777263d304ae6c48f47184a802368da195c0L15-R15) [[8]](diffhunk://#diff-1750b66b342c8fee592c2bc73804e35298da040beaa03175fcbb28c4823b0041L2-R7) [[9]](diffhunk://#diff-c04b4659eee311c775f5200513d4bc6bd29f825d228e8bc6c7b816b17533b756L2-R2) [[10]](diffhunk://#diff-c04b4659eee311c775f5200513d4bc6bd29f825d228e8bc6c7b816b17533b756L49-R49)
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
