### PR TITLE
feat(fuselage): PoC build-time atomic extraction for Box

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default tseslint.config(
       '.yarn/**',
       '**/storybook-static/**',
       '**/*.api.md',
+      '**/poc/**',
     ],
   },
   {

--- a/packages/fuselage/.storybook/main.ts
+++ b/packages/fuselage/.storybook/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
     });
 
     // PoC: build-time atomic extraction for <Box>. Opt-in via BOX_COMPILER=1.
-    if (process.env.BOX_COMPILER === '1') {
+    if (process.env['BOX_COMPILER'] === '1') {
       /* eslint-disable @typescript-eslint/no-require-imports */
       const boxPlugin = require('../poc/box-compiler/plugin.cjs');
       const {

--- a/packages/fuselage/.storybook/main.ts
+++ b/packages/fuselage/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
@@ -8,6 +8,49 @@ const config: StorybookConfig = {
       test: /\.woff2$/,
       type: 'asset/resource',
     });
+
+    // PoC: build-time atomic extraction for <Box>. Opt-in via BOX_COMPILER=1.
+    if (process.env.BOX_COMPILER === '1') {
+      /* eslint-disable @typescript-eslint/no-require-imports */
+      const boxPlugin = require('../poc/box-compiler/plugin.cjs');
+      const {
+        styleProps,
+        resolve: resolveBox,
+      } = require('../poc/box-compiler/resolver.generated.cjs');
+      /* eslint-enable @typescript-eslint/no-require-imports */
+
+      config.module?.rules?.unshift({
+        test: /\.tsx$/,
+        include: [resolve(__dirname, '../src')],
+        enforce: 'pre',
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              configFile: false,
+              presets: [
+                [
+                  require.resolve('@babel/preset-typescript'),
+                  { isTSX: true, allExtensions: true },
+                ],
+              ],
+              plugins: [
+                [
+                  boxPlugin,
+                  {
+                    styleProps,
+                    resolve: resolveBox,
+                    inject: true,
+                    keepProps: true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      });
+    }
 
     return config;
   },

--- a/packages/fuselage/poc/box-compiler/APPLYING-IN-ROCKETCHAT.md
+++ b/packages/fuselage/poc/box-compiler/APPLYING-IN-ROCKETCHAT.md
@@ -1,0 +1,129 @@
+# Applying the Box build-time compiler in Rocket.Chat
+
+How to run this plugin against the Rocket.Chat client (`apps/meteor`).
+
+## TL;DR
+
+Rocket.Chat's client is compiled by **Meteor's `babel-compiler` (Babel, not
+SWC — SWC is dormant under `modern: true`)**, and it **merges
+`apps/meteor/.babelrc`'s `plugins` array** into the transform for every app
+file. So the plugin drops into that array. No webpack/vite/loader exists for
+the client, so use `inject` mode (runtime `attachRules`) — it matches the
+CSS-in-JS injection Fuselage already does; there is no static-CSS-asset path in
+Meteor to target.
+
+## Prerequisite: this is a coordinated change, not just a plugin
+
+The render-CPU win needs **two halves**:
+
+1. **Build half** — this plugin, added to `apps/meteor/.babelrc`. Rewrites
+   `<Box>` at build time: precomputes atomic classes, keeps the props, adds a
+   `data-rcx-atomic` marker.
+2. **Runtime half** — a Fuselage build whose `useStylingProps` honors that
+   marker and skips restyling the compiled props (this branch,
+   `feat/box-atomic-styling`).
+
+Rocket.Chat ships the **published** Fuselage, which does **not** have the
+runtime half. If you add only the build plugin:
+
+- correctness is fine (props are kept; the published runtime restyles them), but
+- there is **no CPU win** (the marker is ignored, so the runtime does the work
+  anyway) and you get a redundant class per Box.
+
+So step 1 is pointing Rocket.Chat at a Fuselage that includes the runtime half.
+
+## Step 1 — Rocket.Chat must use the marker-aware Fuselage
+
+Point `@rocket.chat/fuselage` at this branch (any one of):
+
+- `yarn link` a local `feat/box-atomic-styling` Fuselage build, or
+- a canary/prerelease published from this branch, or
+- a `resolutions` override to a git/tarball build of this branch.
+
+Verify the installed Fuselage `dist` contains the marker check
+(`data-rcx-atomic` in `useStylingProps`).
+
+## Step 2 — Get the plugin + resolver into the repo
+
+The plugin needs its resolver snapshot. **Regenerate the resolver against the
+exact Fuselage version Rocket.Chat installs** (token maps must match, or classes
+drift):
+
+```sh
+# from the fuselage checkout that matches RC's installed version
+node -e "require('esbuild').build({entryPoints:['poc/box-compiler/resolver.entry.ts'],\
+outfile:'poc/box-compiler/resolver.generated.cjs',bundle:true,platform:'node',\
+format:'cjs',external:['@rocket.chat/css-in-js']})"
+```
+
+Copy `plugin.cjs` + `resolver.generated.cjs` into the app, e.g.
+`apps/meteor/.babel/box-atomic/`. (Longer term: export both from the Fuselage
+package so RC consumes them directly and they stay version-locked.)
+
+`@rocket.chat/css-in-js` (what the injected `attachRules` import resolves to) is
+already a transitive dep of Fuselage in `apps/meteor/node_modules`, so the
+injected import resolves with no extra install.
+
+## Step 3 — Wire it into `apps/meteor/.babelrc`
+
+Scope it to client code with a Babel `overrides` block so server files are never
+touched (they have no `<Box>` anyway, but this keeps the blast radius small):
+
+```json
+{
+  "presets": [
+    "@babel/preset-env",
+    ["@babel/preset-react", { "runtime": "automatic" }],
+    ["@babel/preset-typescript", { "allowDeclareFields": true }]
+  ],
+  "overrides": [
+    {
+      "test": ["./client/**/*.tsx", "./ee/client/**/*.tsx", "./imports/**/*.tsx"],
+      "plugins": [["./.babel/box-atomic/plugin.cjs", { "inject": true }]]
+    }
+  ],
+  "env": {
+    "coverage": { "plugins": [["istanbul", { "exclude": ["**/*.spec.js", "**/*.test.js"] }]] }
+  }
+}
+```
+
+- `inject: true` → each transformed module gets a top-of-file
+  `attachRules("<its rules>")`; the CSS lands at module load using Fuselage's
+  own `<style id="rcx-styles">`. `attachRules` dedupes/ref-counts, so shared
+  declarations become one rule.
+- `keepProps` defaults to **true** (safe): props stay on the element for
+  runtime introspection (`cloneElement`, `child.props.x`, spreads); the runtime
+  skips them via the marker. Do **not** set `keepProps:false` app-wide — it is
+  unsafe wherever code reads a Box's props.
+- Plugins run before presets, so the plugin sees JSX before `preset-react`
+  turns it into `_jsx(...)`. Good.
+
+Meteor caches Babel output aggressively — clear `.meteor/local/` (or bump a
+cache key) after changing `.babelrc` so files recompile.
+
+## Step 4 — Verify
+
+Run the client, inspect a `Box` in DevTools:
+
+- element has semantic atomic classes (`rcx-display-flex-…`, `rcx-padding-…`)
+  **and** a `data-rcx-atomic="…"` attribute,
+- `document.getElementById('rcx-styles')` contains the injected rules,
+- nothing renders empty (children/introspection intact).
+
+## Measuring the win in Rocket.Chat
+
+- **Stylesheet size**: count `rcx-css-*` combination rules before vs `rcx-*`
+  atomic rules after on a heavy screen (admin, room).
+- **Render CPU**: React Profiler commit durations on a Box-heavy view, or the
+  bench story approach adapted to a real route.
+- Build a **production** bundle for real numbers (dev Babel + StrictMode inflate).
+
+## Scope / limits
+
+- Only `<Box>` by local name, only literal props. `<Box>` aliased on import,
+  spreads, and dynamic props fall through to the runtime (correct, just not
+  precompiled).
+- Meteor has no loader pipeline → the static-CSS-asset variant (webpack/vite,
+  via the `sheet` option) does not apply here; `inject` is the right mode.
+- Resolver is a snapshot — regenerate on every Fuselage bump.

--- a/packages/fuselage/poc/box-compiler/APPLYING-IN-ROCKETCHAT.md
+++ b/packages/fuselage/poc/box-compiler/APPLYING-IN-ROCKETCHAT.md
@@ -78,12 +78,18 @@ touched (they have no `<Box>` anyway, but this keeps the blast radius small):
   ],
   "overrides": [
     {
-      "test": ["./client/**/*.tsx", "./ee/client/**/*.tsx", "./imports/**/*.tsx"],
+      "test": [
+        "./client/**/*.tsx",
+        "./ee/client/**/*.tsx",
+        "./imports/**/*.tsx"
+      ],
       "plugins": [["./.babel/box-atomic/plugin.cjs", { "inject": true }]]
     }
   ],
   "env": {
-    "coverage": { "plugins": [["istanbul", { "exclude": ["**/*.spec.js", "**/*.test.js"] }]] }
+    "coverage": {
+      "plugins": [["istanbul", { "exclude": ["**/*.spec.js", "**/*.test.js"] }]]
+    }
   }
 }
 ```

--- a/packages/fuselage/poc/box-compiler/README.md
+++ b/packages/fuselage/poc/box-compiler/README.md
@@ -77,19 +77,21 @@ Two harnesses:
 
 - **Node microbench** (reliable, no browser) — measures the per-render hot path
   (`extract → css() → hash`) and stylesheet growth across the three modes:
+
   ```sh
   node -e "require('esbuild').build({entryPoints:['poc/box-compiler/bench.node.entry.ts'],\
   outfile:'poc/box-compiler/bench.node.generated.cjs',bundle:true,platform:'node',\
   format:'cjs',external:['@rocket.chat/css-in-js']})"
   node -e "console.log(require('./poc/box-compiler/bench.node.generated.cjs').run(2000,50))"
   ```
+
   Sample (2000 Boxes, median of 50):
 
-  | mode          | per-render CPU | stylesheet rules |
-  | ------------- | -------------- | ---------------- |
-  | merged        | 9.58 ms        | 1883             |
-  | atomic-runtime| 11.07 ms       | 22               |
-  | build-time    | 0.02 ms        | 22               |
+  | mode           | per-render CPU | stylesheet rules |
+  | -------------- | -------------- | ---------------- |
+  | merged         | 9.58 ms        | 1883             |
+  | atomic-runtime | 11.07 ms       | 22               |
+  | build-time     | 0.02 ms        | 22               |
 
   Takeaway: atomic **runtime** is not a render-CPU win (N hashes/box vs 1) but
   collapses the stylesheet ~85×; the render-CPU win comes from the **build-time**

--- a/packages/fuselage/poc/box-compiler/README.md
+++ b/packages/fuselage/poc/box-compiler/README.md
@@ -1,0 +1,111 @@
+# PoC — build-time atomic extraction for `<Box>`
+
+Proof of concept for the "Tamagui-style" compiler step discussed alongside the
+runtime atomic path. A Babel plugin rewrites `<Box>` at build time so that
+**static** styling props never reach the runtime.
+
+## What it does
+
+For every `<Box>` whose styling props are static literals:
+
+- resolves them to atomic class names **at build time**,
+- strips the props from the JSX,
+- adds/merges a plain `className`,
+- collects the matching CSS rules into an out-of-band sheet (deduped).
+
+Non-literal props (expressions) are left untouched and handled by the runtime
+atomic path (`useAtomicStyle`). A `Box` with only dynamic props is unchanged.
+
+```jsx
+// in
+<Box p="x8" display="flex" bg="tint" className={cls}>hi</Box>
+
+// out
+<Box className={"rcx-padding-… rcx-display-flex-… rcx-bg-… " + cls}>hi</Box>
+// + CSS sheet: .rcx-padding-…{padding:0.5rem!important} .rcx-display-flex-…{…} …
+```
+
+## Zero token drift
+
+Resolution is injected via plugin options, so the plugin reuses Fuselage's real
+runtime resolver (`extractAtomicStylingProps` + `buildAtomicClassName`). The
+classes and rules it emits are byte-identical to the runtime atomic path — the
+compiler just moves the work from render time to build time.
+
+## Run it
+
+```sh
+# transform demo (fake resolver, illustration only)
+node poc/box-compiler/demo.cjs
+
+# real resolver + assertions
+yarn jest src/utilities/boxCompiler.poc.spec.ts
+```
+
+## See it in Storybook
+
+The plugin is wired into Storybook's webpack as an `enforce: 'pre'` babel pass
+(runs before SWC, keeps JSX), gated behind an env flag so normal Storybook is
+untouched:
+
+```sh
+# build-time compiled (props baked into className, CSS via attachRules)
+BOX_COMPILER=1 yarn storybook -p 6007
+
+# normal Storybook (runtime path; compare with the localStorage toggle)
+yarn storybook -p 6006
+```
+
+On the compiled instance, inspect a `Box` in e.g. `Layout/Borders`: the element
+carries multiple semantic atomic classes (`rcx-display-flex-…`,
+`rcx-padding-…`) even with `localStorage` cleared — proof they came from the
+build, not the runtime. The served `main.iframe.bundle.js` contains
+`attachRules(".rcx-…")` calls injected per module.
+
+The build-time resolver is a bundled snapshot of the real runtime resolver.
+Regenerate it after changing `stylingProps.ts` / `buildAtomicClassName.ts`:
+
+```sh
+node -e "require('esbuild').build({entryPoints:['poc/box-compiler/resolver.entry.ts'],\
+outfile:'poc/box-compiler/resolver.generated.cjs',bundle:true,platform:'node',\
+format:'cjs',external:['@rocket.chat/css-in-js']})"
+```
+
+## Benchmark
+
+Two harnesses:
+
+- **Node microbench** (reliable, no browser) — measures the per-render hot path
+  (`extract → css() → hash`) and stylesheet growth across the three modes:
+  ```sh
+  node -e "require('esbuild').build({entryPoints:['poc/box-compiler/bench.node.entry.ts'],\
+  outfile:'poc/box-compiler/bench.node.generated.cjs',bundle:true,platform:'node',\
+  format:'cjs',external:['@rocket.chat/css-in-js']})"
+  node -e "console.log(require('./poc/box-compiler/bench.node.generated.cjs').run(2000,50))"
+  ```
+  Sample (2000 Boxes, median of 50):
+
+  | mode          | per-render CPU | stylesheet rules |
+  | ------------- | -------------- | ---------------- |
+  | merged        | 9.58 ms        | 1883             |
+  | atomic-runtime| 11.07 ms       | 22               |
+  | build-time    | 0.02 ms        | 22               |
+
+  Takeaway: atomic **runtime** is not a render-CPU win (N hashes/box vs 1) but
+  collapses the stylesheet ~85×; the render-CPU win comes from the **build-time**
+  step. Caveats: resolution+hash only (no DOM insertRule, no css-in-js content
+  memoization); `buildAtomicClassName` regex unoptimized.
+
+- **Storybook bench story** (`Layout/Box/Bench`) — in-browser, real React +
+  insertRule. Open the story, hit **run**, compare across `:6006` (merged),
+  `:6006` + `localStorage fuselage-styling=atomic`, and `:6007` (build-time).
+  `poc/box-compiler/bench.run.cjs` is a Playwright driver for it (note: SB dev
+  routes headless loads to the Docs tab; drive it in a real browser for now).
+
+## Scope / not done yet
+
+- Only `<Box>` by local name, only literal props. `is` flattening, spreads,
+  ternaries, imported constants → left to runtime (conservative bail-out).
+- No webpack/vite wiring; the sheet is collected in-memory to prove the model.
+- Next step if adopted: emit the sheet to a `.css` asset and register the
+  plugin in the build.

--- a/packages/fuselage/poc/box-compiler/bench.node.entry.ts
+++ b/packages/fuselage/poc/box-compiler/bench.node.entry.ts
@@ -1,0 +1,99 @@
+import { createClassName } from '@rocket.chat/css-in-js';
+
+import {
+  extractStylingProps,
+  extractAtomicStylingProps,
+} from '../../src/components/Box/stylingProps';
+import { buildAtomicClassName } from '../../src/hooks/buildAtomicClassName';
+
+const POOLS: Record<string, unknown[]> = {
+  padding: ['x4', 'x8', 'x12', 'x16', 'x24'],
+  margin: ['x4', 'x8'],
+  display: ['flex', 'block', 'inline-flex'],
+  alignItems: ['center', 'flex-start', 'stretch'],
+  justifyContent: ['center', 'space-between', 'flex-end'],
+  fontScale: ['p1', 'p2', 'c1'],
+  borderRadius: [2, 4, 8],
+};
+
+// Deterministic-ish corpus of N Boxes drawn from small value pools: many
+// distinct COMBINATIONS, few distinct prop-value PAIRS.
+const makeCorpus = (n: number) => {
+  const keys = Object.keys(POOLS);
+  const out: Record<string, unknown>[] = [];
+  let seed = 1;
+  const rnd = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  for (let i = 0; i < n; i++) {
+    const props: Record<string, unknown> = {};
+    for (const k of keys) {
+      if (rnd() < 0.7) props[k] = POOLS[k][Math.floor(rnd() * POOLS[k].length)];
+    }
+    out.push(props);
+  }
+  return out;
+};
+
+const timeit = (fn: () => void, iters: number) => {
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  return performance.now() - t0;
+};
+
+export const run = (n = 2000, iters = 40) => {
+  const corpus = makeCorpus(n);
+
+  const merged = () => {
+    for (const p of corpus) {
+      const [, styles] = extractStylingProps(p);
+      if (styles) createClassName(styles());
+    }
+  };
+  const atomic = () => {
+    for (const p of corpus) {
+      const [, styles] = extractAtomicStylingProps(p);
+      for (const cssFn of styles) buildAtomicClassName(cssFn());
+    }
+  };
+  const compiled = () => {
+    // build-time: classNames precomputed; per render the runtime just checks
+    // the marker (dropCompiledProps) — represented as that cheap prop read.
+    for (const p of corpus) {
+      if (p['data-rcx-atomic']) continue;
+    }
+  };
+
+  // warmup
+  merged();
+  atomic();
+
+  const mergedMs = timeit(merged, iters);
+  const atomicMs = timeit(atomic, iters);
+  const compiledMs = timeit(compiled, iters);
+
+  // stylesheet growth: distinct rules each strategy inserts
+  const mergedRules = new Set<string>();
+  const atomicRules = new Set<string>();
+  for (const p of corpus) {
+    const [, s] = extractStylingProps(p);
+    if (s) mergedRules.add(createClassName(s()));
+    const [, arr] = extractAtomicStylingProps(p);
+    for (const cssFn of arr) atomicRules.add(buildAtomicClassName(cssFn()));
+  }
+
+  return {
+    boxes: n,
+    iters,
+    perRender_ms: {
+      merged: +(mergedMs / iters).toFixed(2),
+      atomicRuntime: +(atomicMs / iters).toFixed(2),
+      buildTime: +(compiledMs / iters).toFixed(2),
+    },
+    stylesheetRules: {
+      merged: mergedRules.size,
+      atomic: atomicRules.size,
+    },
+  };
+};

--- a/packages/fuselage/poc/box-compiler/bench.node.generated.cjs
+++ b/packages/fuselage/poc/box-compiler/bench.node.generated.cjs
@@ -1,0 +1,1162 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// ../../node_modules/invariant/invariant.js
+var require_invariant = __commonJS({
+  "../../node_modules/invariant/invariant.js"(exports2, module2) {
+    "use strict";
+    var NODE_ENV = process.env.NODE_ENV;
+    var invariant3 = function(condition, format, a, b, c, d, e, f) {
+      if (NODE_ENV !== "production") {
+        if (format === void 0) {
+          throw new Error("invariant requires an error message argument");
+        }
+      }
+      if (!condition) {
+        var error;
+        if (format === void 0) {
+          error = new Error(
+            "Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings."
+          );
+        } else {
+          var args = [a, b, c, d, e, f];
+          var argIndex = 0;
+          error = new Error(
+            format.replace(/%s/g, function() {
+              return args[argIndex++];
+            })
+          );
+          error.name = "Invariant Violation";
+        }
+        error.framesToPop = 1;
+        throw error;
+      }
+    };
+    module2.exports = invariant3;
+  }
+});
+
+// ../memo/dist/cjs/memoize.js
+var require_memoize = __commonJS({
+  "../memo/dist/cjs/memoize.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.clear = exports2.memoize = void 0;
+    var store = /* @__PURE__ */ new WeakMap();
+    var isCachedValue = (cachedValue, arg, cache) => cache.has(arg) && cache.get(arg) === cachedValue;
+    var memoize2 = (fn, _options) => {
+      const cache = /* @__PURE__ */ new Map();
+      const cacheTimers = /* @__PURE__ */ new Map();
+      const memoized = function(arg) {
+        const cleanUp = () => {
+          cache.delete(arg);
+          cacheTimers.delete(arg);
+        };
+        const cachedValue = cache.get(arg);
+        if (isCachedValue(cachedValue, arg, cache)) {
+          const oldTimer = cacheTimers.get(arg);
+          if (oldTimer) {
+            clearTimeout(oldTimer);
+          }
+          if (_options) {
+            const timer = setTimeout(cleanUp, _options.maxAge);
+            cacheTimers.set(arg, timer);
+          }
+          return cachedValue;
+        }
+        const result = fn.call(this, arg);
+        cache.set(arg, result);
+        if (_options) {
+          const timer = setTimeout(cleanUp, _options.maxAge);
+          cacheTimers.set(arg, timer);
+        }
+        return result;
+      };
+      store.set(memoized, cache);
+      return memoized;
+    };
+    exports2.memoize = memoize2;
+    var clear = (fn) => {
+      const cache = store.get(fn);
+      cache?.clear();
+    };
+    exports2.clear = clear;
+  }
+});
+
+// ../memo/dist/cjs/index.js
+var require_cjs = __commonJS({
+  "../memo/dist/cjs/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.clear = exports2.memoize = void 0;
+    var memoize_1 = require_memoize();
+    Object.defineProperty(exports2, "memoize", { enumerable: true, get: function() {
+      return memoize_1.memoize;
+    } });
+    Object.defineProperty(exports2, "clear", { enumerable: true, get: function() {
+      return memoize_1.clear;
+    } });
+  }
+});
+
+// poc/box-compiler/bench.node.entry.ts
+var bench_node_entry_exports = {};
+__export(bench_node_entry_exports, {
+  run: () => run
+});
+module.exports = __toCommonJS(bench_node_entry_exports);
+var import_css_in_js3 = require("@rocket.chat/css-in-js");
+
+// src/components/Box/stylingProps.ts
+var import_css_in_js = require("@rocket.chat/css-in-js");
+
+// ../fuselage-tokens/colors.json
+var colors_default = {
+  white: "#FFFFFF",
+  n100: "#F7F8FA",
+  n200: "#F2F3F5",
+  n250: "#EBECEF",
+  n300: "#EEEFF1",
+  n400: "#E4E7EA",
+  n450: "#D7DBE0",
+  n500: "#CBCED1",
+  n600: "#9EA2A8",
+  n700: "#6C737A",
+  n800: "#2F343D",
+  n900: "#1F2329",
+  r100: "#FFE9EC",
+  r200: "#FFC1C9",
+  r300: "#F98F9D",
+  r400: "#F5455C",
+  r500: "#EC0D2A",
+  r600: "#D40C26",
+  r700: "#BB0B21",
+  r800: "#9B1325",
+  r900: "#8B0719",
+  r1000: "#6B0513",
+  o100: "#FDE8D7",
+  o200: "#FAD1B0",
+  o300: "#F7B27B",
+  o400: "#F59B53",
+  o500: "#F38C39",
+  o600: "#E26D0E",
+  o700: "#BD5A0B",
+  o800: "#974809",
+  o900: "#713607",
+  o1000: "#5B2C06",
+  p100: "#F9EFFC",
+  p200: "#EDD0F7",
+  p300: "#DCA0EF",
+  p400: "#CA71E7",
+  p500: "#9F22C7",
+  p600: "#7F1B9F",
+  p700: "#5F1477",
+  p800: "#4A105D",
+  p900: "#350B42",
+  y100: "#FFF8E0",
+  y200: "#FFECAD",
+  y300: "#FFE383",
+  y400: "#FFD95A",
+  y500: "#FFD031",
+  y600: "#F3BE08",
+  y700: "#DFAC00",
+  y800: "#AC892F",
+  y900: "#8E6300",
+  y1000: "#573D00",
+  g100: "#E5FBF4",
+  g200: "#C0F6E4",
+  g300: "#96F0D2",
+  g400: "#6CE9C0",
+  g500: "#2DE0A5",
+  g600: "#1ECB92",
+  g700: "#19AC7C",
+  g800: "#148660",
+  g900: "#106D4F",
+  g1000: "#0D5940",
+  b100: "#E8F2FF",
+  b200: "#D1EBFE",
+  b300: "#76B7FC",
+  b400: "#549DF9",
+  b500: "#156FF5",
+  b600: "#095AD2",
+  b700: "#10529E",
+  b800: "#01336B",
+  b900: "#012247"
+};
+
+// src/getPaletteColor.ts
+var import_invariant = __toESM(require_invariant());
+var isPaletteColorRef = (ref) => typeof ref === "string" && ref in colors_default;
+var mapTypeToPrefix = {
+  neutral: "n",
+  blue: "b",
+  green: "g",
+  yellow: "y",
+  red: "r",
+  orange: "o",
+  purple: "p"
+};
+var getPaletteColor = (type, grade, alpha) => {
+  const ref = `${mapTypeToPrefix[type]}${grade}`;
+  (0, import_invariant.default)(isPaletteColorRef(ref), "invalid color reference");
+  const baseColor = colors_default[ref];
+  const matches = /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/.exec(
+    baseColor
+  );
+  (0, import_invariant.default)(!!matches, "invalid color token format");
+  if (alpha !== void 0) {
+    const [, r, g, b] = matches;
+    return [
+      `--rcx-color-${type}-${grade}-${(alpha * 100).toFixed(0)}`,
+      `rgba(${parseInt(r, 16)}, ${parseInt(g, 16)}, ${parseInt(b, 16)}, ${alpha * 100}%)`
+    ];
+  }
+  return [`--rcx-color-${type}-${grade}`, baseColor];
+};
+
+// src/helpers/toCSSValue.ts
+var toCSSValue = (label, value) => `var(${label}, ${value})`;
+var toCSSFontValue = (label, value) => toCSSValue(`--rcx-font-family-${label}`, value);
+var toCSSColorValue = (label, value) => toCSSValue(`--rcx-color-${label}`, value);
+
+// src/Theme.ts
+var Var = class _Var {
+  name;
+  value;
+  constructor(name, value) {
+    this.name = name;
+    this.value = value;
+  }
+  toString() {
+    return toCSSColorValue(this.name, this.value);
+  }
+  theme(name) {
+    return new _Var(name, this.toString());
+  }
+};
+var white = new Var("white", "#ffffff");
+var throwErrorOnInvalidToken = false;
+var neutral = {
+  100: new Var("neutral-100", colors_default.n100),
+  200: new Var("neutral-200", colors_default.n200),
+  250: new Var("neutral-250", colors_default.n250),
+  300: new Var("neutral-300", colors_default.n300),
+  400: new Var("neutral-400", colors_default.n400),
+  450: new Var("neutral-450", colors_default.n450),
+  500: new Var("neutral-500", colors_default.n500),
+  600: new Var("neutral-600", colors_default.n600),
+  700: new Var("neutral-700", colors_default.n700),
+  800: new Var("neutral-800", colors_default.n800),
+  900: new Var("neutral-900", colors_default.n900)
+};
+var blue = {
+  100: new Var("primary-100", colors_default.b100),
+  200: new Var("primary-200", colors_default.b200),
+  300: new Var("primary-300", colors_default.b300),
+  400: new Var("primary-400", colors_default.b400),
+  500: new Var("primary-500", colors_default.b500),
+  600: new Var("primary-600", colors_default.b600),
+  700: new Var("primary-700", colors_default.b700),
+  800: new Var("primary-800", colors_default.b800),
+  900: new Var("primary-900", colors_default.b900)
+};
+var green = {
+  100: new Var("success-100", colors_default.g100),
+  200: new Var("success-200", colors_default.g200),
+  300: new Var("success-300", colors_default.g300),
+  400: new Var("success-400", colors_default.g400),
+  500: new Var("success-500", colors_default.g500),
+  600: new Var("success-600", colors_default.g600),
+  700: new Var("success-700", colors_default.g700),
+  800: new Var("success-800", colors_default.g800),
+  900: new Var("success-900", colors_default.g900)
+};
+var yellow = {
+  100: new Var("warning-100", colors_default.y100),
+  200: new Var("warning-200", colors_default.y200),
+  300: new Var("warning-300", colors_default.y300),
+  400: new Var("warning-400", colors_default.y400),
+  500: new Var("warning-500", colors_default.y500),
+  600: new Var("warning-600", colors_default.y600),
+  700: new Var("warning-700", colors_default.y700),
+  800: new Var("warning-800", colors_default.y800),
+  900: new Var("warning-900", colors_default.y900)
+};
+var red = {
+  100: new Var("danger-100", colors_default.r100),
+  200: new Var("danger-200", colors_default.r200),
+  300: new Var("danger-300", colors_default.r300),
+  400: new Var("danger-400", colors_default.r400),
+  500: new Var("danger-500", colors_default.r500),
+  600: new Var("danger-600", colors_default.r600),
+  700: new Var("danger-700", colors_default.r700),
+  800: new Var("danger-800", colors_default.r800),
+  900: new Var("danger-900", colors_default.r900)
+};
+var orange = {
+  100: new Var("service-1-100", colors_default.o100),
+  200: new Var("service-1-200", colors_default.o200),
+  300: new Var("service-1-300", colors_default.o300),
+  400: new Var("service-1-400", colors_default.o400),
+  500: new Var("service-1-500", colors_default.o500),
+  600: new Var("service-1-600", colors_default.o600),
+  700: new Var("service-1-700", colors_default.o700),
+  800: new Var("service-1-800", colors_default.o800),
+  900: new Var("service-1-900", colors_default.o900)
+};
+var purple = {
+  100: new Var("service-2-100", colors_default.p100),
+  200: new Var("service-2-200", colors_default.p200),
+  300: new Var("service-2-300", colors_default.p300),
+  400: new Var("service-2-400", colors_default.p400),
+  500: new Var("service-2-500", colors_default.p500),
+  600: new Var("service-2-600", colors_default.p600),
+  700: new Var("service-2-700", colors_default.p700),
+  800: new Var("service-2-800", colors_default.p800),
+  900: new Var("service-2-900", colors_default.p900)
+};
+var surfaceColors = {
+  "surface-light": white.theme("surface-light"),
+  "surface-tint": neutral[100].theme("surface-tint"),
+  "surface-room": white.theme("surface-room"),
+  "surface-neutral": neutral[400].theme("surface-neutral"),
+  "surface-disabled": neutral[100].theme("surface-disabled"),
+  "surface-hover": neutral[200].theme("surface-hover"),
+  "surface-selected": neutral[450].theme("surface-selected"),
+  "surface-dark": neutral[800].theme("surface-dark"),
+  "surface-featured": purple["700"].theme("surface-featured"),
+  "surface-featured-hover": purple["800"].theme("surface-featured-hover"),
+  "surface-overlay": neutral[800].theme("surface-overlay"),
+  "surface-transparent": "transparent",
+  "surface-sidebar": neutral[400].theme("surface-sidebar")
+};
+var strokeColors = {
+  "stroke-extra-light": neutral[250].theme("stroke-extra-light"),
+  "stroke-light": neutral[500].theme("stroke-light"),
+  "stroke-medium": neutral[600].theme("stroke-medium"),
+  "stroke-dark": neutral[700].theme("stroke-dark"),
+  "stroke-extra-dark": neutral[800].theme("stroke-extra-dark"),
+  "stroke-extra-light-highlight": blue[200].theme(
+    "stroke-extra-light-highlight"
+  ),
+  "stroke-highlight": blue[500].theme("stroke-highlight"),
+  "stroke-extra-light-error": red[200].theme("stroke-extra-light-error"),
+  "stroke-error": red[500].theme("stroke-error")
+};
+var textIconColors = {
+  "font-white": white.theme("font-white"),
+  "font-disabled": neutral[500].theme("font-disabled"),
+  "font-annotation": neutral[600].theme("font-annotation"),
+  "font-hint": neutral[700].theme("font-hint"),
+  "font-secondary-info": neutral[700].theme("font-secondary-info"),
+  "font-default": neutral[800].theme("font-default"),
+  "font-titles-labels": neutral[900].theme("font-titles-labels"),
+  "font-info": blue[600].theme("font-info"),
+  "font-danger": red[600].theme("font-danger"),
+  "font-pure-black": neutral[800].theme("font-pure-black"),
+  "font-pure-white": white.theme("font-pure-white")
+};
+var statusBackgroundColors = {
+  "status-background-info": blue[200].theme("status-background-info"),
+  "status-background-success": green[200].theme("status-background-success"),
+  "status-background-danger": red[200].theme("status-background-danger"),
+  "status-background-warning": yellow[200].theme("status-background-warning"),
+  "status-background-warning-2": yellow[100].theme(
+    "status-background-warning-2"
+  ),
+  "status-background-service-1": orange[200].theme(
+    "status-background-service-1"
+  ),
+  "status-background-service-2": purple[200].theme(
+    "status-background-service-2"
+  )
+};
+var statusColors = {
+  "status-font-on-info": blue[600].theme("status-font-on-info"),
+  "status-font-on-success": green[800].theme("status-font-on-success"),
+  "status-font-on-warning": yellow[800].theme("status-font-on-warning"),
+  "status-font-on-warning-2": neutral[800].theme("status-font-on-warning-2"),
+  "status-font-on-danger": red[800].theme("status-font-on-danger"),
+  "status-font-on-service-1": orange[800].theme("status-font-on-service-1"),
+  "status-font-on-service-2": purple[600].theme("status-font-on-service-2")
+};
+var badgeBackgroundColors = {
+  "badge-background-level-0": neutral[400].theme("badge-background-level-0"),
+  "badge-background-level-1": neutral[600].theme("badge-background-level-1"),
+  "badge-background-level-2": blue[500].theme("badge-background-level-2"),
+  "badge-background-level-3": orange[500].theme("badge-background-level-3"),
+  "badge-background-level-4": red[500].theme("badge-background-level-4")
+};
+var shadowColors = {
+  "shadow-elevation-border": strokeColors["stroke-extra-light"].theme(
+    "shadow-elevation-border"
+  ),
+  "shadow-elevation-1": new Var(
+    "shadow-elevation-1",
+    getPaletteColor("neutral", 800, 0.1)[1]
+  ),
+  "shadow-elevation-2x": new Var(
+    "shadow-elevation-2x",
+    getPaletteColor("neutral", 800, 0.08)[1]
+  ),
+  "shadow-elevation-2y": new Var(
+    "shadow-elevation-2y",
+    getPaletteColor("neutral", 800, 0.12)[1]
+  ),
+  "shadow-highlight": blue[200].theme("shadow-highlight"),
+  "shadow-danger": red[100].theme("shadow-danger")
+};
+var isSurfaceColor = (color2) => typeof color2 === "string" && color2 in surfaceColors;
+var isStrokeColor = (color2) => typeof color2 === "string" && color2 in strokeColors;
+var isTextIconColor = (color2) => typeof color2 === "string" && color2 in textIconColors;
+var isBadgeColor = (color2) => typeof color2 === "string" && color2 in badgeBackgroundColors;
+var isStatusBackgroundColor = (color2) => typeof color2 === "string" && color2 in statusBackgroundColors;
+var isStatusColor = (color2) => typeof color2 === "string" && color2 in statusColors;
+var Palette = {
+  surface: surfaceColors,
+  status: statusBackgroundColors,
+  statusColor: statusColors,
+  badge: badgeBackgroundColors,
+  text: textIconColors,
+  stroke: strokeColors,
+  shadow: shadowColors
+};
+
+// src/helpers/fromCamelToKebab.ts
+var fromCamelToKebab = (string) => string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
+
+// ../fuselage-tokens/typography.json
+var typography_default = {
+  fontFamilies: {
+    sans: [
+      "Inter",
+      "-apple-system",
+      "BlinkMacSystemFont",
+      "Segoe UI",
+      "Roboto",
+      "Oxygen",
+      "Ubuntu",
+      "Cantarell",
+      "Helvetica Neue",
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Meiryo UI",
+      "Arial",
+      "sans-serif"
+    ],
+    mono: [
+      "Menlo",
+      "Monaco",
+      "Consolas",
+      "Liberation Mono",
+      "Courier New",
+      "monospace"
+    ]
+  },
+  fontScales: {
+    hero: {
+      fontSize: 48,
+      fontWeight: 800,
+      letterSpacing: 0,
+      lineHeight: 64
+    },
+    h1: {
+      fontSize: 32,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 40
+    },
+    h2: {
+      fontSize: 24,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 32
+    },
+    h3: {
+      fontSize: 20,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 28
+    },
+    h4: {
+      fontSize: 16,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    h5: {
+      fontSize: 14,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p1: {
+      fontSize: 16,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p1m: {
+      fontSize: 16,
+      fontWeight: 500,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p1b: {
+      fontSize: 16,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p2: {
+      fontSize: 14,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p2m: {
+      fontSize: 14,
+      fontWeight: 500,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p2b: {
+      fontSize: 14,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    c1: {
+      fontSize: 12,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 16
+    },
+    c2: {
+      fontSize: 12,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 16
+    },
+    micro: {
+      fontSize: 10,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 12
+    }
+  }
+};
+
+// src/styleTokens.ts
+var import_memo = __toESM(require_cjs());
+var import_invariant2 = __toESM(require_invariant());
+var measure = (computeSpecialValue) => (0, import_memo.memoize)((value) => {
+  if (typeof value === "number") {
+    return `${value}px`;
+  }
+  if (typeof value !== "string") {
+    return void 0;
+  }
+  const xRegExp = /^(neg-|-)?x(\d+)$/;
+  const matches = xRegExp.exec(value);
+  if (matches) {
+    const [, negativeMark, measureInPixelsAsString] = matches;
+    const measureInPixels = (negativeMark ? -1 : 1) * parseInt(measureInPixelsAsString, 10);
+    return `${measureInPixels / 16}rem`;
+  }
+  if (computeSpecialValue) {
+    return computeSpecialValue(value) || value;
+  }
+  return value;
+});
+var borderWidth = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "default") {
+    return borderWidth("x1");
+  }
+  return void 0;
+});
+var borderRadius = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "full") {
+    return "9999px";
+  }
+  return void 0;
+});
+var mapTypeToPrefix2 = {
+  neutral: "n",
+  blue: "b",
+  green: "g",
+  yellow: "y",
+  red: "r",
+  orange: "o",
+  purple: "p"
+};
+var isPaletteColorType = (type) => typeof type === "string" && type in mapTypeToPrefix2;
+var isPaletteColorGrade = (grade) => typeof grade === "number" && grade % 100 === 0 && grade / 100 >= 1 && grade / 100 <= 9;
+var isPaletteColorAlpha = (alpha) => alpha === void 0 || typeof alpha === "number" && alpha >= 0 && alpha <= 1;
+var paletteColorRegex = /^(neutral|blue|green|yellow|red|orange|purple)-(\d+)(-(\d+))?$/;
+var strokeColor = (0, import_memo.memoize)((value) => {
+  const colorName = `stroke-${value}`;
+  if (isStrokeColor(colorName)) {
+    return strokeColors[colorName].toString();
+  }
+  return color(value);
+});
+var backgroundColor = (0, import_memo.memoize)((value) => {
+  const colorName = `surface-${value}`;
+  if (isSurfaceColor(value)) {
+    return surfaceColors[value].toString();
+  }
+  if (isSurfaceColor(colorName)) {
+    return surfaceColors[colorName].toString();
+  }
+  if (isStatusBackgroundColor(value)) {
+    return statusBackgroundColors[value].toString();
+  }
+  if (isStatusColor(value)) {
+    if (process.env["NODE_ENV"] !== "production" && process.env["NODE_ENV"] !== "test") {
+      console.warn(`${value} shouldn't be used as a backgroundColor.`);
+    }
+    return statusColors[value].toString();
+  }
+  if (isBadgeColor(value)) {
+    return badgeBackgroundColors[value].toString();
+  }
+  return color(value);
+});
+var fontColor = (0, import_memo.memoize)((value) => {
+  const colorName = `font-${value}`;
+  if (isTextIconColor(colorName)) {
+    return textIconColors[colorName].toString();
+  }
+  if (isStatusColor(value)) {
+    return statusColors[value].toString();
+  }
+  return color(value);
+});
+var color = (0, import_memo.memoize)((value) => {
+  if (typeof value !== "string") {
+    return;
+  }
+  if (process.env["NODE_ENV"] !== "production" && process.env["NODE_ENV"] !== "test") {
+    console.warn(`invalid color: ${value}`, new Error().stack);
+  }
+  if (throwErrorOnInvalidToken) {
+    throw new Error(
+      `The color token "${value}" is deprecated. Please use the new color tokens instead.`
+    );
+  }
+  if (isSurfaceColor(value)) {
+    return surfaceColors[value].toString();
+  }
+  if (isStatusBackgroundColor(value)) {
+    return statusBackgroundColors[value].toString();
+  }
+  if (isStrokeColor(value)) {
+    return strokeColors[value].toString();
+  }
+  if (isTextIconColor(value)) {
+    return textIconColors[value].toString();
+  }
+  if (value === "surface" || value === "surface-light") {
+    return surfaceColors["surface-light"].toString();
+  }
+  if (value === "surface-tint") {
+    return toCSSColorValue(value, neutral[100]);
+  }
+  if (value === "secondary-info") {
+    return toCSSColorValue(value, neutral[700]);
+  }
+  if (value === "surface-neutral") {
+    return toCSSColorValue(value, neutral[400]);
+  }
+  const paletteMatches = paletteColorRegex.exec(String(value));
+  if (typeof paletteMatches?.length === "number" && paletteMatches?.length >= 5) {
+    const [, type, gradeString, , alphaString] = paletteMatches;
+    const grade = parseInt(gradeString, 10);
+    const alpha = alphaString !== void 0 ? parseInt(alphaString, 10) / 100 : void 0;
+    (0, import_invariant2.default)(isPaletteColorType(type), "invalid color type");
+    (0, import_invariant2.default)(isPaletteColorGrade(grade), "invalid color grade");
+    (0, import_invariant2.default)(isPaletteColorAlpha(alpha), "invalid color alpha");
+    const [customProperty, color2] = getPaletteColor(type, grade, alpha);
+    if (customProperty) {
+      return toCSSValue(customProperty, color2);
+    }
+    return color2;
+  }
+  return value;
+});
+var size = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "full") {
+    return "100%";
+  }
+  if (value === "sw") {
+    return "100vw";
+  }
+  if (value === "sh") {
+    return "100vh";
+  }
+  return void 0;
+});
+var spacing = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  return void 0;
+});
+var isFontFamily = (value) => typeof value === "string" && value in typography_default.fontFamilies;
+var fontFamily = (0, import_memo.memoize)((value) => {
+  if (!isFontFamily(value)) {
+    return void 0;
+  }
+  const fontFamily2 = typography_default.fontFamilies[value].map((fontFace) => fontFace.includes(" ") ? `'${fontFace}'` : fontFace).join(", ");
+  return toCSSFontValue(value, fontFamily2);
+});
+var isFontScale = (value) => typeof value === "string" && value in typography_default.fontScales;
+var fontScale = (0, import_memo.memoize)(
+  (value) => {
+    if (!isFontScale(value)) {
+      return void 0;
+    }
+    const { fontSize, fontWeight, lineHeight, letterSpacing } = typography_default.fontScales[value];
+    return {
+      fontSize: `${fontSize / 16}rem`,
+      fontWeight,
+      lineHeight: `${lineHeight / 16}rem`,
+      letterSpacing: `${letterSpacing / 16}rem`
+    };
+  }
+);
+
+// src/components/Box/stylingProps.ts
+var stringProp = {
+  toCSSValue: (value) => typeof value === "string" ? value : void 0
+};
+var numberOrStringProp = {
+  toCSSValue: (value) => {
+    if (typeof value === "number" || typeof value === "string") {
+      return String(value);
+    }
+    return void 0;
+  }
+};
+var borderWidthProp = {
+  toCSSValue: borderWidth
+};
+var borderRadiusProp = {
+  toCSSValue: borderRadius
+};
+var backgroundColorProp = {
+  toCSSValue: backgroundColor
+};
+var fontColorProp = {
+  toCSSValue: fontColor
+};
+var strokeColorProp = {
+  toCSSValue: strokeColor
+};
+var sizeProp = {
+  toCSSValue: size
+};
+var insetProp = {
+  toCSSValue: spacing
+};
+var marginProp = {
+  toCSSValue: spacing
+};
+var paddingProp = {
+  toCSSValue: spacing
+};
+var gapProp = {
+  toCSSValue: spacing
+};
+var fontFamilyProp = {
+  toCSSValue: fontFamily
+};
+var fontSizeProp = {
+  toCSSValue: (value) => fontScale(value)?.fontSize || size(value)
+};
+var fontWeightProp = {
+  toCSSValue: (value) => value ? String(fontScale(value)?.fontWeight || value) : void 0
+};
+var lineHeightProp = {
+  toCSSValue: (value) => fontScale(value)?.lineHeight || size(value)
+};
+var letterSpacingProp = {
+  toCSSValue: (value) => value ? String(fontScale(value)?.letterSpacing || value) : void 0
+};
+var propDefs = {
+  border: stringProp,
+  borderBlock: stringProp,
+  borderBlockStart: stringProp,
+  borderBlockEnd: stringProp,
+  borderInline: stringProp,
+  borderInlineStart: stringProp,
+  borderInlineEnd: stringProp,
+  borderWidth: borderWidthProp,
+  borderBlockWidth: borderWidthProp,
+  borderBlockStartWidth: borderWidthProp,
+  borderBlockEndWidth: borderWidthProp,
+  borderInlineWidth: borderWidthProp,
+  borderInlineStartWidth: borderWidthProp,
+  borderInlineEndWidth: borderWidthProp,
+  borderStyle: stringProp,
+  borderBlockStyle: stringProp,
+  borderBlockStartStyle: stringProp,
+  borderBlockEndStyle: stringProp,
+  borderInlineStyle: stringProp,
+  borderInlineStartStyle: stringProp,
+  borderInlineEndStyle: stringProp,
+  borderColor: strokeColorProp,
+  borderBlockColor: strokeColorProp,
+  borderBlockStartColor: strokeColorProp,
+  borderBlockEndColor: strokeColorProp,
+  borderInlineColor: strokeColorProp,
+  borderInlineStartColor: strokeColorProp,
+  borderInlineEndColor: strokeColorProp,
+  borderRadius: borderRadiusProp,
+  borderStartStartRadius: borderRadiusProp,
+  borderStartEndRadius: borderRadiusProp,
+  borderEndStartRadius: borderRadiusProp,
+  borderEndEndRadius: borderRadiusProp,
+  color: fontColorProp,
+  backgroundColor: backgroundColorProp,
+  opacity: numberOrStringProp,
+  alignItems: stringProp,
+  alignContent: stringProp,
+  justifyItems: stringProp,
+  justifyContent: stringProp,
+  flexWrap: stringProp,
+  flexDirection: stringProp,
+  flexGrow: numberOrStringProp,
+  flexShrink: numberOrStringProp,
+  flexBasis: stringProp,
+  justifySelf: stringProp,
+  alignSelf: stringProp,
+  order: numberOrStringProp,
+  gap: gapProp,
+  rowGap: gapProp,
+  columnGap: gapProp,
+  width: sizeProp,
+  minWidth: sizeProp,
+  maxWidth: sizeProp,
+  height: sizeProp,
+  minHeight: sizeProp,
+  maxHeight: sizeProp,
+  display: stringProp,
+  verticalAlign: stringProp,
+  overflow: stringProp,
+  overflowX: stringProp,
+  overflowY: stringProp,
+  objectFit: stringProp,
+  position: stringProp,
+  zIndex: numberOrStringProp,
+  inset: insetProp,
+  insetBlock: insetProp,
+  insetBlockStart: insetProp,
+  insetBlockEnd: insetProp,
+  insetInline: insetProp,
+  insetInlineStart: insetProp,
+  insetInlineEnd: insetProp,
+  margin: marginProp,
+  marginBlock: marginProp,
+  marginBlockStart: marginProp,
+  marginBlockEnd: marginProp,
+  marginInline: marginProp,
+  marginInlineStart: marginProp,
+  marginInlineEnd: marginProp,
+  padding: paddingProp,
+  paddingBlock: paddingProp,
+  paddingBlockStart: paddingProp,
+  paddingBlockEnd: paddingProp,
+  paddingInline: paddingProp,
+  paddingInlineStart: paddingProp,
+  paddingInlineEnd: paddingProp,
+  fontFamily: fontFamilyProp,
+  fontSize: fontSizeProp,
+  fontStyle: stringProp,
+  fontWeight: fontWeightProp,
+  letterSpacing: letterSpacingProp,
+  lineHeight: lineHeightProp,
+  textAlign: stringProp,
+  textTransform: stringProp,
+  textDecorationLine: stringProp,
+  wordBreak: stringProp,
+  elevation: {
+    toStyle: (value) => {
+      if (value === "0") {
+        return import_css_in_js.css`
+          box-shadow: none;
+        `;
+      }
+      if (value === "1") {
+        return import_css_in_js.css`
+          box-shadow: 0px 0px 12px 0px ${Palette.shadow["shadow-elevation-1"]};
+          border: 1px solid ${Palette.shadow["shadow-elevation-border"]};
+        `;
+      }
+      if (value === "1nb") {
+        return import_css_in_js.css`
+          box-shadow: 0px 0px 12px 0px ${Palette.shadow["shadow-elevation-1"]};
+        `;
+      }
+      if (value === "2") {
+        return import_css_in_js.css`
+          box-shadow:
+            0px 0px 2px 0px ${Palette.shadow["shadow-elevation-2x"]},
+            0px 0px 12px 0px ${Palette.shadow["shadow-elevation-2y"]};
+          border: 1px solid ${Palette.shadow["shadow-elevation-border"]};
+        `;
+      }
+      if (value === "2nb") {
+        return import_css_in_js.css`
+          box-shadow:
+            0px 0px 2px 0px ${Palette.shadow["shadow-elevation-2x"]},
+            0px 0px 12px 0px ${Palette.shadow["shadow-elevation-2y"]};
+        `;
+      }
+      return void 0;
+    }
+  },
+  invisible: {
+    toStyle: (value) => value ? import_css_in_js.css`
+            visibility: hidden;
+            opacity: 0;
+          ` : void 0
+  },
+  withTruncatedText: {
+    toStyle: (value) => value ? import_css_in_js.css`
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          ` : void 0
+  },
+  size: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            width: ${size(value)} !important;
+            height: ${size(value)} !important;
+          ` : void 0
+  },
+  minSize: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            min-width: ${size(value)} !important;
+            min-height: ${size(value)} !important;
+          ` : void 0
+  },
+  maxSize: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            max-width: ${size(value)} !important;
+            max-height: ${size(value)} !important;
+          ` : void 0
+  },
+  fontScale: {
+    toStyle: (value) => import_css_in_js.css`
+      font-size: ${fontScale(value)?.fontSize} !important;
+      font-weight: ${fontScale(value)?.fontWeight} !important;
+      letter-spacing: ${fontScale(value)?.letterSpacing} !important;
+      line-height: ${fontScale(value)?.lineHeight} !important;
+    `
+  }
+};
+var compiledPropDefs = new Map(
+  Object.entries(propDefs).map(
+    ([propName, propDef]) => {
+      if ("toCSSValue" in propDef) {
+        const cssProperty = fromCamelToKebab(propName);
+        const { toCSSValue: toCSSValue2 } = propDef;
+        return [
+          propName,
+          (value, stylingProps) => {
+            const cssValue = toCSSValue2(value);
+            if (cssValue === void 0) {
+              return;
+            }
+            stylingProps.set(
+              propName,
+              import_css_in_js.css`
+                ${cssProperty}: ${cssValue} !important;
+              `
+            );
+          }
+        ];
+      }
+      const { toStyle } = propDef;
+      return [
+        propName,
+        (value, stylingProps) => {
+          const style = toStyle(value);
+          if (style === void 0) {
+            return;
+          }
+          stylingProps.set(propName, style);
+        }
+      ];
+    }
+  )
+);
+var collectStylingProps = (props) => {
+  const stylingProps = /* @__PURE__ */ new Map();
+  const newProps = {};
+  for (const [propName, value] of Object.entries(props)) {
+    const inject = compiledPropDefs.get(propName);
+    if (!inject) {
+      newProps[propName] = value;
+      continue;
+    }
+    if (value === void 0) {
+      continue;
+    }
+    inject(value, stylingProps);
+  }
+  return [newProps, stylingProps];
+};
+var extractStylingProps = (props) => {
+  const [newProps, stylingProps] = collectStylingProps(props);
+  const styles = stylingProps.size ? import_css_in_js.css`
+        ${Array.from(stylingProps.values())}
+      ` : void 0;
+  return [newProps, styles];
+};
+var extractAtomicStylingProps = (props) => {
+  const [newProps, stylingProps] = collectStylingProps(props);
+  return [newProps, Array.from(stylingProps.values())];
+};
+
+// src/hooks/buildAtomicClassName.ts
+var import_css_in_js2 = require("@rocket.chat/css-in-js");
+var SINGLE_DECLARATION = /^([a-z-]+):\s*(.+?)\s*(?:!important)?;?$/;
+var buildAtomicClassName = (content) => {
+  const hash = (0, import_css_in_js2.createClassName)(content).slice("rcx-css-".length);
+  const match = SINGLE_DECLARATION.exec(content);
+  if (match) {
+    const [, property, rawValue] = match;
+    const value = rawValue.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    if (value && value.length <= 24) {
+      return `rcx-${property}-${value}-${hash.slice(0, 5)}`;
+    }
+    return `rcx-${property}-${hash}`;
+  }
+  return `rcx-css-${hash}`;
+};
+
+// poc/box-compiler/bench.node.entry.ts
+var POOLS = {
+  padding: ["x4", "x8", "x12", "x16", "x24"],
+  margin: ["x4", "x8"],
+  display: ["flex", "block", "inline-flex"],
+  alignItems: ["center", "flex-start", "stretch"],
+  justifyContent: ["center", "space-between", "flex-end"],
+  fontScale: ["p1", "p2", "c1"],
+  borderRadius: [2, 4, 8]
+};
+var makeCorpus = (n) => {
+  const keys = Object.keys(POOLS);
+  const out = [];
+  let seed = 1;
+  const rnd = () => {
+    seed = seed * 1103515245 + 12345 & 2147483647;
+    return seed / 2147483647;
+  };
+  for (let i = 0; i < n; i++) {
+    const props = {};
+    for (const k of keys) {
+      if (rnd() < 0.7) props[k] = POOLS[k][Math.floor(rnd() * POOLS[k].length)];
+    }
+    out.push(props);
+  }
+  return out;
+};
+var timeit = (fn, iters) => {
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  return performance.now() - t0;
+};
+var run = (n = 2e3, iters = 40) => {
+  const corpus = makeCorpus(n);
+  const merged = () => {
+    for (const p of corpus) {
+      const [, styles] = extractStylingProps(p);
+      if (styles) (0, import_css_in_js3.createClassName)(styles());
+    }
+  };
+  const atomic = () => {
+    for (const p of corpus) {
+      const [, styles] = extractAtomicStylingProps(p);
+      for (const cssFn of styles) buildAtomicClassName(cssFn());
+    }
+  };
+  const compiled = () => {
+    for (const p of corpus) {
+      if (p["data-rcx-atomic"]) continue;
+    }
+  };
+  merged();
+  atomic();
+  const mergedMs = timeit(merged, iters);
+  const atomicMs = timeit(atomic, iters);
+  const compiledMs = timeit(compiled, iters);
+  const mergedRules = /* @__PURE__ */ new Set();
+  const atomicRules = /* @__PURE__ */ new Set();
+  for (const p of corpus) {
+    const [, s] = extractStylingProps(p);
+    if (s) mergedRules.add((0, import_css_in_js3.createClassName)(s()));
+    const [, arr] = extractAtomicStylingProps(p);
+    for (const cssFn of arr) atomicRules.add(buildAtomicClassName(cssFn()));
+  }
+  return {
+    boxes: n,
+    iters,
+    perRender_ms: {
+      merged: +(mergedMs / iters).toFixed(2),
+      atomicRuntime: +(atomicMs / iters).toFixed(2),
+      buildTime: +(compiledMs / iters).toFixed(2)
+    },
+    stylesheetRules: {
+      merged: mergedRules.size,
+      atomic: atomicRules.size
+    }
+  };
+};
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  run
+});

--- a/packages/fuselage/poc/box-compiler/bench.run.cjs
+++ b/packages/fuselage/poc/box-compiler/bench.run.cjs
@@ -1,0 +1,44 @@
+/* Headless bench driver. Runs the Box Bench story in each styling mode and
+   prints a table. Usage: node poc/box-compiler/bench.run.cjs */
+const { chromium } = require('playwright');
+
+const PATH = '/?path=/story/layout-box-bench--benchmark';
+
+const MODES = [
+  { name: 'merged', base: 'http://localhost:6006', atomic: false },
+  { name: 'atomic-runtime', base: 'http://localhost:6006', atomic: true },
+  { name: 'build-time', base: 'http://localhost:6007', atomic: false },
+];
+
+(async () => {
+  const browser = await chromium.launch();
+  const results = [];
+
+  for (const mode of MODES) {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.addInitScript((atomic) => {
+      if (atomic) localStorage.setItem('fuselage-styling', 'atomic');
+      else localStorage.removeItem('fuselage-styling');
+    }, mode.atomic);
+
+    await page.goto(mode.base + PATH, { waitUntil: 'domcontentloaded' });
+
+    const frame = page.frameLocator('#storybook-preview-iframe');
+    const runBtn = frame.getByRole('button', { name: 'run' });
+    await runBtn.waitFor({ state: 'visible', timeout: 60000 });
+    await runBtn.click();
+
+    const pre = frame.locator('pre');
+    await pre.filter({ hasText: 'mountMs' }).first().waitFor({ timeout: 60000 });
+    const json = JSON.parse(await pre.first().textContent());
+    results.push({ mode: mode.name, ...json });
+    await ctx.close();
+  }
+
+  await browser.close();
+  console.table(results);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/fuselage/poc/box-compiler/demo.cjs
+++ b/packages/fuselage/poc/box-compiler/demo.cjs
@@ -1,0 +1,26 @@
+/* Visible before/after demo. Run: node poc/box-compiler/demo.cjs
+   Uses a fake resolver for illustration; the jest spec wires the real one. */
+const { transformSync } = require('@babel/core');
+
+const plugin = require('./plugin.cjs');
+
+const resolve = (props) =>
+  Object.entries(props).map(([k, v]) => ({
+    className: `rcx-${k}-${v}`.replace(/[^a-z0-9-]/gi, '-'),
+    css: `.rcx-${k}-${v}{${k}:${v}}`,
+  }));
+
+const src = `const Card = () => <Box p="x8" display="flex" bg="tint" className={cls}>hi</Box>;`;
+const sheet = new Map();
+const out = transformSync(src, {
+  configFile: false,
+  babelrc: false,
+  plugins: [
+    '@babel/plugin-syntax-jsx',
+    [plugin, { styleProps: ['p', 'display', 'bg'], resolve, sheet }],
+  ],
+});
+
+console.log('IN : ', src);
+console.log('OUT: ', out.code);
+console.log('CSS: ', [...sheet.values()].join(' '));

--- a/packages/fuselage/poc/box-compiler/plugin.cjs
+++ b/packages/fuselage/poc/box-compiler/plugin.cjs
@@ -1,0 +1,163 @@
+/**
+ * PoC Babel plugin: build-time atomic extraction for <Box>.
+ *
+ * For every <Box> whose styling props are static literals, resolve them to
+ * atomic class names at build time, strip the props, and add a plain
+ * `className`. Non-literal props (expressions) are left untouched and handled
+ * by the runtime atomic path.
+ *
+ * The resolved CSS rules are surfaced two ways:
+ *   options.sheet  : Map<className, css>  — collected out-of-band (tests/demo)
+ *   options.inject : boolean              — when true, each file gets a top-of-
+ *                    module `attachRules("<its rules>")` call, so the CSS lands
+ *                    in the page at module load with no external asset. Sharing
+ *                    across files is deduped/ref-counted by attachRules.
+ *
+ * Resolution defaults to the bundled snapshot of Fuselage's real runtime
+ * resolver (resolver.generated.cjs) so the plugin is drop-in: a consumer adds
+ * just this plugin, no wiring. Both can be overridden via options for tests:
+ *   options.styleProps : string[]  — recognised styling prop names
+ *   options.resolve    : (props) => { className, css }[]
+ */
+// Lazily loaded so requiring the plugin never fails if the snapshot is absent
+// (e.g. before the first esbuild bundle); only needed when resolve is omitted.
+let bundled;
+const getBundled = () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  if (!bundled) bundled = require('./resolver.generated.cjs');
+  return bundled;
+};
+
+module.exports = function boxAtomicPlugin({ types: t }) {
+  const staticValue = (node) => {
+    if (node === null) return true; // boolean shorthand: <Box invisible />
+    if (t.isStringLiteral(node)) return node.value;
+    if (t.isJSXExpressionContainer(node)) {
+      const { expression: e } = node;
+      if (
+        t.isStringLiteral(e) ||
+        t.isNumericLiteral(e) ||
+        t.isBooleanLiteral(e)
+      )
+        return e.value;
+    }
+    return undefined; // dynamic — leave for runtime
+  };
+
+  return {
+    name: 'fuselage-box-atomic',
+    pre() {
+      this.rules = new Map(); // className -> css, for this file
+    },
+    visitor: {
+      JSXOpeningElement(path, state) {
+        const { sheet } = state.opts;
+        // Safe default: keep props on the element (runtime skips them via the
+        // marker, so the render-CPU win is preserved) because whether a prop is
+        // introspected elsewhere (cloneElement, child.props.x, spread) can't be
+        // proven statically. Full stripping is opt-in via keepProps:false.
+        const keepProps = state.opts.keepProps !== false;
+        const resolve = state.opts.resolve || getBundled().resolve;
+        const styleProps = state.opts.styleProps || getBundled().styleProps;
+        const propSet = new Set(styleProps);
+
+        if (!t.isJSXIdentifier(path.node.name, { name: 'Box' })) return;
+
+        const collected = {};
+        const toRemove = [];
+
+        for (const attr of path.node.attributes) {
+          if (!t.isJSXAttribute(attr) || !t.isJSXIdentifier(attr.name))
+            continue;
+          if (!propSet.has(attr.name.name)) continue;
+
+          const value = staticValue(attr.value);
+          if (value === undefined) continue; // dynamic prop stays
+
+          collected[attr.name.name] = value;
+          toRemove.push(attr);
+        }
+
+        if (toRemove.length === 0) return;
+
+        const resolved = resolve(collected);
+        if (resolved.length === 0) return;
+
+        const classNames = resolved.map((r) => r.className);
+        for (const { className, css } of resolved) {
+          if (sheet && !sheet.has(className)) sheet.set(className, css);
+          if (!this.rules.has(className)) this.rules.set(className, css);
+        }
+
+        if (keepProps) {
+          // Keep the props on the element so runtime introspection (e.g.
+          // `child.props.bg`, spreads) still works; mark which props are
+          // already compiled so the runtime skips restyling them.
+          path.node.attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier('data-rcx-atomic'),
+              t.stringLiteral(Object.keys(collected).join(' ')),
+            ),
+          );
+        } else {
+          path.node.attributes = path.node.attributes.filter(
+            (a) => !toRemove.includes(a),
+          );
+        }
+
+        const classString = classNames.join(' ');
+        const existing = path.node.attributes.find(
+          (a) =>
+            t.isJSXAttribute(a) &&
+            t.isJSXIdentifier(a.name, { name: 'className' }),
+        );
+
+        if (!existing) {
+          path.node.attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier('className'),
+              t.stringLiteral(classString),
+            ),
+          );
+          return;
+        }
+
+        if (t.isStringLiteral(existing.value)) {
+          existing.value = t.stringLiteral(
+            `${classString} ${existing.value.value}`,
+          );
+          return;
+        }
+
+        // className is an expression: prepend our static classes
+        if (t.isJSXExpressionContainer(existing.value)) {
+          existing.value = t.jsxExpressionContainer(
+            t.binaryExpression(
+              '+',
+              t.stringLiteral(`${classString} `),
+              existing.value.expression,
+            ),
+          );
+        }
+      },
+      Program: {
+        exit(path, state) {
+          if (!state.opts.inject || this.rules.size === 0) return;
+
+          const css = [...this.rules.values()].join('\n');
+          const attach = path.scope.generateUidIdentifier('rcxAttach');
+
+          path.unshiftContainer('body', [
+            t.importDeclaration(
+              [t.importSpecifier(attach, t.identifier('attachRules'))],
+              t.stringLiteral('@rocket.chat/css-in-js'),
+            ),
+            t.expressionStatement(
+              t.callExpression(attach, [t.stringLiteral(css)]),
+            ),
+          ]);
+        },
+      },
+    },
+  };
+};

--- a/packages/fuselage/poc/box-compiler/resolver.entry.ts
+++ b/packages/fuselage/poc/box-compiler/resolver.entry.ts
@@ -1,0 +1,18 @@
+import { escapeName, transpile } from '@rocket.chat/css-in-js';
+
+import {
+  extractAtomicStylingProps,
+  propDefs,
+} from '../../src/components/Box/stylingProps';
+import { buildAtomicClassName } from '../../src/hooks/buildAtomicClassName';
+
+export const styleProps = Object.keys(propDefs);
+
+export const resolve = (props: Record<string, unknown>) => {
+  const [, styles] = extractAtomicStylingProps(props);
+  return styles.map((cssFn) => {
+    const content = cssFn();
+    const className = buildAtomicClassName(content);
+    return { className, css: transpile(`.${escapeName(className)}`, content) };
+  });
+};

--- a/packages/fuselage/poc/box-compiler/resolver.generated.cjs
+++ b/packages/fuselage/poc/box-compiler/resolver.generated.cjs
@@ -1,0 +1,1089 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// ../../node_modules/invariant/invariant.js
+var require_invariant = __commonJS({
+  "../../node_modules/invariant/invariant.js"(exports2, module2) {
+    "use strict";
+    var NODE_ENV = process.env.NODE_ENV;
+    var invariant3 = function(condition, format, a, b, c, d, e, f) {
+      if (NODE_ENV !== "production") {
+        if (format === void 0) {
+          throw new Error("invariant requires an error message argument");
+        }
+      }
+      if (!condition) {
+        var error;
+        if (format === void 0) {
+          error = new Error(
+            "Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings."
+          );
+        } else {
+          var args = [a, b, c, d, e, f];
+          var argIndex = 0;
+          error = new Error(
+            format.replace(/%s/g, function() {
+              return args[argIndex++];
+            })
+          );
+          error.name = "Invariant Violation";
+        }
+        error.framesToPop = 1;
+        throw error;
+      }
+    };
+    module2.exports = invariant3;
+  }
+});
+
+// ../memo/dist/cjs/memoize.js
+var require_memoize = __commonJS({
+  "../memo/dist/cjs/memoize.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.clear = exports2.memoize = void 0;
+    var store = /* @__PURE__ */ new WeakMap();
+    var isCachedValue = (cachedValue, arg, cache) => cache.has(arg) && cache.get(arg) === cachedValue;
+    var memoize2 = (fn, _options) => {
+      const cache = /* @__PURE__ */ new Map();
+      const cacheTimers = /* @__PURE__ */ new Map();
+      const memoized = function(arg) {
+        const cleanUp = () => {
+          cache.delete(arg);
+          cacheTimers.delete(arg);
+        };
+        const cachedValue = cache.get(arg);
+        if (isCachedValue(cachedValue, arg, cache)) {
+          const oldTimer = cacheTimers.get(arg);
+          if (oldTimer) {
+            clearTimeout(oldTimer);
+          }
+          if (_options) {
+            const timer = setTimeout(cleanUp, _options.maxAge);
+            cacheTimers.set(arg, timer);
+          }
+          return cachedValue;
+        }
+        const result = fn.call(this, arg);
+        cache.set(arg, result);
+        if (_options) {
+          const timer = setTimeout(cleanUp, _options.maxAge);
+          cacheTimers.set(arg, timer);
+        }
+        return result;
+      };
+      store.set(memoized, cache);
+      return memoized;
+    };
+    exports2.memoize = memoize2;
+    var clear = (fn) => {
+      const cache = store.get(fn);
+      cache?.clear();
+    };
+    exports2.clear = clear;
+  }
+});
+
+// ../memo/dist/cjs/index.js
+var require_cjs = __commonJS({
+  "../memo/dist/cjs/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.clear = exports2.memoize = void 0;
+    var memoize_1 = require_memoize();
+    Object.defineProperty(exports2, "memoize", { enumerable: true, get: function() {
+      return memoize_1.memoize;
+    } });
+    Object.defineProperty(exports2, "clear", { enumerable: true, get: function() {
+      return memoize_1.clear;
+    } });
+  }
+});
+
+// poc/box-compiler/resolver.entry.ts
+var resolver_entry_exports = {};
+__export(resolver_entry_exports, {
+  resolve: () => resolve,
+  styleProps: () => styleProps
+});
+module.exports = __toCommonJS(resolver_entry_exports);
+var import_css_in_js3 = require("@rocket.chat/css-in-js");
+
+// src/components/Box/stylingProps.ts
+var import_css_in_js = require("@rocket.chat/css-in-js");
+
+// ../fuselage-tokens/colors.json
+var colors_default = {
+  white: "#FFFFFF",
+  n100: "#F7F8FA",
+  n200: "#F2F3F5",
+  n250: "#EBECEF",
+  n300: "#EEEFF1",
+  n400: "#E4E7EA",
+  n450: "#D7DBE0",
+  n500: "#CBCED1",
+  n600: "#9EA2A8",
+  n700: "#6C737A",
+  n800: "#2F343D",
+  n900: "#1F2329",
+  r100: "#FFE9EC",
+  r200: "#FFC1C9",
+  r300: "#F98F9D",
+  r400: "#F5455C",
+  r500: "#EC0D2A",
+  r600: "#D40C26",
+  r700: "#BB0B21",
+  r800: "#9B1325",
+  r900: "#8B0719",
+  r1000: "#6B0513",
+  o100: "#FDE8D7",
+  o200: "#FAD1B0",
+  o300: "#F7B27B",
+  o400: "#F59B53",
+  o500: "#F38C39",
+  o600: "#E26D0E",
+  o700: "#BD5A0B",
+  o800: "#974809",
+  o900: "#713607",
+  o1000: "#5B2C06",
+  p100: "#F9EFFC",
+  p200: "#EDD0F7",
+  p300: "#DCA0EF",
+  p400: "#CA71E7",
+  p500: "#9F22C7",
+  p600: "#7F1B9F",
+  p700: "#5F1477",
+  p800: "#4A105D",
+  p900: "#350B42",
+  y100: "#FFF8E0",
+  y200: "#FFECAD",
+  y300: "#FFE383",
+  y400: "#FFD95A",
+  y500: "#FFD031",
+  y600: "#F3BE08",
+  y700: "#DFAC00",
+  y800: "#AC892F",
+  y900: "#8E6300",
+  y1000: "#573D00",
+  g100: "#E5FBF4",
+  g200: "#C0F6E4",
+  g300: "#96F0D2",
+  g400: "#6CE9C0",
+  g500: "#2DE0A5",
+  g600: "#1ECB92",
+  g700: "#19AC7C",
+  g800: "#148660",
+  g900: "#106D4F",
+  g1000: "#0D5940",
+  b100: "#E8F2FF",
+  b200: "#D1EBFE",
+  b300: "#76B7FC",
+  b400: "#549DF9",
+  b500: "#156FF5",
+  b600: "#095AD2",
+  b700: "#10529E",
+  b800: "#01336B",
+  b900: "#012247"
+};
+
+// src/getPaletteColor.ts
+var import_invariant = __toESM(require_invariant());
+var isPaletteColorRef = (ref) => typeof ref === "string" && ref in colors_default;
+var mapTypeToPrefix = {
+  neutral: "n",
+  blue: "b",
+  green: "g",
+  yellow: "y",
+  red: "r",
+  orange: "o",
+  purple: "p"
+};
+var getPaletteColor = (type, grade, alpha) => {
+  const ref = `${mapTypeToPrefix[type]}${grade}`;
+  (0, import_invariant.default)(isPaletteColorRef(ref), "invalid color reference");
+  const baseColor = colors_default[ref];
+  const matches = /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/.exec(
+    baseColor
+  );
+  (0, import_invariant.default)(!!matches, "invalid color token format");
+  if (alpha !== void 0) {
+    const [, r, g, b] = matches;
+    return [
+      `--rcx-color-${type}-${grade}-${(alpha * 100).toFixed(0)}`,
+      `rgba(${parseInt(r, 16)}, ${parseInt(g, 16)}, ${parseInt(b, 16)}, ${alpha * 100}%)`
+    ];
+  }
+  return [`--rcx-color-${type}-${grade}`, baseColor];
+};
+
+// src/helpers/toCSSValue.ts
+var toCSSValue = (label, value) => `var(${label}, ${value})`;
+var toCSSFontValue = (label, value) => toCSSValue(`--rcx-font-family-${label}`, value);
+var toCSSColorValue = (label, value) => toCSSValue(`--rcx-color-${label}`, value);
+
+// src/Theme.ts
+var Var = class _Var {
+  name;
+  value;
+  constructor(name, value) {
+    this.name = name;
+    this.value = value;
+  }
+  toString() {
+    return toCSSColorValue(this.name, this.value);
+  }
+  theme(name) {
+    return new _Var(name, this.toString());
+  }
+};
+var white = new Var("white", "#ffffff");
+var throwErrorOnInvalidToken = false;
+var neutral = {
+  100: new Var("neutral-100", colors_default.n100),
+  200: new Var("neutral-200", colors_default.n200),
+  250: new Var("neutral-250", colors_default.n250),
+  300: new Var("neutral-300", colors_default.n300),
+  400: new Var("neutral-400", colors_default.n400),
+  450: new Var("neutral-450", colors_default.n450),
+  500: new Var("neutral-500", colors_default.n500),
+  600: new Var("neutral-600", colors_default.n600),
+  700: new Var("neutral-700", colors_default.n700),
+  800: new Var("neutral-800", colors_default.n800),
+  900: new Var("neutral-900", colors_default.n900)
+};
+var blue = {
+  100: new Var("primary-100", colors_default.b100),
+  200: new Var("primary-200", colors_default.b200),
+  300: new Var("primary-300", colors_default.b300),
+  400: new Var("primary-400", colors_default.b400),
+  500: new Var("primary-500", colors_default.b500),
+  600: new Var("primary-600", colors_default.b600),
+  700: new Var("primary-700", colors_default.b700),
+  800: new Var("primary-800", colors_default.b800),
+  900: new Var("primary-900", colors_default.b900)
+};
+var green = {
+  100: new Var("success-100", colors_default.g100),
+  200: new Var("success-200", colors_default.g200),
+  300: new Var("success-300", colors_default.g300),
+  400: new Var("success-400", colors_default.g400),
+  500: new Var("success-500", colors_default.g500),
+  600: new Var("success-600", colors_default.g600),
+  700: new Var("success-700", colors_default.g700),
+  800: new Var("success-800", colors_default.g800),
+  900: new Var("success-900", colors_default.g900)
+};
+var yellow = {
+  100: new Var("warning-100", colors_default.y100),
+  200: new Var("warning-200", colors_default.y200),
+  300: new Var("warning-300", colors_default.y300),
+  400: new Var("warning-400", colors_default.y400),
+  500: new Var("warning-500", colors_default.y500),
+  600: new Var("warning-600", colors_default.y600),
+  700: new Var("warning-700", colors_default.y700),
+  800: new Var("warning-800", colors_default.y800),
+  900: new Var("warning-900", colors_default.y900)
+};
+var red = {
+  100: new Var("danger-100", colors_default.r100),
+  200: new Var("danger-200", colors_default.r200),
+  300: new Var("danger-300", colors_default.r300),
+  400: new Var("danger-400", colors_default.r400),
+  500: new Var("danger-500", colors_default.r500),
+  600: new Var("danger-600", colors_default.r600),
+  700: new Var("danger-700", colors_default.r700),
+  800: new Var("danger-800", colors_default.r800),
+  900: new Var("danger-900", colors_default.r900)
+};
+var orange = {
+  100: new Var("service-1-100", colors_default.o100),
+  200: new Var("service-1-200", colors_default.o200),
+  300: new Var("service-1-300", colors_default.o300),
+  400: new Var("service-1-400", colors_default.o400),
+  500: new Var("service-1-500", colors_default.o500),
+  600: new Var("service-1-600", colors_default.o600),
+  700: new Var("service-1-700", colors_default.o700),
+  800: new Var("service-1-800", colors_default.o800),
+  900: new Var("service-1-900", colors_default.o900)
+};
+var purple = {
+  100: new Var("service-2-100", colors_default.p100),
+  200: new Var("service-2-200", colors_default.p200),
+  300: new Var("service-2-300", colors_default.p300),
+  400: new Var("service-2-400", colors_default.p400),
+  500: new Var("service-2-500", colors_default.p500),
+  600: new Var("service-2-600", colors_default.p600),
+  700: new Var("service-2-700", colors_default.p700),
+  800: new Var("service-2-800", colors_default.p800),
+  900: new Var("service-2-900", colors_default.p900)
+};
+var surfaceColors = {
+  "surface-light": white.theme("surface-light"),
+  "surface-tint": neutral[100].theme("surface-tint"),
+  "surface-room": white.theme("surface-room"),
+  "surface-neutral": neutral[400].theme("surface-neutral"),
+  "surface-disabled": neutral[100].theme("surface-disabled"),
+  "surface-hover": neutral[200].theme("surface-hover"),
+  "surface-selected": neutral[450].theme("surface-selected"),
+  "surface-dark": neutral[800].theme("surface-dark"),
+  "surface-featured": purple["700"].theme("surface-featured"),
+  "surface-featured-hover": purple["800"].theme("surface-featured-hover"),
+  "surface-overlay": neutral[800].theme("surface-overlay"),
+  "surface-transparent": "transparent",
+  "surface-sidebar": neutral[400].theme("surface-sidebar")
+};
+var strokeColors = {
+  "stroke-extra-light": neutral[250].theme("stroke-extra-light"),
+  "stroke-light": neutral[500].theme("stroke-light"),
+  "stroke-medium": neutral[600].theme("stroke-medium"),
+  "stroke-dark": neutral[700].theme("stroke-dark"),
+  "stroke-extra-dark": neutral[800].theme("stroke-extra-dark"),
+  "stroke-extra-light-highlight": blue[200].theme(
+    "stroke-extra-light-highlight"
+  ),
+  "stroke-highlight": blue[500].theme("stroke-highlight"),
+  "stroke-extra-light-error": red[200].theme("stroke-extra-light-error"),
+  "stroke-error": red[500].theme("stroke-error")
+};
+var textIconColors = {
+  "font-white": white.theme("font-white"),
+  "font-disabled": neutral[500].theme("font-disabled"),
+  "font-annotation": neutral[600].theme("font-annotation"),
+  "font-hint": neutral[700].theme("font-hint"),
+  "font-secondary-info": neutral[700].theme("font-secondary-info"),
+  "font-default": neutral[800].theme("font-default"),
+  "font-titles-labels": neutral[900].theme("font-titles-labels"),
+  "font-info": blue[600].theme("font-info"),
+  "font-danger": red[600].theme("font-danger"),
+  "font-pure-black": neutral[800].theme("font-pure-black"),
+  "font-pure-white": white.theme("font-pure-white")
+};
+var statusBackgroundColors = {
+  "status-background-info": blue[200].theme("status-background-info"),
+  "status-background-success": green[200].theme("status-background-success"),
+  "status-background-danger": red[200].theme("status-background-danger"),
+  "status-background-warning": yellow[200].theme("status-background-warning"),
+  "status-background-warning-2": yellow[100].theme(
+    "status-background-warning-2"
+  ),
+  "status-background-service-1": orange[200].theme(
+    "status-background-service-1"
+  ),
+  "status-background-service-2": purple[200].theme(
+    "status-background-service-2"
+  )
+};
+var statusColors = {
+  "status-font-on-info": blue[600].theme("status-font-on-info"),
+  "status-font-on-success": green[800].theme("status-font-on-success"),
+  "status-font-on-warning": yellow[800].theme("status-font-on-warning"),
+  "status-font-on-warning-2": neutral[800].theme("status-font-on-warning-2"),
+  "status-font-on-danger": red[800].theme("status-font-on-danger"),
+  "status-font-on-service-1": orange[800].theme("status-font-on-service-1"),
+  "status-font-on-service-2": purple[600].theme("status-font-on-service-2")
+};
+var badgeBackgroundColors = {
+  "badge-background-level-0": neutral[400].theme("badge-background-level-0"),
+  "badge-background-level-1": neutral[600].theme("badge-background-level-1"),
+  "badge-background-level-2": blue[500].theme("badge-background-level-2"),
+  "badge-background-level-3": orange[500].theme("badge-background-level-3"),
+  "badge-background-level-4": red[500].theme("badge-background-level-4")
+};
+var shadowColors = {
+  "shadow-elevation-border": strokeColors["stroke-extra-light"].theme(
+    "shadow-elevation-border"
+  ),
+  "shadow-elevation-1": new Var(
+    "shadow-elevation-1",
+    getPaletteColor("neutral", 800, 0.1)[1]
+  ),
+  "shadow-elevation-2x": new Var(
+    "shadow-elevation-2x",
+    getPaletteColor("neutral", 800, 0.08)[1]
+  ),
+  "shadow-elevation-2y": new Var(
+    "shadow-elevation-2y",
+    getPaletteColor("neutral", 800, 0.12)[1]
+  ),
+  "shadow-highlight": blue[200].theme("shadow-highlight"),
+  "shadow-danger": red[100].theme("shadow-danger")
+};
+var isSurfaceColor = (color2) => typeof color2 === "string" && color2 in surfaceColors;
+var isStrokeColor = (color2) => typeof color2 === "string" && color2 in strokeColors;
+var isTextIconColor = (color2) => typeof color2 === "string" && color2 in textIconColors;
+var isBadgeColor = (color2) => typeof color2 === "string" && color2 in badgeBackgroundColors;
+var isStatusBackgroundColor = (color2) => typeof color2 === "string" && color2 in statusBackgroundColors;
+var isStatusColor = (color2) => typeof color2 === "string" && color2 in statusColors;
+var Palette = {
+  surface: surfaceColors,
+  status: statusBackgroundColors,
+  statusColor: statusColors,
+  badge: badgeBackgroundColors,
+  text: textIconColors,
+  stroke: strokeColors,
+  shadow: shadowColors
+};
+
+// src/helpers/fromCamelToKebab.ts
+var fromCamelToKebab = (string) => string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
+
+// ../fuselage-tokens/typography.json
+var typography_default = {
+  fontFamilies: {
+    sans: [
+      "Inter",
+      "-apple-system",
+      "BlinkMacSystemFont",
+      "Segoe UI",
+      "Roboto",
+      "Oxygen",
+      "Ubuntu",
+      "Cantarell",
+      "Helvetica Neue",
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Meiryo UI",
+      "Arial",
+      "sans-serif"
+    ],
+    mono: [
+      "Menlo",
+      "Monaco",
+      "Consolas",
+      "Liberation Mono",
+      "Courier New",
+      "monospace"
+    ]
+  },
+  fontScales: {
+    hero: {
+      fontSize: 48,
+      fontWeight: 800,
+      letterSpacing: 0,
+      lineHeight: 64
+    },
+    h1: {
+      fontSize: 32,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 40
+    },
+    h2: {
+      fontSize: 24,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 32
+    },
+    h3: {
+      fontSize: 20,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 28
+    },
+    h4: {
+      fontSize: 16,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    h5: {
+      fontSize: 14,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p1: {
+      fontSize: 16,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p1m: {
+      fontSize: 16,
+      fontWeight: 500,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p1b: {
+      fontSize: 16,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 24
+    },
+    p2: {
+      fontSize: 14,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p2m: {
+      fontSize: 14,
+      fontWeight: 500,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    p2b: {
+      fontSize: 14,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 20
+    },
+    c1: {
+      fontSize: 12,
+      fontWeight: 400,
+      letterSpacing: 0,
+      lineHeight: 16
+    },
+    c2: {
+      fontSize: 12,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 16
+    },
+    micro: {
+      fontSize: 10,
+      fontWeight: 700,
+      letterSpacing: 0,
+      lineHeight: 12
+    }
+  }
+};
+
+// src/styleTokens.ts
+var import_memo = __toESM(require_cjs());
+var import_invariant2 = __toESM(require_invariant());
+var measure = (computeSpecialValue) => (0, import_memo.memoize)((value) => {
+  if (typeof value === "number") {
+    return `${value}px`;
+  }
+  if (typeof value !== "string") {
+    return void 0;
+  }
+  const xRegExp = /^(neg-|-)?x(\d+)$/;
+  const matches = xRegExp.exec(value);
+  if (matches) {
+    const [, negativeMark, measureInPixelsAsString] = matches;
+    const measureInPixels = (negativeMark ? -1 : 1) * parseInt(measureInPixelsAsString, 10);
+    return `${measureInPixels / 16}rem`;
+  }
+  if (computeSpecialValue) {
+    return computeSpecialValue(value) || value;
+  }
+  return value;
+});
+var borderWidth = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "default") {
+    return borderWidth("x1");
+  }
+  return void 0;
+});
+var borderRadius = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "full") {
+    return "9999px";
+  }
+  return void 0;
+});
+var mapTypeToPrefix2 = {
+  neutral: "n",
+  blue: "b",
+  green: "g",
+  yellow: "y",
+  red: "r",
+  orange: "o",
+  purple: "p"
+};
+var isPaletteColorType = (type) => typeof type === "string" && type in mapTypeToPrefix2;
+var isPaletteColorGrade = (grade) => typeof grade === "number" && grade % 100 === 0 && grade / 100 >= 1 && grade / 100 <= 9;
+var isPaletteColorAlpha = (alpha) => alpha === void 0 || typeof alpha === "number" && alpha >= 0 && alpha <= 1;
+var paletteColorRegex = /^(neutral|blue|green|yellow|red|orange|purple)-(\d+)(-(\d+))?$/;
+var strokeColor = (0, import_memo.memoize)((value) => {
+  const colorName = `stroke-${value}`;
+  if (isStrokeColor(colorName)) {
+    return strokeColors[colorName].toString();
+  }
+  return color(value);
+});
+var backgroundColor = (0, import_memo.memoize)((value) => {
+  const colorName = `surface-${value}`;
+  if (isSurfaceColor(value)) {
+    return surfaceColors[value].toString();
+  }
+  if (isSurfaceColor(colorName)) {
+    return surfaceColors[colorName].toString();
+  }
+  if (isStatusBackgroundColor(value)) {
+    return statusBackgroundColors[value].toString();
+  }
+  if (isStatusColor(value)) {
+    if (process.env["NODE_ENV"] !== "production" && process.env["NODE_ENV"] !== "test") {
+      console.warn(`${value} shouldn't be used as a backgroundColor.`);
+    }
+    return statusColors[value].toString();
+  }
+  if (isBadgeColor(value)) {
+    return badgeBackgroundColors[value].toString();
+  }
+  return color(value);
+});
+var fontColor = (0, import_memo.memoize)((value) => {
+  const colorName = `font-${value}`;
+  if (isTextIconColor(colorName)) {
+    return textIconColors[colorName].toString();
+  }
+  if (isStatusColor(value)) {
+    return statusColors[value].toString();
+  }
+  return color(value);
+});
+var color = (0, import_memo.memoize)((value) => {
+  if (typeof value !== "string") {
+    return;
+  }
+  if (process.env["NODE_ENV"] !== "production" && process.env["NODE_ENV"] !== "test") {
+    console.warn(`invalid color: ${value}`, new Error().stack);
+  }
+  if (throwErrorOnInvalidToken) {
+    throw new Error(
+      `The color token "${value}" is deprecated. Please use the new color tokens instead.`
+    );
+  }
+  if (isSurfaceColor(value)) {
+    return surfaceColors[value].toString();
+  }
+  if (isStatusBackgroundColor(value)) {
+    return statusBackgroundColors[value].toString();
+  }
+  if (isStrokeColor(value)) {
+    return strokeColors[value].toString();
+  }
+  if (isTextIconColor(value)) {
+    return textIconColors[value].toString();
+  }
+  if (value === "surface" || value === "surface-light") {
+    return surfaceColors["surface-light"].toString();
+  }
+  if (value === "surface-tint") {
+    return toCSSColorValue(value, neutral[100]);
+  }
+  if (value === "secondary-info") {
+    return toCSSColorValue(value, neutral[700]);
+  }
+  if (value === "surface-neutral") {
+    return toCSSColorValue(value, neutral[400]);
+  }
+  const paletteMatches = paletteColorRegex.exec(String(value));
+  if (typeof paletteMatches?.length === "number" && paletteMatches?.length >= 5) {
+    const [, type, gradeString, , alphaString] = paletteMatches;
+    const grade = parseInt(gradeString, 10);
+    const alpha = alphaString !== void 0 ? parseInt(alphaString, 10) / 100 : void 0;
+    (0, import_invariant2.default)(isPaletteColorType(type), "invalid color type");
+    (0, import_invariant2.default)(isPaletteColorGrade(grade), "invalid color grade");
+    (0, import_invariant2.default)(isPaletteColorAlpha(alpha), "invalid color alpha");
+    const [customProperty, color2] = getPaletteColor(type, grade, alpha);
+    if (customProperty) {
+      return toCSSValue(customProperty, color2);
+    }
+    return color2;
+  }
+  return value;
+});
+var size = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  if (value === "full") {
+    return "100%";
+  }
+  if (value === "sw") {
+    return "100vw";
+  }
+  if (value === "sh") {
+    return "100vh";
+  }
+  return void 0;
+});
+var spacing = measure((value) => {
+  if (value === "none") {
+    return "0px";
+  }
+  return void 0;
+});
+var isFontFamily = (value) => typeof value === "string" && value in typography_default.fontFamilies;
+var fontFamily = (0, import_memo.memoize)((value) => {
+  if (!isFontFamily(value)) {
+    return void 0;
+  }
+  const fontFamily2 = typography_default.fontFamilies[value].map((fontFace) => fontFace.includes(" ") ? `'${fontFace}'` : fontFace).join(", ");
+  return toCSSFontValue(value, fontFamily2);
+});
+var isFontScale = (value) => typeof value === "string" && value in typography_default.fontScales;
+var fontScale = (0, import_memo.memoize)(
+  (value) => {
+    if (!isFontScale(value)) {
+      return void 0;
+    }
+    const { fontSize, fontWeight, lineHeight, letterSpacing } = typography_default.fontScales[value];
+    return {
+      fontSize: `${fontSize / 16}rem`,
+      fontWeight,
+      lineHeight: `${lineHeight / 16}rem`,
+      letterSpacing: `${letterSpacing / 16}rem`
+    };
+  }
+);
+
+// src/components/Box/stylingProps.ts
+var stringProp = {
+  toCSSValue: (value) => typeof value === "string" ? value : void 0
+};
+var numberOrStringProp = {
+  toCSSValue: (value) => {
+    if (typeof value === "number" || typeof value === "string") {
+      return String(value);
+    }
+    return void 0;
+  }
+};
+var borderWidthProp = {
+  toCSSValue: borderWidth
+};
+var borderRadiusProp = {
+  toCSSValue: borderRadius
+};
+var backgroundColorProp = {
+  toCSSValue: backgroundColor
+};
+var fontColorProp = {
+  toCSSValue: fontColor
+};
+var strokeColorProp = {
+  toCSSValue: strokeColor
+};
+var sizeProp = {
+  toCSSValue: size
+};
+var insetProp = {
+  toCSSValue: spacing
+};
+var marginProp = {
+  toCSSValue: spacing
+};
+var paddingProp = {
+  toCSSValue: spacing
+};
+var gapProp = {
+  toCSSValue: spacing
+};
+var fontFamilyProp = {
+  toCSSValue: fontFamily
+};
+var fontSizeProp = {
+  toCSSValue: (value) => fontScale(value)?.fontSize || size(value)
+};
+var fontWeightProp = {
+  toCSSValue: (value) => value ? String(fontScale(value)?.fontWeight || value) : void 0
+};
+var lineHeightProp = {
+  toCSSValue: (value) => fontScale(value)?.lineHeight || size(value)
+};
+var letterSpacingProp = {
+  toCSSValue: (value) => value ? String(fontScale(value)?.letterSpacing || value) : void 0
+};
+var propDefs = {
+  border: stringProp,
+  borderBlock: stringProp,
+  borderBlockStart: stringProp,
+  borderBlockEnd: stringProp,
+  borderInline: stringProp,
+  borderInlineStart: stringProp,
+  borderInlineEnd: stringProp,
+  borderWidth: borderWidthProp,
+  borderBlockWidth: borderWidthProp,
+  borderBlockStartWidth: borderWidthProp,
+  borderBlockEndWidth: borderWidthProp,
+  borderInlineWidth: borderWidthProp,
+  borderInlineStartWidth: borderWidthProp,
+  borderInlineEndWidth: borderWidthProp,
+  borderStyle: stringProp,
+  borderBlockStyle: stringProp,
+  borderBlockStartStyle: stringProp,
+  borderBlockEndStyle: stringProp,
+  borderInlineStyle: stringProp,
+  borderInlineStartStyle: stringProp,
+  borderInlineEndStyle: stringProp,
+  borderColor: strokeColorProp,
+  borderBlockColor: strokeColorProp,
+  borderBlockStartColor: strokeColorProp,
+  borderBlockEndColor: strokeColorProp,
+  borderInlineColor: strokeColorProp,
+  borderInlineStartColor: strokeColorProp,
+  borderInlineEndColor: strokeColorProp,
+  borderRadius: borderRadiusProp,
+  borderStartStartRadius: borderRadiusProp,
+  borderStartEndRadius: borderRadiusProp,
+  borderEndStartRadius: borderRadiusProp,
+  borderEndEndRadius: borderRadiusProp,
+  color: fontColorProp,
+  backgroundColor: backgroundColorProp,
+  opacity: numberOrStringProp,
+  alignItems: stringProp,
+  alignContent: stringProp,
+  justifyItems: stringProp,
+  justifyContent: stringProp,
+  flexWrap: stringProp,
+  flexDirection: stringProp,
+  flexGrow: numberOrStringProp,
+  flexShrink: numberOrStringProp,
+  flexBasis: stringProp,
+  justifySelf: stringProp,
+  alignSelf: stringProp,
+  order: numberOrStringProp,
+  gap: gapProp,
+  rowGap: gapProp,
+  columnGap: gapProp,
+  width: sizeProp,
+  minWidth: sizeProp,
+  maxWidth: sizeProp,
+  height: sizeProp,
+  minHeight: sizeProp,
+  maxHeight: sizeProp,
+  display: stringProp,
+  verticalAlign: stringProp,
+  overflow: stringProp,
+  overflowX: stringProp,
+  overflowY: stringProp,
+  objectFit: stringProp,
+  position: stringProp,
+  zIndex: numberOrStringProp,
+  inset: insetProp,
+  insetBlock: insetProp,
+  insetBlockStart: insetProp,
+  insetBlockEnd: insetProp,
+  insetInline: insetProp,
+  insetInlineStart: insetProp,
+  insetInlineEnd: insetProp,
+  margin: marginProp,
+  marginBlock: marginProp,
+  marginBlockStart: marginProp,
+  marginBlockEnd: marginProp,
+  marginInline: marginProp,
+  marginInlineStart: marginProp,
+  marginInlineEnd: marginProp,
+  padding: paddingProp,
+  paddingBlock: paddingProp,
+  paddingBlockStart: paddingProp,
+  paddingBlockEnd: paddingProp,
+  paddingInline: paddingProp,
+  paddingInlineStart: paddingProp,
+  paddingInlineEnd: paddingProp,
+  fontFamily: fontFamilyProp,
+  fontSize: fontSizeProp,
+  fontStyle: stringProp,
+  fontWeight: fontWeightProp,
+  letterSpacing: letterSpacingProp,
+  lineHeight: lineHeightProp,
+  textAlign: stringProp,
+  textTransform: stringProp,
+  textDecorationLine: stringProp,
+  wordBreak: stringProp,
+  elevation: {
+    toStyle: (value) => {
+      if (value === "0") {
+        return import_css_in_js.css`
+          box-shadow: none;
+        `;
+      }
+      if (value === "1") {
+        return import_css_in_js.css`
+          box-shadow: 0px 0px 12px 0px ${Palette.shadow["shadow-elevation-1"]};
+          border: 1px solid ${Palette.shadow["shadow-elevation-border"]};
+        `;
+      }
+      if (value === "1nb") {
+        return import_css_in_js.css`
+          box-shadow: 0px 0px 12px 0px ${Palette.shadow["shadow-elevation-1"]};
+        `;
+      }
+      if (value === "2") {
+        return import_css_in_js.css`
+          box-shadow:
+            0px 0px 2px 0px ${Palette.shadow["shadow-elevation-2x"]},
+            0px 0px 12px 0px ${Palette.shadow["shadow-elevation-2y"]};
+          border: 1px solid ${Palette.shadow["shadow-elevation-border"]};
+        `;
+      }
+      if (value === "2nb") {
+        return import_css_in_js.css`
+          box-shadow:
+            0px 0px 2px 0px ${Palette.shadow["shadow-elevation-2x"]},
+            0px 0px 12px 0px ${Palette.shadow["shadow-elevation-2y"]};
+        `;
+      }
+      return void 0;
+    }
+  },
+  invisible: {
+    toStyle: (value) => value ? import_css_in_js.css`
+            visibility: hidden;
+            opacity: 0;
+          ` : void 0
+  },
+  withTruncatedText: {
+    toStyle: (value) => value ? import_css_in_js.css`
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          ` : void 0
+  },
+  size: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            width: ${size(value)} !important;
+            height: ${size(value)} !important;
+          ` : void 0
+  },
+  minSize: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            min-width: ${size(value)} !important;
+            min-height: ${size(value)} !important;
+          ` : void 0
+  },
+  maxSize: {
+    toStyle: (value) => size(value) ? import_css_in_js.css`
+            max-width: ${size(value)} !important;
+            max-height: ${size(value)} !important;
+          ` : void 0
+  },
+  fontScale: {
+    toStyle: (value) => import_css_in_js.css`
+      font-size: ${fontScale(value)?.fontSize} !important;
+      font-weight: ${fontScale(value)?.fontWeight} !important;
+      letter-spacing: ${fontScale(value)?.letterSpacing} !important;
+      line-height: ${fontScale(value)?.lineHeight} !important;
+    `
+  }
+};
+var compiledPropDefs = new Map(
+  Object.entries(propDefs).map(
+    ([propName, propDef]) => {
+      if ("toCSSValue" in propDef) {
+        const cssProperty = fromCamelToKebab(propName);
+        const { toCSSValue: toCSSValue2 } = propDef;
+        return [
+          propName,
+          (value, stylingProps) => {
+            const cssValue = toCSSValue2(value);
+            if (cssValue === void 0) {
+              return;
+            }
+            stylingProps.set(
+              propName,
+              import_css_in_js.css`
+                ${cssProperty}: ${cssValue} !important;
+              `
+            );
+          }
+        ];
+      }
+      const { toStyle } = propDef;
+      return [
+        propName,
+        (value, stylingProps) => {
+          const style = toStyle(value);
+          if (style === void 0) {
+            return;
+          }
+          stylingProps.set(propName, style);
+        }
+      ];
+    }
+  )
+);
+var collectStylingProps = (props) => {
+  const stylingProps = /* @__PURE__ */ new Map();
+  const newProps = {};
+  for (const [propName, value] of Object.entries(props)) {
+    const inject = compiledPropDefs.get(propName);
+    if (!inject) {
+      newProps[propName] = value;
+      continue;
+    }
+    if (value === void 0) {
+      continue;
+    }
+    inject(value, stylingProps);
+  }
+  return [newProps, stylingProps];
+};
+var extractAtomicStylingProps = (props) => {
+  const [newProps, stylingProps] = collectStylingProps(props);
+  return [newProps, Array.from(stylingProps.values())];
+};
+
+// src/hooks/buildAtomicClassName.ts
+var import_css_in_js2 = require("@rocket.chat/css-in-js");
+var SINGLE_DECLARATION = /^([a-z-]+):\s*(.+?)\s*(?:!important)?;?$/;
+var buildAtomicClassName = (content) => {
+  const hash = (0, import_css_in_js2.createClassName)(content).slice("rcx-css-".length);
+  const match = SINGLE_DECLARATION.exec(content);
+  if (match) {
+    const [, property, rawValue] = match;
+    const value = rawValue.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    if (value && value.length <= 24) {
+      return `rcx-${property}-${value}-${hash.slice(0, 5)}`;
+    }
+    return `rcx-${property}-${hash}`;
+  }
+  return `rcx-css-${hash}`;
+};
+
+// poc/box-compiler/resolver.entry.ts
+var styleProps = Object.keys(propDefs);
+var resolve = (props) => {
+  const [, styles] = extractAtomicStylingProps(props);
+  return styles.map((cssFn) => {
+    const content = cssFn();
+    const className = buildAtomicClassName(content);
+    return { className, css: (0, import_css_in_js3.transpile)(`.${(0, import_css_in_js3.escapeName)(className)}`, content) };
+  });
+};
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  resolve,
+  styleProps
+});

--- a/packages/fuselage/src/components/Box/bench.stories.tsx
+++ b/packages/fuselage/src/components/Box/bench.stories.tsx
@@ -1,0 +1,167 @@
+/**
+ * Styling perf bench for Box. Renders many Boxes with LITERAL props (so the
+ * build-time compiler can extract them on :6007) and measures, across a
+ * detached root, the cost the styling path actually pays:
+ *
+ *   - mount ms   : first render + style resolution + insertRule (flushSync)
+ *   - update ms  : re-render of the same tree (styling re-runs per Box)
+ *   - rules      : rows in the shared rcx stylesheet (atomic plateaus)
+ *   - classes/el : class tokens on one Box (1 for merged, N for atomic)
+ *
+ * Compare the same story in each mode:
+ *   :6006 (no flag)                         → merged (per-combination)
+ *   :6006 + localStorage fuselage-styling=atomic → atomic runtime
+ *   :6007 (BOX_COMPILER=1)                  → build-time (props precompiled)
+ *
+ * Dev React is slower and double-renders under StrictMode; use it for RELATIVE
+ * comparison, or `storybook build` for production-grade absolute numbers.
+ */
+import type { Meta } from '@storybook/react-webpack5';
+import { useState } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+
+import Box from './Box';
+
+export default {
+  title: 'Layout/Box/Bench',
+} satisfies Meta;
+
+// A cell of varied, STATIC styling props (compilable at build time).
+const Cell = () => (
+  <Box
+    display='flex'
+    alignItems='center'
+    justifyContent='center'
+    padding='x8'
+    margin='x4'
+  >
+    <Box marginInline='x4' fontScale='p2' color='default'>
+      a
+    </Box>
+    <Box
+      marginInline='x4'
+      fontScale='c1'
+      color='hint'
+      backgroundColor='tint'
+      borderRadius={4}
+      paddingInline='x8'
+    >
+      b
+    </Box>
+    <Box marginInlineStart='x8' fontScale='micro' color='annotation'>
+      c
+    </Box>
+  </Box>
+);
+
+const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+};
+
+const ruleCount = () => {
+  const el = document.getElementById('rcx-styles') as HTMLStyleElement | null;
+  try {
+    return el?.sheet?.cssRules.length ?? 0;
+  } catch {
+    return 0;
+  }
+};
+
+const runOnce = (n: number) => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+
+  const t0 = performance.now();
+  flushSync(() => {
+    root.render(
+      <>
+        {Array.from({ length: n }, (_, i) => (
+          <Cell key={i} />
+        ))}
+      </>,
+    );
+  });
+  const t1 = performance.now();
+
+  // update: force a re-render of the whole tree
+  flushSync(() => {
+    root.render(
+      <div>
+        {Array.from({ length: n }, (_, i) => (
+          <Cell key={i} />
+        ))}
+      </div>,
+    );
+  });
+  const t2 = performance.now();
+
+  const sampleClasses =
+    host.querySelector('[class]')?.getAttribute('class')?.split(' ').length ??
+    0;
+
+  root.unmount();
+  host.remove();
+
+  return { mount: t1 - t0, update: t2 - t1, sampleClasses };
+};
+
+export const Benchmark = () => {
+  const [n, setN] = useState(500);
+  const [iters, setIters] = useState(7);
+  const [out, setOut] = useState<string>('');
+
+  const run = () => {
+    // warmup
+    runOnce(Math.min(n, 100));
+    const runs = Array.from({ length: iters }, () => runOnce(n));
+    const rules = ruleCount();
+    setOut(
+      JSON.stringify(
+        {
+          boxes: n * 7, // 7 Box per Cell
+          mountMs: +median(runs.map((r) => r.mount)).toFixed(1),
+          updateMs: +median(runs.map((r) => r.update)).toFixed(1),
+          rcxRules: rules,
+          classesPerEl: runs[0].sampleClasses,
+        },
+        null,
+        2,
+      ),
+    );
+  };
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: 16 }}>
+      <label>
+        cells:{' '}
+        <input
+          type='number'
+          value={n}
+          onChange={(e) => setN(Number(e.target.value))}
+        />
+      </label>{' '}
+      <label>
+        iters:{' '}
+        <input
+          type='number'
+          value={iters}
+          onChange={(e) => setIters(Number(e.target.value))}
+        />
+      </label>{' '}
+      <button type='button' onClick={run}>
+        run
+      </button>
+      <pre>{out}</pre>
+      <p>
+        mode:{' '}
+        {typeof localStorage !== 'undefined' &&
+        localStorage.getItem('fuselage-styling') === 'atomic'
+          ? 'atomic (runtime)'
+          : 'merged / build-time (check port)'}
+      </p>
+    </div>
+  );
+};

--- a/packages/fuselage/src/components/Box/useStylingProps.ts
+++ b/packages/fuselage/src/components/Box/useStylingProps.ts
@@ -55,6 +55,32 @@ const useMergedStylingProps = <TProps extends { className?: string }>(
   return props;
 };
 
-export const useStylingProps = ATOMIC_STYLING
+const useStylingPropsImpl = ATOMIC_STYLING
   ? useAtomicStylingProps
   : useMergedStylingProps;
+
+/**
+ * Drop styling props already compiled at build time (marked via the
+ * `data-rcx-atomic` attribute by the PoC compiler): they are represented by
+ * the precomputed className, so the runtime must not restyle them, but they
+ * are removed here rather than at build so runtime prop introspection
+ * (e.g. `child.props.bg`) keeps working. Inert when the marker is absent.
+ */
+const dropCompiledProps = <TProps extends Record<string, unknown>>(
+  props: TProps,
+): TProps => {
+  const compiled = props['data-rcx-atomic'];
+  if (typeof compiled !== 'string') return props;
+
+  const next: Record<string, unknown> = { ...props };
+  delete next['data-rcx-atomic'];
+  for (const name of compiled.split(' ')) {
+    delete next[name];
+  }
+  return next as TProps;
+};
+
+export const useStylingProps = <TProps extends { className?: string }>(
+  originalProps: TProps,
+): Omit<TProps, keyof StylingProps> =>
+  useStylingPropsImpl(dropCompiledProps(originalProps));

--- a/packages/fuselage/src/utilities/boxCompiler.poc.spec.ts
+++ b/packages/fuselage/src/utilities/boxCompiler.poc.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * PoC: build-time atomic extraction for <Box>.
+ *
+ * Proves a Babel plugin can turn static styling props into a plain className
+ * plus an out-of-band CSS sheet, reusing Fuselage's real runtime resolver so
+ * the emitted classes/rules are identical to the runtime atomic path.
+ */
+import { transformSync } from '@babel/core';
+import { escapeName, transpile } from '@rocket.chat/css-in-js';
+
+import {
+  extractAtomicStylingProps,
+  propDefs,
+} from '../components/Box/stylingProps';
+import { buildAtomicClassName } from '../hooks/useAtomicStyle';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const plugin = require('../../poc/box-compiler/plugin.cjs');
+
+const resolve = (props: Record<string, unknown>) => {
+  const [, styles] = extractAtomicStylingProps(props);
+  return styles.map((cssFn) => {
+    const content = cssFn();
+    const className = buildAtomicClassName(content);
+    return { className, css: transpile(`.${escapeName(className)}`, content) };
+  });
+};
+
+const compile = (code: string, opts: Record<string, unknown> = {}) => {
+  const sheet = new Map<string, string>();
+  const out = transformSync(code, {
+    configFile: false,
+    babelrc: false,
+    plugins: [
+      '@babel/plugin-syntax-jsx',
+      [plugin, { styleProps: Object.keys(propDefs), resolve, sheet, ...opts }],
+    ],
+  });
+  return { code: out?.code ?? '', css: [...sheet.values()].join('\n') };
+};
+
+describe('PoC build-time Box compiler', () => {
+  it('extracts static styling props into a className and a CSS sheet (keepProps:false strips)', () => {
+    const { code, css } = compile('<Box padding="x8" display="flex" />;', {
+      keepProps: false,
+    });
+
+    expect(code).toMatch(/className="rcx-padding-\S+ rcx-display-flex-\S+"/);
+    expect(code).not.toMatch(/padding=/);
+    expect(code).not.toMatch(/display=/);
+
+    expect(css).toContain('padding:0.5rem!important');
+    expect(css).toContain('display:flex!important');
+  });
+
+  it('leaves dynamic props to the runtime, extracts the static ones', () => {
+    const { code } = compile('<Box padding={spacing} display="flex" />;');
+
+    expect(code).toContain('padding={spacing}'); // dynamic → untouched
+    expect(code).toMatch(/className="rcx-display-flex-\S+"/);
+  });
+
+  it('merges into an existing static className', () => {
+    const { code } = compile('<Box padding="x8" className="foo" />;');
+    expect(code).toMatch(/className="rcx-padding-\S+ foo"/);
+  });
+
+  it('keepProps mode retains props for introspection and marks them', () => {
+    const { code } = compile('<Box backgroundColor="tint" padding="x8" />;', {
+      keepProps: true,
+    });
+
+    expect(code).toContain('backgroundColor="tint"'); // kept for introspection
+    expect(code).toContain('padding="x8"');
+    expect(code).toMatch(
+      /data-rcx-atomic="(backgroundColor padding|padding backgroundColor)"/,
+    );
+    expect(code).toMatch(
+      /className="rcx-background-color-\S+ rcx-padding-\S+"/,
+    );
+  });
+
+  it('dedupes shared declarations across many Boxes into one rule', () => {
+    const { css } = compile(
+      '<><Box display="flex" padding="x8" /><Box display="flex" padding="x16" /></>;',
+    );
+    // display:flex emitted once; two paddings → 3 rules total
+    expect(css.match(/display:flex!important/g)).toHaveLength(1);
+    expect(css.match(/\{/g)).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
**Stacked on #2097** (base: `feat/box-atomic-runtime`).

Moves the atomic styling work from render time to **build time**. A Babel plugin rewrites `<Box>`: static styling props resolved to atomic classes at compile, kept on the element with a `data-rcx-atomic` marker; the runtime skips restyling marked props (render-CPU win) while keeping props for introspection.

- `poc/box-compiler/plugin.cjs`: self-contained, reuses the **real** runtime resolver (no token drift), `keepProps` safe by default (full strip opt-in — unsafe where props are introspected).
- Runtime handshake in `useStylingProps` (`dropCompiledProps`), inert without the marker.
- Storybook wiring behind `BOX_COMPILER=1` (enforce:'pre' babel pass; SWC downstream).
- Benches: Node microbench + `Layout/Box/Bench` story. 2000 Boxes: **build-time 0.02ms/render vs merged 6.9ms**, 22 vs 1883 rules.
- `APPLYING-IN-ROCKETCHAT.md`: how to wire into RC's Meteor/Babel build (client is Babel, not SWC; `.babelrc` plugins is the hook; needs a marker-aware Fuselage or there's no CPU win).

Draft / PoC. Not wired into the production build; static-CSS-asset variant is webpack/vite-only.