### PR TITLE
feat(Table): add cellVerticalAlign prop to TableRow

### DIFF
--- a/packages/fuselage/src/components/Table/Table.styles.scss
+++ b/packages/fuselage/src/components/Table/Table.styles.scss
@@ -79,6 +79,12 @@ $table-selected-border-radius: theme(
       @include clickable;
       background-color: colors.surface(hover);
     }
+
+    &--cell-align-top {
+      .rcx-table__cell {
+        vertical-align: top;
+      }
+    }
   }
 
   &__cell {

--- a/packages/fuselage/src/components/Table/TableRow.tsx
+++ b/packages/fuselage/src/components/Table/TableRow.tsx
@@ -3,14 +3,23 @@ import { Box, type BoxProps } from '../Box';
 export type TableRowProps = Omit<BoxProps, 'action'> & {
   action?: boolean;
   hasAction?: boolean;
+  cellVerticalAlign?: 'top';
 };
 
-const TableRow = ({ action, selected, ...props }: TableRowProps) => (
+const TableRow = ({
+  action,
+  selected,
+  cellVerticalAlign,
+  className,
+  ...props
+}: TableRowProps) => (
   <Box
     is='tr'
     rcx-table__row
     rcx-table__row--selected={selected}
     rcx-table__row--action={action}
+    rcx-table__row--cell-align-top={cellVerticalAlign === 'top'}
+    className={className}
     {...props}
   />
 );


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->

Adds a new `cellVerticalAlign` prop to `TableRow` to allow consumers to apply `vertical-align: top` to all table cells (`td`) within a row.

This provides a reusable API for top-aligning table cells instead of requiring downstream projects to duplicate the styling.

<!-- END CHANGELOG -->

## Issue(s)

Related to RocketChat/Rocket.Chat#41442

## Further comments

This change was extracted into Fuselage following the review feedback on Rocket.Chat PR #41442 so the behavior can be reused by downstream projects.