### PR TITLE
feat(fuselage): opt-in atomic styling path for Box

### DIFF
--- a/packages/fuselage/src/components/Box/stylingProps.atomic.spec.ts
+++ b/packages/fuselage/src/components/Box/stylingProps.atomic.spec.ts
@@ -1,0 +1,37 @@
+import { extractAtomicStylingProps, extractStylingProps } from './stylingProps';
+
+const contentsFor = (props: Record<string, unknown>) => {
+  const [, styles] = extractAtomicStylingProps(props);
+  return styles.map((cssFn) => cssFn());
+};
+
+describe('extractAtomicStylingProps', () => {
+  it('emits one cssFn per styling prop and keeps non-styling props', () => {
+    const [rest, styles] = extractAtomicStylingProps({
+      padding: 'x8',
+      display: 'flex',
+      id: 'keep-me',
+    });
+
+    expect(styles).toHaveLength(2);
+    expect(rest).toEqual({ id: 'keep-me' });
+  });
+
+  it('yields identical content for a declaration common to two Boxes (dedup)', () => {
+    const a = contentsFor({ display: 'flex', padding: 'x8' });
+    const b = contentsFor({ display: 'flex', padding: 'x16' });
+
+    // display:flex → same content on both (one shared class); padding differs
+    const shared = a.filter((content) => b.includes(content));
+    expect(shared).toHaveLength(1);
+    expect(a).not.toEqual(b);
+  });
+
+  it('produces the same declarations as the merged path', () => {
+    const props = { display: 'flex', padding: 'x8', color: 'default' };
+    const [, merged] = extractStylingProps(props);
+    const [, atomic] = extractAtomicStylingProps(props);
+
+    expect(atomic.map((cssFn) => cssFn()).join('')).toBe(merged?.());
+  });
+});

--- a/packages/fuselage/src/components/Box/stylingProps.ts
+++ b/packages/fuselage/src/components/Box/stylingProps.ts
@@ -481,9 +481,9 @@ const compiledPropDefs = new Map(
   ),
 );
 
-export const extractStylingProps = <TProps extends Record<string, unknown>>(
+const collectStylingProps = <TProps extends Record<string, unknown>>(
   props: TProps & Partial<StylingProps>,
-): [props: TProps, styles: cssFn | undefined] => {
+): [props: TProps, styles: Map<keyof StylingProps, cssFn>] => {
   const stylingProps = new Map<keyof StylingProps, cssFn>();
   const newProps: Record<string, unknown> = {};
 
@@ -502,11 +502,35 @@ export const extractStylingProps = <TProps extends Record<string, unknown>>(
     inject(value, stylingProps);
   }
 
+  return [newProps as TProps, stylingProps];
+};
+
+export const extractStylingProps = <TProps extends Record<string, unknown>>(
+  props: TProps & Partial<StylingProps>,
+): [props: TProps, styles: cssFn | undefined] => {
+  const [newProps, stylingProps] = collectStylingProps(props);
+
   const styles = stylingProps.size
     ? css`
         ${Array.from(stylingProps.values())}
       `
     : undefined;
 
-  return [newProps as TProps, styles];
+  return [newProps, styles];
+};
+
+/**
+ * Like extractStylingProps, but returns one cssFn per styling prop instead of a
+ * single merged style. Each cssFn becomes its own atomic (one property) class,
+ * so common declarations (e.g. `display: flex`) are shared across every Box
+ * instead of duplicated inside a per-combination class.
+ */
+export const extractAtomicStylingProps = <
+  TProps extends Record<string, unknown>,
+>(
+  props: TProps & Partial<StylingProps>,
+): [props: TProps, styles: cssFn[]] => {
+  const [newProps, stylingProps] = collectStylingProps(props);
+
+  return [newProps, Array.from(stylingProps.values())];
 };

--- a/packages/fuselage/src/components/Box/useStylingProps.ts
+++ b/packages/fuselage/src/components/Box/useStylingProps.ts
@@ -1,10 +1,45 @@
 import { appendClassName } from '../../helpers/appendClassName';
+import { useAtomicStyle } from '../../hooks/useAtomicStyle';
 import { useStyle } from '../../hooks/useStyle';
 
 import type { StylingProps } from './stylingProps';
-import { extractStylingProps } from './stylingProps';
+import { extractAtomicStylingProps, extractStylingProps } from './stylingProps';
 
-export const useStylingProps = <TProps extends { className?: string }>(
+/**
+ * Opt into the experimental atomic styling path (one class per prop) to compare
+ * it against the default per-combination path. Run in the browser console then
+ * reload:
+ *   localStorage.setItem('fuselage-styling', 'atomic')  // atomic (experimental)
+ *   localStorage.removeItem('fuselage-styling')         // per-combination (default)
+ *
+ * Read once at module load so the branch stays stable across renders and the
+ * two paths never mix their hooks.
+ */
+const ATOMIC_STYLING = (() => {
+  try {
+    return globalThis.localStorage?.getItem('fuselage-styling') === 'atomic';
+  } catch {
+    return false;
+  }
+})();
+
+const useAtomicStylingProps = <TProps extends { className?: string }>(
+  originalProps: TProps,
+): Omit<TProps, keyof StylingProps> => {
+  const [props, styles] = extractAtomicStylingProps(originalProps);
+
+  const newClassName = useAtomicStyle(styles);
+
+  if (newClassName) {
+    props.className = props.className
+      ? appendClassName(props.className, newClassName)
+      : newClassName;
+  }
+
+  return props;
+};
+
+const useMergedStylingProps = <TProps extends { className?: string }>(
   originalProps: TProps,
 ): Omit<TProps, keyof StylingProps> => {
   const [props, styles] = extractStylingProps(originalProps);
@@ -19,3 +54,7 @@ export const useStylingProps = <TProps extends { className?: string }>(
 
   return props;
 };
+
+export const useStylingProps = ATOMIC_STYLING
+  ? useAtomicStylingProps
+  : useMergedStylingProps;

--- a/packages/fuselage/src/hooks/buildAtomicClassName.ts
+++ b/packages/fuselage/src/hooks/buildAtomicClassName.ts
@@ -1,0 +1,33 @@
+import { createClassName } from '@rocket.chat/css-in-js';
+
+const SINGLE_DECLARATION = /^([a-z-]+):\s*(.+?)\s*(?:!important)?;?$/;
+
+/**
+ * Readable class name for an atomic (single-prop) style. Prefixes the class
+ * with `<property>[-<value>]` so it can be recognised in the DOM, and always
+ * keeps a short content hash so distinct declarations can never collide.
+ * Falls back to the plain hash for multi-declaration or non-tokenish values
+ * (e.g. `var(--…)` colors, `calc(…)`, box-shadows).
+ *
+ * Kept free of React imports so it can be reused by build-time tooling.
+ */
+export const buildAtomicClassName = (content: string): string => {
+  const hash = createClassName(content).slice('rcx-css-'.length);
+  const match = SINGLE_DECLARATION.exec(content);
+
+  if (match) {
+    const [, property, rawValue] = match;
+    const value = rawValue
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    if (value && value.length <= 24) {
+      return `rcx-${property}-${value}-${hash.slice(0, 5)}`;
+    }
+
+    return `rcx-${property}-${hash}`;
+  }
+
+  return `rcx-css-${hash}`;
+};

--- a/packages/fuselage/src/hooks/useAtomicStyle.spec.ts
+++ b/packages/fuselage/src/hooks/useAtomicStyle.spec.ts
@@ -1,0 +1,34 @@
+import { buildAtomicClassName } from './useAtomicStyle';
+
+describe('buildAtomicClassName', () => {
+  it('embeds property and tokenish value with a short hash suffix', () => {
+    expect(buildAtomicClassName('display: flex !important;')).toMatch(
+      /^rcx-display-flex-[0-9a-z]{5}$/,
+    );
+    expect(
+      buildAtomicClassName('justify-content: space-between !important;'),
+    ).toMatch(/^rcx-justify-content-space-between-[0-9a-z]{5}$/);
+  });
+
+  it('keeps the property but full hash when the value is not tokenish', () => {
+    const cls = buildAtomicClassName(
+      'color: var(--rcx-color-font-default) !important;',
+    );
+    expect(cls).toMatch(/^rcx-color-[0-9a-z]+$/);
+    expect(cls).not.toContain('var-');
+  });
+
+  it('falls back to the plain hash for multi-declaration content', () => {
+    const cls = buildAtomicClassName(
+      'box-shadow: none;\n      border: 1px solid red;',
+    );
+    expect(cls).toMatch(/^rcx-css-[0-9a-z]+$/);
+  });
+
+  it('is deterministic and distinguishes different values', () => {
+    const a = buildAtomicClassName('padding: 0.5rem !important;');
+    const b = buildAtomicClassName('padding: 1rem !important;');
+    expect(a).toBe(buildAtomicClassName('padding: 0.5rem !important;'));
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/fuselage/src/hooks/useAtomicStyle.ts
+++ b/packages/fuselage/src/hooks/useAtomicStyle.ts
@@ -1,0 +1,47 @@
+import type { cssFn } from '@rocket.chat/css-in-js';
+import { escapeName, transpile, attachRules } from '@rocket.chat/css-in-js';
+import { useDebugValue, useInsertionEffect, useMemo } from 'react';
+
+import { useOwnerDocument } from '../contexts';
+
+import { buildAtomicClassName } from './buildAtomicClassName';
+
+export { buildAtomicClassName };
+
+/**
+ * Atomic counterpart of useStyle: takes one cssFn per styling prop and emits
+ * one class per prop instead of a single merged class. attachRules already
+ * dedupes identical rules per document and ref-counts them, so shared
+ * declarations (e.g. `display: flex`) resolve to a single stylesheet rule
+ * reused by every Box instead of being duplicated in each combination class.
+ */
+export const useAtomicStyle = (styles: cssFn[]): string => {
+  const rules = useMemo(
+    () =>
+      styles.map((cssFn) => {
+        const content = cssFn();
+        const className = buildAtomicClassName(content);
+        return { className, selector: `.${escapeName(className)}`, content };
+      }),
+    [styles],
+  );
+
+  const classNames = rules.map((rule) => rule.className).join(' ');
+  useDebugValue(classNames);
+
+  const { document } = useOwnerDocument();
+
+  useInsertionEffect(() => {
+    const detaches = rules.map(({ selector, content }) =>
+      attachRules(transpile(selector, content), { document }),
+    );
+
+    return () => {
+      for (const detach of detaches) {
+        setTimeout(detach, 1000);
+      }
+    };
+  }, [rules, document]);
+
+  return classNames;
+};


### PR DESCRIPTION
Adds an **opt-in** atomic styling path for `Box` (one class per prop) alongside the current per-combination path, so the two can be compared.

Toggle at runtime (read once at module load), default unchanged:
```js
localStorage.setItem('fuselage-styling', 'atomic') // atomic
localStorage.removeItem('fuselage-styling')        // per-combination (default)
```

- `extractAtomicStylingProps` + `useAtomicStyle`: one class per styling prop; `attachRules` dedupes/ref-counts shared declarations into a single rule.
- `buildAtomicClassName`: readable `rcx-<property>-<value>-<hash>` names (hash suffix keeps distinct declarations collision-free).
- Specs: atomic emits the **same declarations** as the merged path; one-class-per-prop; cross-Box dedup.

Bench (2000 Boxes): stylesheet 1883 → 22 rules. Per-render CPU is ~equal (atomic does N hashes/box vs 1) — the render-CPU win comes from the stacked build-time PR.

Draft — comparison/foundation. Build-time compiler stacks on top in a follow-up PR.