### PR TITLE
feat(fuselage): extract controlled AudioPlayerControls from AudioPlayer

### DIFF
--- a/.changeset/audio-player-controls.md
+++ b/.changeset/audio-player-controls.md
@@ -2,4 +2,4 @@
 '@rocket.chat/fuselage': minor
 ---
 
-Extracted the presentational, fully controlled `AudioPlayerControls` component from `AudioPlayer` and exported it. It renders the play/pause, seek, elapsed time, playback speed and optional download controls without owning an `<audio>` element or any playback state, so it can be driven by an external/shared media element. `AudioPlayer` keeps its previous self-contained behavior and now composes `AudioPlayerControls` internally, so existing usage is unchanged.
+feat(fuselage): extract controlled AudioPlayerControls from AudioPlayer

--- a/.changeset/audio-player-controls.md
+++ b/.changeset/audio-player-controls.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': minor
+---
+
+Extracted the presentational, fully controlled `AudioPlayerControls` component from `AudioPlayer` and exported it. It renders the play/pause, seek, elapsed time, playback speed and optional download controls without owning an `<audio>` element or any playback state, so it can be driven by an external/shared media element. `AudioPlayer` keeps its previous self-contained behavior and now composes `AudioPlayerControls` internally, so existing usage is unchanged.

--- a/packages/fuselage/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/fuselage/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -1,8 +1,6 @@
 import type { Meta } from '@storybook/react-webpack5';
-import { useState } from 'react';
 
 import AudioPlayer from './AudioPlayer';
-import AudioPlayerControls from './AudioPlayerControls';
 
 export default {
   title: 'Media/AudioPlayer',
@@ -13,24 +11,3 @@ const AUDIO_URL =
   'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-17.mp3';
 
 export const AudioPlayerDefault = () => <AudioPlayer src={AUDIO_URL} />;
-
-export const Controls = () => {
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(12);
-  const [playbackSpeed, setPlaybackSpeed] = useState(1);
-  const durationTime = 86;
-
-  return (
-    <AudioPlayerControls
-      isPlaying={isPlaying}
-      currentTime={currentTime}
-      durationTime={durationTime}
-      playbackSpeed={playbackSpeed}
-      onTogglePlay={() => setIsPlaying((playing) => !playing)}
-      onSeek={setCurrentTime}
-      onChangePlaybackSpeed={() =>
-        setPlaybackSpeed((speed) => (speed >= 2 ? 1 : speed + 0.5))
-      }
-    />
-  );
-};

--- a/packages/fuselage/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/fuselage/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta } from '@storybook/react-webpack5';
+import { useState } from 'react';
 
 import AudioPlayer from './AudioPlayer';
+import AudioPlayerControls from './AudioPlayerControls';
 
 export default {
   title: 'Media/AudioPlayer',
@@ -11,3 +13,24 @@ const AUDIO_URL =
   'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-17.mp3';
 
 export const AudioPlayerDefault = () => <AudioPlayer src={AUDIO_URL} />;
+
+export const Controls = () => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(12);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+  const durationTime = 86;
+
+  return (
+    <AudioPlayerControls
+      isPlaying={isPlaying}
+      currentTime={currentTime}
+      durationTime={durationTime}
+      playbackSpeed={playbackSpeed}
+      onTogglePlay={() => setIsPlaying((playing) => !playing)}
+      onSeek={setCurrentTime}
+      onChangePlaybackSpeed={() =>
+        setPlaybackSpeed((speed) => (speed >= 2 ? 1 : speed + 0.5))
+      }
+    />
+  );
+};

--- a/packages/fuselage/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/packages/fuselage/src/components/AudioPlayer/AudioPlayer.tsx
@@ -2,14 +2,9 @@ import { useMergedRefs, useResizeObserver } from '@rocket.chat/fuselage-hooks';
 import type { TrackHTMLAttributes } from 'react';
 import { useState, useRef, forwardRef } from 'react';
 
-import { Box, Button, IconButton, Margins } from '../..';
+import { Box } from '../..';
 import { useOwnerDocument } from '../../contexts';
-import { Slider } from '../Slider';
-
-const getMaskTime = (durationTime: number) =>
-  new Date(durationTime * 1000)
-    .toISOString()
-    .slice(durationTime > 60 * 60 ? 11 : 14, 19);
+import AudioPlayerControls from './AudioPlayerControls';
 
 function forceDownload(
   ownerDocument: Document,
@@ -150,60 +145,33 @@ const AudioPlayer = forwardRef<HTMLAudioElement, AudioPlayerProps>(
         display='flex'
         alignItems='center'
       >
-        <IconButton
-          primary
-          medium
-          onClick={handlePlay}
-          aria-label={isPlaying ? pauseLabel : playLabel}
-          icon={isPlaying ? 'pause-shape-filled' : 'play-shape-filled'}
+        <AudioPlayerControls
+          isPlaying={isPlaying}
+          currentTime={currentTime}
+          durationTime={durationTime}
+          playbackSpeed={playbackSpeed}
+          onTogglePlay={handlePlay}
+          onSeek={(time) => {
+            if (audioRef.current) {
+              audioRef.current.currentTime = time;
+            }
+          }}
+          onChangePlaybackSpeed={handlePlaybackSpeedSingleControl}
+          download={download}
+          downloadHref={src}
+          onDownload={(e) => {
+            const { host } = new URL(src);
+            if (host !== ownerDocument.defaultView?.location.host) {
+              e.preventDefault();
+              forceDownload(ownerDocument, src);
+            }
+          }}
+          playLabel={playLabel}
+          pauseLabel={pauseLabel}
+          audioPlaybackRangeLabel={audioPlaybackRangeLabel}
+          changePlaybackSpeedLabel={changePlaybackSpeedLabel}
+          downloadAudioFileLabel={downloadAudioFileLabel}
         />
-        <Margins inline={8}>
-          <Box fontScale='p2' color='secondary-info'>
-            {isPlaying || currentTime > 0
-              ? getMaskTime(currentTime)
-              : getMaskTime(durationTime)}
-          </Box>
-          <Box mi={16} w='full'>
-            <Slider
-              aria-label={audioPlaybackRangeLabel}
-              showOutput={false}
-              value={currentTime}
-              maxValue={durationTime}
-              onChange={(value) => {
-                if (audioRef.current) {
-                  audioRef.current.currentTime = value;
-                }
-              }}
-            />
-          </Box>
-
-          <Button
-            secondary
-            small
-            onClick={handlePlaybackSpeedSingleControl}
-            aria-label={changePlaybackSpeedLabel}
-          >
-            {playbackSpeed}x
-          </Button>
-        </Margins>
-        {download && (
-          <IconButton
-            primary
-            aria-label={downloadAudioFileLabel}
-            is='a'
-            href={src}
-            download
-            icon='download'
-            medium
-            onClick={(e) => {
-              const { host } = new URL(src);
-              if (host !== ownerDocument.defaultView?.location.host) {
-                e.preventDefault();
-                forceDownload(ownerDocument, src);
-              }
-            }}
-          />
-        )}
         <audio
           style={{ display: 'none' }}
           onTimeUpdate={(e) => {

--- a/packages/fuselage/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/packages/fuselage/src/components/AudioPlayer/AudioPlayer.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, forwardRef } from 'react';
 
 import { Box } from '../..';
 import { useOwnerDocument } from '../../contexts';
+
 import AudioPlayerControls from './AudioPlayerControls';
 
 function forceDownload(

--- a/packages/fuselage/src/components/AudioPlayer/AudioPlayerControls.tsx
+++ b/packages/fuselage/src/components/AudioPlayer/AudioPlayerControls.tsx
@@ -1,0 +1,101 @@
+import type { MouseEvent } from 'react';
+
+import { Box, Button, IconButton, Margins } from '../..';
+import { Slider } from '../Slider';
+
+const getMaskTime = (durationTime: number) =>
+  new Date(durationTime * 1000)
+    .toISOString()
+    .slice(durationTime > 60 * 60 ? 11 : 14, 19);
+
+export type AudioPlayerControlsProps = {
+  isPlaying: boolean;
+  currentTime: number;
+  durationTime: number;
+  playbackSpeed: number;
+  onTogglePlay: () => void;
+  onSeek: (time: number) => void;
+  onChangePlaybackSpeed: () => void;
+  download?: boolean;
+  downloadHref?: string;
+  onDownload?: (event: MouseEvent<HTMLElement>) => void;
+  playLabel?: string;
+  pauseLabel?: string;
+  audioPlaybackRangeLabel?: string;
+  changePlaybackSpeedLabel?: string;
+  downloadAudioFileLabel?: string;
+};
+
+/**
+ * Presentational, fully controlled audio controls (play/pause, seek, elapsed
+ * time, playback speed and optional download). It owns no `<audio>` element and
+ * no playback state, so it can be driven by any source — a local element or a
+ * shared/persistent one. `AudioPlayer` wraps this with its own element for the
+ * common self-contained case.
+ */
+const AudioPlayerControls = ({
+  isPlaying,
+  currentTime,
+  durationTime,
+  playbackSpeed,
+  onTogglePlay,
+  onSeek,
+  onChangePlaybackSpeed,
+  download = false,
+  downloadHref,
+  onDownload,
+  playLabel = 'Play',
+  pauseLabel = 'Pause',
+  audioPlaybackRangeLabel = 'Audio Playback Range',
+  changePlaybackSpeedLabel = 'Change Playback Speed',
+  downloadAudioFileLabel = 'Download Audio File',
+}: AudioPlayerControlsProps) => (
+  <Box display='flex' alignItems='center' w='full'>
+    <IconButton
+      primary
+      medium
+      onClick={onTogglePlay}
+      aria-label={isPlaying ? pauseLabel : playLabel}
+      icon={isPlaying ? 'pause-shape-filled' : 'play-shape-filled'}
+    />
+    <Margins inline={8}>
+      <Box fontScale='p2' color='secondary-info'>
+        {isPlaying || currentTime > 0
+          ? getMaskTime(currentTime)
+          : getMaskTime(durationTime)}
+      </Box>
+      <Box mi={16} w='full'>
+        <Slider
+          aria-label={audioPlaybackRangeLabel}
+          showOutput={false}
+          value={currentTime}
+          maxValue={durationTime}
+          onChange={(value) => onSeek(Array.isArray(value) ? value[0] : value)}
+        />
+      </Box>
+
+      <Button
+        secondary
+        small
+        onClick={onChangePlaybackSpeed}
+        aria-label={changePlaybackSpeedLabel}
+      >
+        {playbackSpeed}x
+      </Button>
+    </Margins>
+    {download && (
+      <IconButton
+        primary
+        medium
+        is='a'
+        href={downloadHref}
+        download
+        icon='download'
+        aria-label={downloadAudioFileLabel}
+        onClick={onDownload}
+      />
+    )}
+  </Box>
+);
+
+export default AudioPlayerControls;

--- a/packages/fuselage/src/components/AudioPlayer/index.ts
+++ b/packages/fuselage/src/components/AudioPlayer/index.ts
@@ -1,1 +1,5 @@
 export { default as AudioPlayer, type AudioPlayerProps } from './AudioPlayer';
+export {
+  default as AudioPlayerControls,
+  type AudioPlayerControlsProps,
+} from './AudioPlayerControls';


### PR DESCRIPTION
## Why

`AudioPlayer` owns its own `<audio>` element and playback state internally, so it can't be driven by an external/shared media element. That makes cases like a persistent player (audio that keeps playing while the UI that hosts it unmounts, e.g. navigating between rooms) impossible to build on top of it — consumers currently have to re-implement the whole control layout.

## What

Extracts the presentational part of `AudioPlayer` into a new, fully **controlled** `AudioPlayerControls` component and exports it:

- `AudioPlayerControls` renders play/pause, seek, elapsed time, playback speed and the optional download button. It owns **no** `<audio>` element and **no** playback state — everything is driven by props (`isPlaying`, `currentTime`, `durationTime`, `playbackSpeed`, `onTogglePlay`, `onSeek`, `onChangePlaybackSpeed`, download props and labels).
- `AudioPlayer` keeps its previous self-contained behavior (creates the `<audio>`, manages state) and now composes `AudioPlayerControls` internally.

Consumers that need to drive a shared/external element use `AudioPlayerControls` directly; everyone already using `AudioPlayer` is unaffected.

## Backward compatibility

Non-breaking. `AudioPlayer`'s public props and rendered output are unchanged — it just delegates its inner layout to `AudioPlayerControls`.

## Notes

Added a `Controls` story demonstrating the controlled usage. Changeset included (`@rocket.chat/fuselage`: minor).