### PR TITLE
fix: `MultiSelect`/`PaginatedMultiSelect` dropdowns never open

### DIFF
--- a/.changeset/shiny-worms-film.md
+++ b/.changeset/shiny-worms-film.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+fix: `MultiSelect`/`MultiSelectFiltered`/`PaginatedMultiSelect` dropdown never opening (pass `visible` instead of `visibility` to `PositionAnimated`)

--- a/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/fuselage/src/components/MultiSelect/MultiSelect.tsx
@@ -243,7 +243,7 @@ function MultiSelect({
           />
         </Margins>
       </FlexItem>
-      <PositionAnimated visibility={visible} anchor={containerRef}>
+      <PositionAnimated visible={visible} anchor={containerRef}>
         <_Options
           width={borderBoxSize.inlineSize}
           onMouseDown={prevent}

--- a/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
+++ b/packages/fuselage/src/components/PaginatedSelect/PaginatedMultiSelect.tsx
@@ -209,7 +209,7 @@ const PaginatedMultiSelect = ({
           />
         </Margins>
       </FlexItem>
-      <PositionAnimated visibility={visible} anchor={containerRef}>
+      <PositionAnimated visible={visible} anchor={containerRef}>
         <OptionsComponent
           width={borderBoxSize.inlineSize}
           onMouseDown={prevent}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The options dropdown of `MultiSelect`, `MultiSelectFiltered` and `PaginatedMultiSelect` never opens — typing filters nothing and no option can be selected.

Regression from #2073, which swapped the inline `<AnimatedVisibility visibility={visible}>` for the `PositionAnimated` wrapper but kept the old prop name. `AnimatedVisibility` reads `visibility`; `PositionAnimated` reads **`visible`** — so the value became `undefined` and the dropdown stayed permanently hidden. TypeScript didn't catch it (`visibility` is a valid `Box` prop).

Fix — pass the correct prop (the other callers were already correct):

```diff
- <PositionAnimated visibility={visible} anchor={containerRef}>
+ <PositionAnimated visible={visible} anchor={containerRef}>
```

in `MultiSelect.tsx` and `PaginatedMultiSelect.tsx`.

## Issue(s)

Regression from #2073. Surfaced downstream as [CORE-2393](https://rocketchat.atlassian.net/browse/CORE-2393).

## Steps to test or reproduce

Storybook → **Inputs → MultiSelect → With Filter**: type a letter → dropdown now opens and filters (before: nothing rendered).

## Further comments

[CORE-2393]: https://rocketchat.atlassian.net/browse/CORE-2393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ