### PR TITLE
fix(fuselage): prevent MultiSelect dropdown from reopening on toggle …

### DIFF
--- a/.changeset/multiselect-toggle-reopen.md
+++ b/.changeset/multiselect-toggle-reopen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+fix(fuselage): `MultiSelect` dropdown reopening when its toggle is clicked while open

--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.spec.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.spec.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react-webpack5';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { withResizeObserverMock } from 'testing-utils/mocks/withResizeObserverMock';
 
@@ -31,6 +31,44 @@ test.each(testCases)(
     expect(results).toHaveNoViolations();
   },
 );
+
+test('stays closed when the toggle is clicked while open (regression for #1869)', () => {
+  // The visibility state is debounced (10ms). When the open dropdown is
+  // clicked, the anchor blurs first (`onBlur: hide`) and that debounced hide
+  // flushes before the trailing `click` fires. Previously `handleClick` read
+  // the already-HIDDEN `visible` state and re-opened the dropdown. Reproduce
+  // that exact ordering with controlled timers.
+  jest.useFakeTimers();
+
+  try {
+    const { Default } = composeStories(stories);
+    render(<Default />);
+
+    const combobox = screen.getByRole('combobox');
+    const container = combobox.closest('.rcx-select') as HTMLElement;
+
+    // Open the dropdown.
+    fireEvent.click(container);
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    // Clicking the toggle: blur closes it, then the click must keep it closed.
+    fireEvent.blur(combobox);
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+    fireEvent.click(container);
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+  } finally {
+    jest.useRealTimers();
+  }
+});
 
 test('MultiSelectFiltered prevents Chrome autocomplete overlay (regression)', () => {
   const { WithFilter } = composeStories(stories);

--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
@@ -142,9 +142,16 @@ const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
     };
 
     const handleClick = useStableCallback(() => {
-      if (visible === AnimatedVisibility.VISIBLE) {
+      // Toggle based on the self-managed `focus-visible` class rather than the
+      // `visible` state. The anchor's `onBlur` fires `hide()` during the
+      // mousedown that precedes this click, so reading `visible` here would
+      // already see HIDDEN and re-open the dropdown. This mirrors SelectLegacy.
+      if (innerRef.current?.classList.contains('focus-visible')) {
+        removeFocusClass();
         return hide();
       }
+
+      innerRef.current?.classList.add('focus-visible');
       innerRef.current?.focus();
       return show();
     });


### PR DESCRIPTION
Clicking the toggle of an open MultiSelect blurred the anchor first, firing the debounced `hide()`, which flushed before the trailing `click`. The click handler then read the already-HIDDEN `visible` state and re-opened the dropdown. Toggle now keys off the self-managed `focus-visible` class instead, matching SelectLegacy.

Closes #1869

**This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text.**

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
