### PR TITLE
fix(fuselage): InputBox not stretching to the maximum available width

### DIFF
--- a/.changeset/cold-knives-post.md
+++ b/.changeset/cold-knives-post.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+fix(fuselage): InputBox not stretching to the maximum available width

--- a/packages/fuselage/src/components/InputBox/InputBox.styles.scss
+++ b/packages/fuselage/src/components/InputBox/InputBox.styles.scss
@@ -76,6 +76,7 @@ $input-border-radius: theme(
   flex: 1 0 auto;
 
   flex-basis: lengths.size(none);
+
   min-width: lengths.size(128);
 
   user-select: initial;

--- a/packages/fuselage/src/components/InputBox/InputBox.styles.scss
+++ b/packages/fuselage/src/components/InputBox/InputBox.styles.scss
@@ -75,7 +75,7 @@ $input-border-radius: theme(
 
   flex: 1 0 auto;
 
-  width: lengths.size(none);
+  flex-basis: lengths.size(none);
   min-width: lengths.size(128);
 
   user-select: initial;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

`InputBox`, and everything built on it (`TextInput`, `UrlInput`, `EmailInput`, `NumberInput`, `TelephoneInput`, `TextAreaInput`, etc.) collapses to its `min-width` instead of filling the available space when it is rendered as a direct child of a flex‑column container (e.g. a fuselage `Field`, which is `display: flex; flex-direction: column; align-items: stretch`) rather than inside a `FieldRow`.

**Root cause**: v0.79.1 (https://github.com/RocketChat/fuselage/pull/2024) added `width: 0` to the shared `.rcx-input-box` rule. A definite `width` disables the cross‑axis `stretch` of a flex column item, so the input stops growing to the container width and falls back to `min-width: 8rem`. In v0.79.0 and earlier the rule had no `width`, so it stretched correctly.

**Fix**: Use a main‑axis‑only basis instead of a definite width:

**Where it shows**: in Rocket.Chat admin settings, every `relativeUrl` setting (e.g. the OAuth "Callback URL" fields) renders a readonly `UrlInput` directly inside a `Field`, and appears collapsed to ~128px with the URL truncated, while sibling text/secret fields (which sit inside a `FieldRow`) look fine.

- **The defect is in the component's sizing contract, not in one call site.** `width: 0` breaks `InputBox` for *any* addon‑less input rendered in a stretch (column/block) container, which is a valid usage. The `relativeUrl` setting (the one used in `apps/meteor/server/settings/oauth.ts`) is just the first place it became visible: `TextInput`, `EmailInput`, etc. collapse identically there, they are the same component with a different `type`. Fixing it in Rocket.Chat main repo would patch one symptom and leave the latent bug for every other current and future consumer.

## Issue(s)
[CORE-2348 [Regression] OAuth callback URL fields render too narrow in admin settings](https://rocketchat.atlassian.net/browse/CORE-2348)
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
