### PR TITLE
fix(fuselage): Adapt `NavBarSection` to match previous (accidental) runtime behavior

### DIFF
--- a/.changeset/cold-cases-kiss.md
+++ b/.changeset/cold-cases-kiss.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+fix: Adapt `NavBarSection` to match previous (accidental) runtime behavior

--- a/packages/fuselage/src/components/NavBar/NavBarSection.tsx
+++ b/packages/fuselage/src/components/NavBar/NavBarSection.tsx
@@ -1,33 +1,21 @@
-import type { ComponentType, HTMLAttributes, ReactElement } from 'react';
-import { Fragment, Children, isValidElement } from 'react';
+import type { HTMLAttributes } from 'react';
+import { Fragment } from 'react';
+import { isElement } from 'react-is';
+import flattenChildren from 'react-keyed-flatten-children';
 
 import NavBarDivider from './NavBarDivider';
-import NavBarGroup from './NavBarGroup';
-
-type ComponentWithDisplayName = {
-  displayName?: string;
-  props?: Record<string, unknown>;
-} & ComponentType;
 
 export type NavbarSectionProps = HTMLAttributes<HTMLSpanElement>;
 
-const isNavBarGroup = (
-  child: unknown,
-): child is ReactElement<NavbarSectionProps, ComponentWithDisplayName> => {
-  if (!isValidElement(child)) return false;
-  const component = child.type as ComponentWithDisplayName;
-  return component.name === NavBarGroup.name;
-};
-
 const NavBarSection = ({ children, ...props }: NavbarSectionProps) => {
-  const validChildren = Children.toArray(children).filter(isNavBarGroup);
+  const groups = flattenChildren(children).filter(isElement);
 
   return (
     <span className='rcx-navbar-section' {...props}>
-      {Children.toArray(children).map((child, index) => (
+      {groups.map((child, index) => (
         <Fragment key={index}>
           {child}
-          {index < validChildren.length - 1 && <NavBarDivider />}
+          {index < groups.length - 1 && <NavBarDivider />}
         </Fragment>
       ))}
     </span>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation only changes
  refactor: For code organization without affecting the end-user
  revert: For git source control reversions
  test: For test-related tasks

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
It replaces legacy React APIs under `NavBarSection` reverting the behavior on handling dividers.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
