### PR TITLE
chore: Deprecate legacy `AutoComplete`, `Contextualbar`, `Sidebar` and `TopBar` components

### DIFF
--- a/.changeset/brave-owls-relax.md
+++ b/.changeset/brave-owls-relax.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+chore(fuselage): Deprecate the `Sidebar` component family in favor of `SidebarV2`

--- a/.changeset/lucky-plums-jump.md
+++ b/.changeset/lucky-plums-jump.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+chore(fuselage): Deprecate the `Contextualbar` component family in favor of `ContextualbarV2`

--- a/.changeset/proud-doors-wander.md
+++ b/.changeset/proud-doors-wander.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+chore(fuselage): Deprecate `AutoComplete` in favor of `SelectFiltered` and `MultiSelectFiltered`

--- a/.changeset/tame-moons-argue.md
+++ b/.changeset/tame-moons-argue.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+chore(fuselage): Deprecate the sidebar `TopBar` and `TopBarV2` components

--- a/.changeset/wild-mangos-listen.md
+++ b/.changeset/wild-mangos-listen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage-forms': patch
+---
+
+chore(fuselage-forms): Deprecate `AutoComplete` in favor of `MultiSelectFiltered`

--- a/packages/fuselage-forms/fuselage-forms.api.md
+++ b/packages/fuselage-forms/fuselage-forms.api.md
@@ -41,7 +41,7 @@ import { TextAreaInputProps } from '@rocket.chat/fuselage';
 import { TextInputProps } from '@rocket.chat/fuselage';
 import { UrlInputProps } from '@rocket.chat/fuselage';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const AutoComplete: typeof AutoComplete_2;
 
 // @public (undocumented)

--- a/packages/fuselage-forms/src/Inputs/WrappedInputComponents.ts
+++ b/packages/fuselage-forms/src/Inputs/WrappedInputComponents.ts
@@ -38,6 +38,10 @@ export const UrlInput = withLabelId(UrlInputComponent);
 export const Select = withAriaLabelledBy(SelectComponent);
 
 // with aria-labelledby + id for aria-controls
+/**
+ * @deprecated Use `MultiSelectFiltered` instead, or `SelectFiltered` from
+ * `@rocket.chat/fuselage` for single selection.
+ */
 export const AutoComplete = withAriaLabelledByAndId(
   AutoCompleteComponent<any>,
 ) as typeof AutoCompleteComponent;

--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -2918,81 +2918,81 @@ export type TooltipProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement> & 
     placement?: 'top-start' | 'top-middle' | 'top-end' | 'bottom-start' | 'bottom-middle' | 'bottom-end' | 'top' | 'left' | 'bottom' | 'right' | null;
 };
 
-// @public
+// @public @deprecated
 const TopBar: (input: TopBarProps) => JSX.Element;
 export { TopBar as SidebarTopBar }
 export { TopBar }
 
 // Warning: (ae-forgotten-export) The symbol "TopBarActionProps" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 function TopBarAction(props: TopBarActionProps): JSX.Element;
 export { TopBarAction as SidebarTopBarAction }
 export { TopBarAction }
 
 // Warning: (ae-forgotten-export) The symbol "TopBarActionsProps" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 function TopBarActions(props: TopBarActionsProps): JSX.Element;
 export { TopBarActions as SidebarTopBarActions }
 export { TopBarActions }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 const TopBarAvatar: {
     size: "x24";
 };
 export { TopBarAvatar as SidebarTopBarAvatar }
 export { TopBarAvatar }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarProps = {
     children?: ReactNode;
     className?: string;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const TopBarSection: (input: TopBarSectionProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarSectionProps = {
     children?: ReactNode;
     className?: string;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 const TopBarTitle: (props: TopBarTitleProps) => JSX.Element;
 export { TopBarTitle as SidebarTopBarTitle }
 export { TopBarTitle }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarTitleProps = {
     children?: ReactNode;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 const TopBarToolBox: (input: TopBarToolBoxProps) => JSX.Element;
 export { TopBarToolBox as SidebarTopBarToolBox }
 export { TopBarToolBox }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarToolBoxProps = {
     children?: ReactNode;
     className?: string;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const TopBarV2: (input: TopBarV2Props) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarV2Props = {
     children?: ReactNode;
     className?: string;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const TopBarWrapper: (input: TopBarWrapperProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TopBarWrapperProps = {
     children?: ReactNode;
 };

--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -130,7 +130,7 @@ export type AudioPlayerProps = RefAttributes<HTMLAudioElement> & {
     trackProps?: TrackHTMLAttributes<HTMLTrackElement>;
 };
 
-// @public
+// @public @deprecated
 export function AutoComplete<TLabel = ReactNode>(input: AutoCompleteProps<TLabel>): JSX.Element;
 
 // @public (undocumented)
@@ -139,7 +139,7 @@ export type AutoCompleteOption<TLabel> = {
     label: TLabel;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type AutoCompleteProps<TLabel = ReactNode> = Omit<AllHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'is'> & {
     filter: string;
     setFilter?: (filter: string) => void;

--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -2050,16 +2050,16 @@ export type SelectProps = Omit<BoxProps, 'ref' | 'onChange'> & RefAttributes<HTM
     addonIcon?: IconProps['name'];
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const Sidebar: (props: SidebarProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarActionProps = Omit<IconButtonProps, 'ref'> & RefAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarBanner: (input: SidebarBannerProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarBannerProps = {
     text?: ReactNode;
     description?: ReactNode;
@@ -2070,81 +2070,81 @@ export type SidebarBannerProps = {
     addon?: ReactNode;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarBannerVariant = 'default' | 'info' | 'success' | 'warning' | 'danger';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarDivider: () => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarFooter: (input: SidebarFooterProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarFooterHighlight: (input: SidebarFooterHighlightProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarFooterHighlightProps = {
     children?: ReactNode;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarFooterProps = {
     children?: ReactNode;
     elevated?: boolean;
 };
 
-// @public
+// @public @deprecated
 export const SidebarItem: (input: SidebarItemProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemAction: (props: SidebarItemActionProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemActionProps = SidebarActionProps;
 
 // Warning: (ae-forgotten-export) The symbol "SidebarActions" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemActions: typeof SidebarActions;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemAvatar: (input: SidebarItemAvatarProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemAvatarProps = {
     children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemBadge: (input: SidebarItemBadgeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemBadgeProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemContainer: (props: SidebarItemContainerProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemContainerProps = {
     children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemContent: (input: SidebarItemContentProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemContentProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemIcon: (input: SidebarItemIconProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemIconProps = {
     children?: ReactNode;
     className?: string;
@@ -2152,15 +2152,15 @@ export type SidebarItemIconProps = {
     icon: IconProps['name'];
 } & Omit<AllHTMLAttributes<HTMLElement>, 'name' | 'is'>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemMenu: (props: SidebarItemMenuProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemMenuProps = {
     children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemProps = {
     selected?: boolean;
     highlighted?: boolean;
@@ -2170,57 +2170,57 @@ export type SidebarItemProps = {
     children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemSubtitle: (input: SidebarItemSubtitleProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemSubtitleProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemTime: (input: SidebarItemTimeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemTimeProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemTitle: (input: SidebarItemTitleProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemTitleProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarItemWrapper: (input: SidebarItemWrapperProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarItemWrapperProps = {
     children?: ReactNode;
     className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarProps = BoxProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarSection: (props: SidebarSectionProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarSectionProps = {
     children?: ReactNode;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const SidebarSectionTitle: (props: SidebarSectionTitleProps) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SidebarSectionTitleProps = {
     children?: ReactNode;
 };

--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -463,43 +463,43 @@ export const color: MemoizedFunction<unknown, unknown, string | undefined>;
 
 // Warning: (ae-forgotten-export) The symbol "Contextualbar_2" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const Contextualbar: MemoExoticComponent<typeof Contextualbar_2>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarAction: MemoExoticComponent<(input: ContextualbarActionProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarActionProps = {
     name: IconProps['name'];
 } & Omit<IconButtonProps, 'icon'>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarActions: MemoExoticComponent<(props: ContextualbarActionsProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarActionsProps = ButtonGroupProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarButton: MemoExoticComponent<(props: ContextualbarButtonProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarButtonProps = ButtonProps;
 
 // Warning: (ae-forgotten-export) The symbol "ContextualbarContent_2" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarContent: MemoExoticComponent<typeof ContextualbarContent_2>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarContentProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement>;
 
 // Warning: (ae-forgotten-export) The symbol "ContextualbarEmptyContent_2" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarEmptyContent: MemoExoticComponent<typeof ContextualbarEmptyContent_2>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarEmptyContentProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement> & {
     icon?: StatesIconProps['name'];
     title?: string;
@@ -508,45 +508,45 @@ export type ContextualbarEmptyContentProps = Omit<BoxProps, 'ref'> & RefAttribut
 
 // Warning: (ae-forgotten-export) The symbol "ContextualbarFooter_2" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarFooter: MemoExoticComponent<typeof ContextualbarFooter_2>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarFooterProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarHeader: MemoExoticComponent<(input: ContextualbarHeaderProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarHeaderProps = BoxProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarIcon: MemoExoticComponent<(props: ContextualbarIconProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarIconProps = IconProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement>;
 
 // Warning: (ae-forgotten-export) The symbol "ContextualbarSection_2" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarSection: MemoExoticComponent<typeof ContextualbarSection_2>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarSectionProps = Omit<BoxProps, 'ref'> & RefAttributes<HTMLElement>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarSkeleton: MemoExoticComponent<(props: ContextualbarSkeletonProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarSkeletonProps = BoxProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ContextualbarTitle: MemoExoticComponent<(props: ContextualbarTitleProps) => JSX.Element>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ContextualbarTitleProps = BoxProps;
 
 // Warning: (ae-forgotten-export) The symbol "Contextualbar_3" needs to be exported by the entry point index.d.ts

--- a/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
+++ b/packages/fuselage/src/components/AutoComplete/AutoComplete.tsx
@@ -53,6 +53,9 @@ const isSelectedValid =
       : value.includes(selected.value);
   };
 
+/**
+ * @deprecated Use `SelectFilteredProps` or `MultiSelectFilteredProps` instead.
+ */
 export type AutoCompleteProps<TLabel = ReactNode> = Omit<
   AllHTMLAttributes<HTMLInputElement>,
   'value' | 'onChange' | 'is'
@@ -85,6 +88,8 @@ export type AutoCompleteProps<TLabel = ReactNode> = Omit<
 
 /**
  * An input for selection of options.
+ *
+ * @deprecated Use `SelectFiltered` or `MultiSelectFiltered` instead.
  */
 function AutoComplete<TLabel = ReactNode>({
   ref,

--- a/packages/fuselage/src/components/Contextualbar/Contextualbar.tsx
+++ b/packages/fuselage/src/components/Contextualbar/Contextualbar.tsx
@@ -4,6 +4,9 @@ import { memo } from 'react';
 import { Box } from '..';
 import type { BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `ContextualbarV2Props` instead.
+ */
 export type ContextualbarProps = Omit<BoxProps, 'ref'> &
   RefAttributes<HTMLElement>;
 
@@ -38,4 +41,7 @@ function Contextualbar({
   );
 }
 
+/**
+ * @deprecated Use `ContextualbarV2` instead.
+ */
 export default memo(Contextualbar);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarAction.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarAction.tsx
@@ -4,6 +4,9 @@ import type { IconProps } from '..';
 import { IconButton } from '..';
 import type { IconButtonProps } from '../Button/IconButton';
 
+/**
+ * @deprecated Use `ContextualbarV2ActionProps` instead.
+ */
 export type ContextualbarActionProps = {
   name: IconProps['name'];
 } & Omit<IconButtonProps, 'icon'>;
@@ -12,4 +15,7 @@ const ContextualbarAction = ({ name, ...props }: ContextualbarActionProps) => (
   <IconButton {...props} small flexShrink={0} icon={name} />
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Action` instead.
+ */
 export default memo(ContextualbarAction);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarActions.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarActions.tsx
@@ -2,10 +2,16 @@ import { memo } from 'react';
 
 import { ButtonGroup, type ButtonGroupProps } from '../ButtonGroup';
 
+/**
+ * @deprecated Use `ContextualbarV2ActionsProps` instead.
+ */
 export type ContextualbarActionsProps = ButtonGroupProps;
 
 const ContextualbarActions = (props: ContextualbarActionsProps) => (
   <ButtonGroup {...props} />
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Actions` instead.
+ */
 export default memo(ContextualbarActions);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarButton.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarButton.tsx
@@ -2,10 +2,16 @@ import { memo } from 'react';
 
 import { Button, type ButtonProps } from '../Button';
 
+/**
+ * @deprecated Use `ContextualbarV2ButtonProps` instead.
+ */
 export type ContextualbarButtonProps = ButtonProps;
 
 const ContextualbarButton = (props: ContextualbarButtonProps) => (
   <Button {...props} />
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Button` instead.
+ */
 export default memo(ContextualbarButton);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarContent.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarContent.tsx
@@ -3,6 +3,9 @@ import { memo } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `ContextualbarV2ContentProps` instead.
+ */
 export type ContextualbarContentProps = Omit<BoxProps, 'ref'> &
   RefAttributes<HTMLElement>;
 
@@ -20,4 +23,7 @@ function ContextualbarContent(props: ContextualbarContentProps) {
   );
 }
 
+/**
+ * @deprecated Use `ContextualbarV2Content` instead.
+ */
 export default memo(ContextualbarContent);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarEmptyContent.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarEmptyContent.tsx
@@ -7,6 +7,9 @@ import type { BoxProps } from '../Box';
 
 import ContextualbarContent from './ContextualbarContent';
 
+/**
+ * @deprecated Use `ContextualbarV2EmptyContentProps` instead.
+ */
 export type ContextualbarEmptyContentProps = Omit<BoxProps, 'ref'> &
   RefAttributes<HTMLElement> & {
     icon?: StatesIconProps['name'];
@@ -31,4 +34,7 @@ function ContextualbarEmptyContent({
   );
 }
 
+/**
+ * @deprecated Use `ContextualbarV2EmptyContent` instead.
+ */
 export default memo(ContextualbarEmptyContent);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarFooter.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarFooter.tsx
@@ -4,6 +4,9 @@ import { memo } from 'react';
 import { Box } from '..';
 import type { BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `ContextualbarV2FooterProps` instead.
+ */
 export type ContextualbarFooterProps = Omit<BoxProps, 'ref'> &
   RefAttributes<HTMLElement>;
 
@@ -11,4 +14,7 @@ function ContextualbarFooter(props: ContextualbarFooterProps) {
   return <Box padding={24} {...props} />;
 }
 
+/**
+ * @deprecated Use `ContextualbarV2Footer` instead.
+ */
 export default memo(ContextualbarFooter);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarHeader.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarHeader.tsx
@@ -3,6 +3,9 @@ import { memo } from 'react';
 import { Box, type BoxProps } from '../Box';
 import { Margins } from '../Margins';
 
+/**
+ * @deprecated Use `ContextualbarV2HeaderProps` instead.
+ */
 export type ContextualbarHeaderProps = BoxProps;
 
 const ContextualbarHeader = ({
@@ -32,4 +35,7 @@ const ContextualbarHeader = ({
     </Box>
   </Box>
 );
+/**
+ * @deprecated Use `ContextualbarV2Header` instead.
+ */
 export default memo(ContextualbarHeader);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarIcon.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarIcon.tsx
@@ -2,10 +2,16 @@ import { memo } from 'react';
 
 import { Icon, type IconProps } from '../Icon';
 
+/**
+ * @deprecated Use `ContextualbarV2IconProps` instead.
+ */
 export type ContextualbarIconProps = IconProps;
 
 const ContextualbarIcon = (props: ContextualbarIconProps) => (
   <Icon {...props} paddingInline={2} size='x24' />
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Icon` instead.
+ */
 export default memo(ContextualbarIcon);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarSection.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarSection.tsx
@@ -3,6 +3,9 @@ import { memo } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `ContextualbarV2SectionProps` instead.
+ */
 export type ContextualbarSectionProps = Omit<BoxProps, 'ref'> &
   RefAttributes<HTMLElement>;
 
@@ -22,4 +25,7 @@ function ContextualbarSection(props: ContextualbarSectionProps) {
   );
 }
 
+/**
+ * @deprecated Use `ContextualbarV2Section` instead.
+ */
 export default memo(ContextualbarSection);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarSkeleton.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarSkeleton.tsx
@@ -6,6 +6,9 @@ import { Skeleton } from '../Skeleton';
 import Contextualbar from './Contextualbar';
 import ContextualbarHeader from './ContextualbarHeader';
 
+/**
+ * @deprecated Use `ContextualbarV2SkeletonProps` instead.
+ */
 export type ContextualbarSkeletonProps = BoxProps;
 
 const ContextualbarSkeleton = (props: ContextualbarSkeletonProps) => (
@@ -24,4 +27,7 @@ const ContextualbarSkeleton = (props: ContextualbarSkeletonProps) => (
   </Contextualbar>
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Skeleton` instead.
+ */
 export default memo(ContextualbarSkeleton);

--- a/packages/fuselage/src/components/Contextualbar/ContextualbarTitle.tsx
+++ b/packages/fuselage/src/components/Contextualbar/ContextualbarTitle.tsx
@@ -2,6 +2,9 @@ import { memo } from 'react';
 
 import { Box, type BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `ContextualbarV2TitleProps` instead.
+ */
 export type ContextualbarTitleProps = BoxProps;
 
 const ContextualbarTitle = (props: ContextualbarTitleProps) => (
@@ -14,4 +17,7 @@ const ContextualbarTitle = (props: ContextualbarTitleProps) => (
   />
 );
 
+/**
+ * @deprecated Use `ContextualbarV2Title` instead.
+ */
 export default memo(ContextualbarTitle);

--- a/packages/fuselage/src/components/Sidebar/Item.tsx
+++ b/packages/fuselage/src/components/Sidebar/Item.tsx
@@ -7,10 +7,16 @@ import { Icon as FuselageIcon } from '../Icon';
 import type { SidebarActionProps } from './SidebarActions';
 import { SidebarAction, SidebarActions } from './SidebarActions';
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export type SidebarItemContainerProps = {
   children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export const SidebarItemContainer = (props: SidebarItemContainerProps) => (
   <div
     className='rc-box rcx-box--full rcx-sidebar-item__container'
@@ -18,10 +24,16 @@ export const SidebarItemContainer = (props: SidebarItemContainerProps) => (
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemMenu` instead.
+ */
 export type SidebarItemMenuProps = {
   children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemMenu` instead.
+ */
 export const SidebarItemMenu = (props: SidebarItemMenuProps) => (
   <div
     className='rc-box rcx-box--full rcx-box--animated rcx-sidebar-item__menu-wrapper'
@@ -29,11 +41,17 @@ export const SidebarItemMenu = (props: SidebarItemMenuProps) => (
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemContent` instead.
+ */
 export type SidebarItemContentProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemContent` instead.
+ */
 export const SidebarItemContent = ({
   className = '',
   ...props
@@ -44,11 +62,17 @@ export const SidebarItemContent = ({
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemTitle` instead.
+ */
 export type SidebarItemTitleProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemTitle` instead.
+ */
 export const SidebarItemTitle = ({
   className = '',
   ...props
@@ -59,11 +83,17 @@ export const SidebarItemTitle = ({
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemTimestamp` instead.
+ */
 export type SidebarItemTimeProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemTimestamp` instead.
+ */
 export const SidebarItemTime = ({
   className,
   ...props
@@ -74,11 +104,17 @@ export const SidebarItemTime = ({
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemBadge` instead.
+ */
 export type SidebarItemBadgeProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemBadge` instead.
+ */
 export const SidebarItemBadge = ({
   className,
   ...props
@@ -89,11 +125,17 @@ export const SidebarItemBadge = ({
   />
 );
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export type SidebarItemSubtitleProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export const SidebarItemSubtitle = ({
   className,
   ...props
@@ -104,11 +146,17 @@ export const SidebarItemSubtitle = ({
   />
 );
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export type SidebarItemWrapperProps = {
   children?: ReactNode;
   className?: string;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use the `SidebarV2` component family instead.
+ */
 export const SidebarItemWrapper = ({
   className = '',
   ...props
@@ -119,6 +167,9 @@ export const SidebarItemWrapper = ({
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemIconProps` instead.
+ */
 export type SidebarItemIconProps = {
   children?: ReactNode;
   className?: string;
@@ -126,6 +177,9 @@ export type SidebarItemIconProps = {
   icon: IconProps['name'];
 } & Omit<AllHTMLAttributes<HTMLElement>, 'name' | 'is'>;
 
+/**
+ * @deprecated Use `SidebarV2ItemIcon` instead.
+ */
 export const SidebarItemIcon = ({
   highlighted,
   children,
@@ -146,24 +200,42 @@ export const SidebarItemIcon = ({
   </div>
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemAvatarWrapper` instead.
+ */
 export type SidebarItemAvatarProps = {
   children?: ReactNode;
 } & AllHTMLAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2ItemAvatarWrapper` instead.
+ */
 export const SidebarItemAvatar = ({ ...props }: SidebarItemAvatarProps) => (
   <SidebarItemContainer>
     <div className='rc-box rcx-box--full rcx-sidebar-item__avatar' {...props} />
   </SidebarItemContainer>
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemMenu` instead.
+ */
 export const SidebarItemActions = SidebarActions;
 
+/**
+ * @deprecated Use `SidebarV2ItemAction` instead.
+ */
 export type SidebarItemActionProps = SidebarActionProps;
 
+/**
+ * @deprecated Use `SidebarV2ItemAction` instead.
+ */
 export const SidebarItemAction = (props: SidebarItemActionProps) => (
   <SidebarAction {...props} />
 );
 
+/**
+ * @deprecated Use `SidebarV2ItemProps` instead.
+ */
 export type SidebarItemProps = {
   selected?: boolean;
   highlighted?: boolean;
@@ -175,6 +247,8 @@ export type SidebarItemProps = {
 
 /**
  * Item component to be used inside Sidebar.
+ *
+ * @deprecated Use `SidebarV2Item` instead.
  */
 export const SidebarItem = ({
   selected,

--- a/packages/fuselage/src/components/Sidebar/Section.tsx
+++ b/packages/fuselage/src/components/Sidebar/Section.tsx
@@ -1,17 +1,29 @@
 import type { ReactNode } from 'react';
 
+/**
+ * @deprecated Use `SidebarV2GroupTitleProps` instead.
+ */
 export type SidebarSectionTitleProps = {
   children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `SidebarV2GroupTitle` instead.
+ */
 export const SidebarSectionTitle = (props: SidebarSectionTitleProps) => (
   <div className='rcx-box rcx-box--full rcx-sidebar-title' {...props} />
 );
 
+/**
+ * @deprecated Use `SidebarV2Section` instead.
+ */
 export type SidebarSectionProps = {
   children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `SidebarV2Section` instead.
+ */
 export const SidebarSection = (props: SidebarSectionProps) => (
   <div className='rcx-box rcx-box--full rcx-sidebar-section' {...props} />
 );

--- a/packages/fuselage/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fuselage/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,13 @@
 import { Box, type BoxProps } from '../Box';
 
+/**
+ * @deprecated Use `SidebarV2Props` instead.
+ */
 export type SidebarProps = BoxProps;
 
+/**
+ * @deprecated Use `SidebarV2` instead.
+ */
 const Sidebar = (props: SidebarProps) => <Box rcx-sidebar {...props} />;
 
 export default Sidebar;

--- a/packages/fuselage/src/components/Sidebar/SidebarActions.tsx
+++ b/packages/fuselage/src/components/Sidebar/SidebarActions.tsx
@@ -5,15 +5,27 @@ import type { IconButtonProps } from '../Button/IconButton';
 import type { ButtonGroupProps } from '../ButtonGroup';
 import { ButtonGroup } from '../ButtonGroup';
 
+/**
+ * @deprecated Use `SidebarV2ActionsProps` instead.
+ */
 export type SidebarActionsProps = ButtonGroupProps;
 
+/**
+ * @deprecated Use `SidebarV2Actions` instead.
+ */
 export function SidebarActions(props: SidebarActionsProps) {
   return <ButtonGroup {...props} />;
 }
 
+/**
+ * @deprecated Use `SidebarV2ActionProps` instead.
+ */
 export type SidebarActionProps = Omit<IconButtonProps, 'ref'> &
   RefAttributes<HTMLElement>;
 
+/**
+ * @deprecated Use `SidebarV2Action` instead.
+ */
 export function SidebarAction(props: SidebarActionProps) {
   return <IconButton small {...props} />;
 }

--- a/packages/fuselage/src/components/Sidebar/SidebarBanner.tsx
+++ b/packages/fuselage/src/components/Sidebar/SidebarBanner.tsx
@@ -2,6 +2,9 @@ import type { ReactNode } from 'react';
 
 import { IconButton } from '../Button';
 
+/**
+ * @deprecated Use `SidebarV2BannerVariant` instead.
+ */
 export type SidebarBannerVariant =
   | 'default'
   | 'info'
@@ -9,6 +12,9 @@ export type SidebarBannerVariant =
   | 'warning'
   | 'danger';
 
+/**
+ * @deprecated Use `SidebarV2BannerProps` instead.
+ */
 export type SidebarBannerProps = {
   text?: ReactNode;
   description?: ReactNode;
@@ -19,6 +25,9 @@ export type SidebarBannerProps = {
   addon?: ReactNode;
 };
 
+/**
+ * @deprecated Use `SidebarV2Banner` instead.
+ */
 const SidebarBanner = ({
   text,
   description,

--- a/packages/fuselage/src/components/Sidebar/SidebarDivider.tsx
+++ b/packages/fuselage/src/components/Sidebar/SidebarDivider.tsx
@@ -1,5 +1,8 @@
 import { Divider } from '../Divider';
 
+/**
+ * @deprecated Use `SidebarV2Divider` instead.
+ */
 const SidebarDivider = () => (
   <Divider rcx-sidebar--divider marginBlockStart={-2} marginBlockEnd={0} />
 );

--- a/packages/fuselage/src/components/Sidebar/SidebarFooter.tsx
+++ b/packages/fuselage/src/components/Sidebar/SidebarFooter.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from 'react';
 
+/**
+ * @deprecated Use `SidebarV2Footer` instead.
+ */
 export type SidebarFooterProps = {
   children?: ReactNode;
   elevated?: boolean;
 };
 
+/**
+ * @deprecated Use `SidebarV2Footer` instead.
+ */
 export const SidebarFooter = ({ elevated, ...props }: SidebarFooterProps) => (
   <div
     className={[
@@ -17,10 +23,16 @@ export const SidebarFooter = ({ elevated, ...props }: SidebarFooterProps) => (
   />
 );
 
+/**
+ * @deprecated Use `SidebarV2FooterContent` instead.
+ */
 export type SidebarFooterHighlightProps = {
   children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `SidebarV2FooterContent` instead.
+ */
 export const SidebarFooterHighlight = ({
   ...props
 }: SidebarFooterHighlightProps) => (

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBar.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBar.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarProps = {
   children?: ReactNode;
   className?: string;
@@ -7,6 +10,8 @@ export type TopBarProps = {
 
 /**
  * Sidebar TopBar and ToolBox.
+ *
+ * @deprecated Use `NavBar` for app-level navigation instead.
  */
 export const TopBar = ({ className, ...props }: TopBarProps) => (
   <div

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarAction.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarAction.tsx
@@ -3,6 +3,9 @@ import { SidebarAction } from '../SidebarActions';
 
 type TopBarActionProps = SidebarActionProps;
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export function TopBarAction(props: TopBarActionProps) {
   return <SidebarAction {...props} />;
 }

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarActions.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarActions.tsx
@@ -3,6 +3,9 @@ import { SidebarActions } from '../SidebarActions';
 
 type TopBarActionsProps = SidebarActionsProps;
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export function TopBarActions(props: TopBarActionsProps) {
   return <SidebarActions {...props} />;
 }

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarSection.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarSection.tsx
@@ -5,11 +5,17 @@ import SidebarDivider from '../SidebarDivider';
 import { TopBar } from './TopBar';
 import { TopBarWrapper } from './TopBarWrapper';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarSectionProps = {
   children?: ReactNode;
   className?: string;
 };
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarSection = ({
   className,
   children,

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarTitle.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarTitle.tsx
@@ -2,10 +2,16 @@ import type { ReactNode } from 'react';
 
 import { Box } from '../../Box';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarTitleProps = {
   children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarTitle = (props: TopBarTitleProps) => (
   <Box className='rcx-sidebar-topbar__title' withTruncatedText {...props} />
 );

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarToolBox.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarToolBox.tsx
@@ -5,11 +5,17 @@ import SidebarDivider from '../SidebarDivider';
 import { TopBar } from './TopBar';
 import { TopBarWrapper } from './TopBarWrapper';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarToolBoxProps = {
   children?: ReactNode;
   className?: string;
 };
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarToolBox = ({
   children,
   className,

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarV2.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarV2.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from 'react';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarV2Props = {
   children?: ReactNode;
   className?: string;
 };
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarV2 = ({ className, ...props }: TopBarV2Props) => (
   <div
     className={[

--- a/packages/fuselage/src/components/Sidebar/TopBar/TopBarWrapper.tsx
+++ b/packages/fuselage/src/components/Sidebar/TopBar/TopBarWrapper.tsx
@@ -1,9 +1,15 @@
 import type { ReactNode } from 'react';
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export type TopBarWrapperProps = {
   children?: ReactNode;
 };
 
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarWrapper = ({ children }: TopBarWrapperProps) => (
   <div className='rc-box rc-box--full rcx-sidebar-topbar__wrapper'>
     {children}

--- a/packages/fuselage/src/components/Sidebar/TopBar/index.ts
+++ b/packages/fuselage/src/components/Sidebar/TopBar/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use `NavBar` for app-level navigation instead.
+ */
 export const TopBarAvatar = { size: 'x24' as const };
 export * from './TopBar';
 export * from './TopBarV2';


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->

Marks the legacy component families as deprecated through `@deprecated` JSDoc, so consumers get IDE and API-report warnings before they are removed. No runtime behavior changes — comments only.

| Deprecated | Use instead |
| --- | --- |
| `AutoComplete` (`@rocket.chat/fuselage`) | `SelectFiltered` / `MultiSelectFiltered` |
| `AutoComplete` (`@rocket.chat/fuselage-forms`) | `MultiSelectFiltered` |
| `Contextualbar*` | `ContextualbarV2*` |
| `Sidebar*` | `SidebarV2*` |
| `TopBar*`, `TopBarV2`, `SidebarTopBar*` | `NavBar` |

Notes on the mapping:

- The `Contextualbar` family is a 1:1 rename, so every component and props type points at its `ContextualbarV2*` counterpart.
- The `Sidebar` family is not 1:1. Where a counterpart exists it is named (for example `SidebarItemTime` → `SidebarV2ItemTimestamp`, `SidebarItemAvatar` → `SidebarV2ItemAvatarWrapper`, `SidebarSectionTitle` → `SidebarV2GroupTitle`). `SidebarItemContainer`, `SidebarItemWrapper` and `SidebarItemSubtitle` have no V2 equivalent, since V2 restructured them into `SidebarV2ItemRow`/`SidebarV2ItemCol`, so those point at the family instead of asserting a replacement.
- Both `TopBar` and `TopBarV2` are deprecated, so there is no in-family successor; they point at `NavBar` for app-level navigation.
- These components are exported as `export default memo(X)` in the `Contextualbar` family, where JSDoc on the inner declaration does not attach to the exported symbol. The tags are therefore placed on the `export default` statements, which is what makes them show up in the API reports.

<!-- END CHANGELOG -->

## Issue(s)

## Further comments

Verified per commit: `yarn build` for both affected packages (api-extractor regenerated `fuselage.api.md` and `fuselage-forms.api.md`, and the reports confirm every intended export flipped to `@public @deprecated` and nothing else did), plus `yarn lint` (0 errors, only the 3 pre-existing `react-hooks/exhaustive-deps` warnings in `MultiSelect`/`SelectLegacy`) and `tsc --noEmit`.

Unit tests and visual regression were not run — the changes are comments only and do not affect rendered output.
