### PR TITLE
feat(fuselage): Add LabelReset and FieldLabelReset components

### DIFF
--- a/.changeset/label-reset-component.md
+++ b/.changeset/label-reset-component.md
@@ -1,0 +1,11 @@
+---
+'@rocket.chat/fuselage': minor
+---
+
+feat(fuselage): Add `LabelReset` and `FieldLabelReset` components
+
+Introduces `LabelReset`, a label affordance that renders a fixed 20px, neutral `IconButton` with the `undo` icon to reset a field to its default value, plus `FieldLabelReset`, the `Field`-aware wrapper.
+
+Unlike `LabelInfo`, the reset is composed as a sibling of the label (not nested inside it), so hovering or clicking it is never forwarded to the field's control. It's placed in the field row next to the control (or alone at the right for stacked inputs), and the `ref` is forwarded to the underlying button so consumers can move focus to it or anchor a tooltip.
+
+This is intended to standardize the reset affordance across the design system and to eventually replace Rocket.Chat core's custom `ResetSettingButton`. That current button is a 28px `danger` (red) `IconButton`; adopting `FieldLabelReset` is a deliberate design change — the reset becomes **20px and neutral**. The size is fixed (not overridable) to enforce the standard; the variant defaults to neutral but remains overridable.

--- a/packages/fuselage/src/components/Field/Field.stories.tsx
+++ b/packages/fuselage/src/components/Field/Field.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
+import { Box } from '../Box';
 import { CheckBox } from '../CheckBox';
 import { RadioButton } from '../RadioButton';
 import { TextAreaInput } from '../TextAreaInput';
@@ -12,6 +13,7 @@ import FieldError from './FieldError';
 import FieldHint from './FieldHint';
 import FieldLabel from './FieldLabel';
 import FieldLabelInfo from './FieldLabelInfo';
+import FieldLabelReset from './FieldLabelReset';
 import FieldLink from './FieldLink';
 import FieldRow from './FieldRow';
 
@@ -24,6 +26,7 @@ export default {
     FieldHint,
     FieldLabel,
     FieldLabelInfo,
+    FieldLabelReset,
     FieldLink,
     FieldRow,
   },
@@ -49,10 +52,13 @@ type Story = StoryObj<typeof Field>;
 export const WithTextInput: Story = {
   render: () => (
     <Field>
-      <FieldLabel required htmlFor='fieldWithText'>
-        Label
-        <FieldLabelInfo id='fieldWithTextInfo' title='this is a info label' />
-      </FieldLabel>
+      <FieldRow>
+        <FieldLabel required htmlFor='fieldWithText'>
+          Label
+          <FieldLabelInfo id='fieldWithTextInfo' title='this is a info label' />
+        </FieldLabel>
+        <FieldLabelReset title='reset to default' />
+      </FieldRow>
       <FieldDescription>Description</FieldDescription>
       <FieldRow>
         <TextInput id='fieldWithText' aria-describedby='fieldWithTextInfo' />
@@ -69,13 +75,16 @@ export const WithTextInput: Story = {
 export const WithTextArea: Story = {
   render: () => (
     <Field>
-      <FieldLabel required htmlFor='fieldWithTextArea'>
-        Label
-        <FieldLabelInfo
-          id='fieldWithTextAreaInfo'
-          title='this is a info label'
-        />
-      </FieldLabel>
+      <FieldRow>
+        <FieldLabel required htmlFor='fieldWithTextArea'>
+          Label
+          <FieldLabelInfo
+            id='fieldWithTextAreaInfo'
+            title='this is a info label'
+          />
+        </FieldLabel>
+        <FieldLabelReset title='reset to default' />
+      </FieldRow>
       <FieldDescription>Description</FieldDescription>
       <FieldRow>
         <TextAreaInput
@@ -96,13 +105,22 @@ export const WithRadioButton: Story = {
   render: () => (
     <Field>
       <FieldRow>
-        <FieldLabel required htmlFor='fieldWithRadio'>
-          Label
-          <FieldLabelInfo
-            id='fieldWithRadioInfo'
-            title='this is a info label'
-          />
-        </FieldLabel>
+        <Box
+          is='span'
+          display='flex'
+          alignItems='center'
+          flexGrow={1}
+          marginInlineEnd={8}
+        >
+          <FieldLabel required htmlFor='fieldWithRadio'>
+            Label
+            <FieldLabelInfo
+              id='fieldWithRadioInfo'
+              title='this is a info label'
+            />
+          </FieldLabel>
+          <FieldLabelReset title='reset to default' />
+        </Box>
         <RadioButton
           id='fieldWithRadio'
           aria-describedby='fieldWithRadioInfo'
@@ -122,13 +140,22 @@ export const WithToggleSwitch: Story = {
   render: () => (
     <Field>
       <FieldRow>
-        <FieldLabel required htmlFor='fieldWithToggle'>
-          Label
-          <FieldLabelInfo
-            id='fieldWithToggleInfo'
-            title='this is a info label'
-          />
-        </FieldLabel>
+        <Box
+          is='span'
+          display='flex'
+          alignItems='center'
+          flexGrow={1}
+          marginInlineEnd={8}
+        >
+          <FieldLabel required htmlFor='fieldWithToggle'>
+            Label
+            <FieldLabelInfo
+              id='fieldWithToggleInfo'
+              title='this is a info label'
+            />
+          </FieldLabel>
+          <FieldLabelReset title='reset to default' />
+        </Box>
         <ToggleSwitch
           id='fieldWithToggle'
           aria-describedby='fieldWithToggleInfo'
@@ -148,13 +175,22 @@ export const WithCheckbox: Story = {
   render: () => (
     <Field>
       <FieldRow>
-        <FieldLabel required htmlFor='fieldWithCheckbox'>
-          Label
-          <FieldLabelInfo
-            id='fieldWithCheckboxInfo'
-            title='this is a info label'
-          />
-        </FieldLabel>
+        <Box
+          is='span'
+          display='flex'
+          alignItems='center'
+          flexGrow={1}
+          marginInlineEnd={8}
+        >
+          <FieldLabel required htmlFor='fieldWithCheckbox'>
+            Label
+            <FieldLabelInfo
+              id='fieldWithCheckboxInfo'
+              title='this is a info label'
+            />
+          </FieldLabel>
+          <FieldLabelReset title='reset to default' />
+        </Box>
         <CheckBox
           id='fieldWithCheckbox'
           aria-describedby='fieldWithCheckboxInfo'

--- a/packages/fuselage/src/components/Field/FieldLabelReset.tsx
+++ b/packages/fuselage/src/components/Field/FieldLabelReset.tsx
@@ -1,0 +1,27 @@
+import WithErrorWrapper from '../../helpers/WithErrorWrapper';
+import type { LabelResetProps } from '../Label/LabelReset';
+import { LabelReset } from '../Label/LabelReset';
+
+import { FieldContext } from './Field';
+
+export type FieldLabelResetProps = LabelResetProps;
+
+const FieldLabelReset = (props: FieldLabelResetProps) => {
+  const component = <LabelReset {...props} />;
+
+  if (process.env['NODE_ENV'] === 'development') {
+    return (
+      <WithErrorWrapper
+        context={FieldContext}
+        parentComponent='Field'
+        componentName={FieldLabelReset.name}
+      >
+        {component}
+      </WithErrorWrapper>
+    );
+  }
+
+  return component;
+};
+
+export default FieldLabelReset;

--- a/packages/fuselage/src/components/Field/__snapshots__/Field.spec.tsx.snap
+++ b/packages/fuselage/src/components/Field/__snapshots__/Field.spec.tsx.snap
@@ -9,35 +9,56 @@ exports[`[Field Component] renders WithCheckbox without crashing 1`] = `
       <span
         class="rcx-box rcx-box--full rcx-field__row"
       >
-        <label
-          class="rcx-box rcx-box--full rcx-field__label rcx-label"
-          for="fieldWithCheckbox"
+        <span
+          class="rcx-box rcx-box--full rcx-css-1vmw47n"
         >
-          Label
-          <span
-            class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+          <label
+            class="rcx-box rcx-box--full rcx-field__label rcx-label"
+            for="fieldWithCheckbox"
           >
+            Label
             <span
-              hidden=""
-              id="fieldWithCheckboxInfo"
+              class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
             >
-              this is a info label
+              <span
+                hidden=""
+                id="fieldWithCheckboxInfo"
+              >
+                this is a info label
+              </span>
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+                title="this is a info label"
+              >
+                
+              </i>
             </span>
-            <i
+            <span
               aria-hidden="true"
-              class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-              title="this is a info label"
+              class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
             >
-              
-            </i>
-          </span>
+              *
+            </span>
+          </label>
           <span
-            aria-hidden="true"
-            class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+            class="rcx-box rcx-box--full rcx-label__reset"
           >
-            *
+            <button
+              aria-label="reset to default"
+              class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+              title="reset to default"
+              type="button"
+            >
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+              >
+                ❰
+              </i>
+            </button>
           </span>
-        </label>
+        </span>
         <label
           class="rcx-box rcx-box--full rcx-check-box"
         >
@@ -92,35 +113,56 @@ exports[`[Field Component] renders WithRadioButton without crashing 1`] = `
       <span
         class="rcx-box rcx-box--full rcx-field__row"
       >
-        <label
-          class="rcx-box rcx-box--full rcx-field__label rcx-label"
-          for="fieldWithRadio"
+        <span
+          class="rcx-box rcx-box--full rcx-css-1vmw47n"
         >
-          Label
-          <span
-            class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+          <label
+            class="rcx-box rcx-box--full rcx-field__label rcx-label"
+            for="fieldWithRadio"
           >
+            Label
             <span
-              hidden=""
-              id="fieldWithRadioInfo"
+              class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
             >
-              this is a info label
+              <span
+                hidden=""
+                id="fieldWithRadioInfo"
+              >
+                this is a info label
+              </span>
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+                title="this is a info label"
+              >
+                
+              </i>
             </span>
-            <i
+            <span
               aria-hidden="true"
-              class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-              title="this is a info label"
+              class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
             >
-              
-            </i>
-          </span>
+              *
+            </span>
+          </label>
           <span
-            aria-hidden="true"
-            class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+            class="rcx-box rcx-box--full rcx-label__reset"
           >
-            *
+            <button
+              aria-label="reset to default"
+              class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+              title="reset to default"
+              type="button"
+            >
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+              >
+                ❰
+              </i>
+            </button>
           </span>
-        </label>
+        </span>
         <label
           class="rcx-box rcx-box--full rcx-radio-button"
         >
@@ -172,35 +214,56 @@ exports[`[Field Component] renders WithTextArea without crashing 1`] = `
     <div
       class="rcx-box rcx-box--full rcx-field"
     >
-      <label
-        class="rcx-box rcx-box--full rcx-field__label rcx-label"
-        for="fieldWithTextArea"
+      <span
+        class="rcx-box rcx-box--full rcx-field__row"
       >
-        Label
-        <span
-          class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+        <label
+          class="rcx-box rcx-box--full rcx-field__label rcx-label"
+          for="fieldWithTextArea"
         >
+          Label
           <span
-            hidden=""
-            id="fieldWithTextAreaInfo"
+            class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
           >
-            this is a info label
+            <span
+              hidden=""
+              id="fieldWithTextAreaInfo"
+            >
+              this is a info label
+            </span>
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+              title="this is a info label"
+            >
+              
+            </i>
           </span>
-          <i
+          <span
             aria-hidden="true"
-            class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-            title="this is a info label"
+            class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
           >
-            
-          </i>
-        </span>
+            *
+          </span>
+        </label>
         <span
-          aria-hidden="true"
-          class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+          class="rcx-box rcx-box--full rcx-label__reset"
         >
-          *
+          <button
+            aria-label="reset to default"
+            class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+            title="reset to default"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+            >
+              ❰
+            </i>
+          </button>
         </span>
-      </label>
+      </span>
       <span
         class="rcx-box rcx-box--full rcx-field__description"
       >
@@ -248,35 +311,56 @@ exports[`[Field Component] renders WithTextInput without crashing 1`] = `
     <div
       class="rcx-box rcx-box--full rcx-field"
     >
-      <label
-        class="rcx-box rcx-box--full rcx-field__label rcx-label"
-        for="fieldWithText"
+      <span
+        class="rcx-box rcx-box--full rcx-field__row"
       >
-        Label
-        <span
-          class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+        <label
+          class="rcx-box rcx-box--full rcx-field__label rcx-label"
+          for="fieldWithText"
         >
+          Label
           <span
-            hidden=""
-            id="fieldWithTextInfo"
+            class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
           >
-            this is a info label
+            <span
+              hidden=""
+              id="fieldWithTextInfo"
+            >
+              this is a info label
+            </span>
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+              title="this is a info label"
+            >
+              
+            </i>
           </span>
-          <i
+          <span
             aria-hidden="true"
-            class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-            title="this is a info label"
+            class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
           >
-            
-          </i>
-        </span>
+            *
+          </span>
+        </label>
         <span
-          aria-hidden="true"
-          class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+          class="rcx-box rcx-box--full rcx-label__reset"
         >
-          *
+          <button
+            aria-label="reset to default"
+            class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+            title="reset to default"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+            >
+              ❰
+            </i>
+          </button>
         </span>
-      </label>
+      </span>
       <span
         class="rcx-box rcx-box--full rcx-field__description"
       >
@@ -327,35 +411,56 @@ exports[`[Field Component] renders WithToggleSwitch without crashing 1`] = `
       <span
         class="rcx-box rcx-box--full rcx-field__row"
       >
-        <label
-          class="rcx-box rcx-box--full rcx-field__label rcx-label"
-          for="fieldWithToggle"
+        <span
+          class="rcx-box rcx-box--full rcx-css-1vmw47n"
         >
-          Label
-          <span
-            class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+          <label
+            class="rcx-box rcx-box--full rcx-field__label rcx-label"
+            for="fieldWithToggle"
           >
+            Label
             <span
-              hidden=""
-              id="fieldWithToggleInfo"
+              class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
             >
-              this is a info label
+              <span
+                hidden=""
+                id="fieldWithToggleInfo"
+              >
+                this is a info label
+              </span>
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+                title="this is a info label"
+              >
+                
+              </i>
             </span>
-            <i
+            <span
               aria-hidden="true"
-              class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-              title="this is a info label"
+              class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
             >
-              
-            </i>
-          </span>
+              *
+            </span>
+          </label>
           <span
-            aria-hidden="true"
-            class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+            class="rcx-box rcx-box--full rcx-label__reset"
           >
-            *
+            <button
+              aria-label="reset to default"
+              class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+              title="reset to default"
+              type="button"
+            >
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+              >
+                ❰
+              </i>
+            </button>
           </span>
-        </label>
+        </span>
         <label
           class="rcx-box rcx-box--full rcx-toggle-switch"
         >

--- a/packages/fuselage/src/components/Field/index.ts
+++ b/packages/fuselage/src/components/Field/index.ts
@@ -10,5 +10,9 @@ export {
   default as FieldLabelInfo,
   type FieldLabelInfoProps,
 } from './FieldLabelInfo';
+export {
+  default as FieldLabelReset,
+  type FieldLabelResetProps,
+} from './FieldLabelReset';
 export { default as FieldLink, type FieldLinkProps } from './FieldLink';
 export { default as FieldRow, type FieldRowProps } from './FieldRow';

--- a/packages/fuselage/src/components/Label/Label.stories.tsx
+++ b/packages/fuselage/src/components/Label/Label.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
+import { Box } from '../Box';
+
 import Label from './Label';
 import { LabelInfo } from './LabelInfo';
+import { LabelReset } from './LabelReset';
 
 export default {
   title: 'Inputs/Label',
@@ -68,15 +71,27 @@ export const Info: Story = {
   ),
 };
 
-export const InfoRequired: Story = {
+export const Reset: Story = {
+  render: (args) => (
+    <Box display='flex' alignItems='center' width='100%'>
+      <Label {...args}>Label</Label>
+      <LabelReset title='reset to default' />
+    </Box>
+  ),
+};
+
+export const InfoRequiredReset: Story = {
   args: {
     required: true,
   },
   render: (args) => (
-    <Label {...args}>
-      Label
-      <LabelInfo title='this is a label info' />
-    </Label>
+    <Box display='flex' alignItems='center' width='100%'>
+      <Label {...args}>
+        Label
+        <LabelInfo title='this is a label info' />
+      </Label>
+      <LabelReset title='reset to default' />
+    </Box>
   ),
 };
 

--- a/packages/fuselage/src/components/Label/Label.styles.scss
+++ b/packages/fuselage/src/components/Label/Label.styles.scss
@@ -22,6 +22,16 @@
     order: 1;
   }
 
+  &__reset {
+    display: flex;
+    align-items: center;
+
+    // Sits as a sibling of the label within the field row; the auto inline-start
+    // margin pushes it to the end so it lands next to the field's control
+    // (toggle, radio, checkbox) or alone at the right when there is no control.
+    margin-inline-start: auto;
+  }
+
   &__required {
     color: colors.font(danger);
   }

--- a/packages/fuselage/src/components/Label/LabelReset.tsx
+++ b/packages/fuselage/src/components/Label/LabelReset.tsx
@@ -1,0 +1,23 @@
+import { Box } from '../Box';
+import {
+  IconButton,
+  type IconButtonProps,
+  type IconButtonSize,
+} from '../Button';
+
+export type LabelResetProps = {
+  title: string;
+} & Omit<IconButtonProps, 'icon' | keyof IconButtonSize>;
+
+export const LabelReset = ({ title, ref, ...props }: LabelResetProps) => (
+  <Box is='span' rcx-label__reset>
+    <IconButton
+      ref={ref}
+      {...props}
+      mini
+      icon='undo'
+      title={title}
+      aria-label={title}
+    />
+  </Box>
+);

--- a/packages/fuselage/src/components/Label/__snapshots__/Label.spec.tsx.snap
+++ b/packages/fuselage/src/components/Label/__snapshots__/Label.spec.tsx.snap
@@ -52,36 +52,57 @@ exports[`[Label Component] renders Info without crashing 1`] = `
 </body>
 `;
 
-exports[`[Label Component] renders InfoRequired without crashing 1`] = `
+exports[`[Label Component] renders InfoRequiredReset without crashing 1`] = `
 <body>
   <div>
-    <label
-      class="rcx-box rcx-box--full rcx-label"
+    <div
+      class="rcx-box rcx-box--full rcx-css-g1wnuz"
     >
-      Label
-      <span
-        class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
+      <label
+        class="rcx-box rcx-box--full rcx-label"
       >
+        Label
         <span
-          hidden=""
+          class="rcx-box rcx-box--full rcx-label__info rcx-css-wcp0mp"
         >
-          this is a label info
+          <span
+            hidden=""
+          >
+            this is a label info
+          </span>
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
+            title="this is a label info"
+          >
+            
+          </i>
         </span>
-        <i
+        <span
           aria-hidden="true"
-          class="rcx-box rcx-box--full rcx-icon--name-info-circled rcx-icon"
-          title="this is a label info"
+          class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
         >
-          
-        </i>
-      </span>
+          *
+        </span>
+      </label>
       <span
-        aria-hidden="true"
-        class="rcx-box rcx-box--full rcx-label__required rcx-css-b7g1a9"
+        class="rcx-box rcx-box--full rcx-label__reset"
       >
-        *
+        <button
+          aria-label="reset to default"
+          class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+          title="reset to default"
+          type="button"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+          >
+            ❰
+          </i>
+        </button>
       </span>
-    </label>
+    </div>
   </div>
 </body>
 `;
@@ -100,6 +121,39 @@ exports[`[Label Component] renders Required without crashing 1`] = `
         *
       </span>
     </label>
+  </div>
+</body>
+`;
+
+exports[`[Label Component] renders Reset without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-css-g1wnuz"
+    >
+      <label
+        class="rcx-box rcx-box--full rcx-label"
+      >
+        Label
+      </label>
+      <span
+        class="rcx-box rcx-box--full rcx-label__reset"
+      >
+        <button
+          aria-label="reset to default"
+          class="rcx-box rcx-box--full rcx-button--mini-square rcx-button--square rcx-button--icon rcx-button"
+          title="reset to default"
+          type="button"
+        >
+          <i
+            aria-hidden="true"
+            class="rcx-box rcx-box--full rcx-icon--name-undo rcx-icon rcx-css-1tg7yd0"
+          >
+            ❰
+          </i>
+        </button>
+      </span>
+    </div>
   </div>
 </body>
 `;

--- a/packages/fuselage/src/components/Label/index.ts
+++ b/packages/fuselage/src/components/Label/index.ts
@@ -1,2 +1,3 @@
 export { default as Label, type LabelProps } from './Label';
 export type { LabelInfoProps } from './LabelInfo';
+export type { LabelResetProps } from './LabelReset';


### PR DESCRIPTION
## Summary

Adds `LabelReset` and `FieldLabelReset` — a standardized "reset to default" affordance for form fields.

- **`LabelReset`**: a fixed **20px, neutral** `IconButton` with the `undo` icon.
- **`FieldLabelReset`**: the `Field`-aware wrapper (dev-mode error boundary), mirroring `FieldLabelInfo`.

## Composition

Unlike `LabelInfo`, the reset is composed as a **sibling of the label**, not nested inside it — because it's interactive, nesting it in the `<label>` would forward hover/click to the field's control. It sits in the field row next to the control (8px gap), or alone at the right for stacked inputs. The `ref` is forwarded to the underlying button so consumers can move focus to it or anchor a tooltip.

## API decisions

- **Size fixed at 20px** (`mini`) — the icon and size props are `Omit`ed from the type and set internally, enforcing the standard rather than just defaulting it.
- **Neutral by default**, variant still overridable.
- Accessible name via `title` → `aria-label`.

## Intended follow-up (Rocket.Chat core)

This is designed to replace core's custom `ResetSettingButton` (currently a **28px `danger`/red** `IconButton`). Adopting `FieldLabelReset` is a deliberate design change: the reset becomes **20px and neutral**. The composition already matches core's usage (sibling of `FieldLabel` in a `FieldRow`, conditionally rendered on `hasResetButton`), so the swap is mechanical:

```diff
- <IconButton icon='undo' danger small title={t('Reset')} {...props} />
+ <FieldLabelReset title={t('Reset')} onClick={onResetButtonClick} />
```

## Stories

- **Inputs / Label**: `Reset`, `Info Required Reset`
- **Inputs / Field**: reset shown across all five field stories (text, textarea, radio, toggle, checkbox)

## Testing

- Snapshot + `jest-axe` a11y tests pass (auto-generated per story via `composeStories`)
- Verified in Storybook: right-alignment, 8px gap to control, vertical centering, hover isolation (hovering the reset never highlights the control), and responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
