### PR TITLE
chore(fuselage)!: Remove `useArrayLikeClassNameProp` and `Falsy` from the public API

### DIFF
--- a/packages/fuselage/fuselage.api.md
+++ b/packages/fuselage/fuselage.api.md
@@ -573,9 +573,6 @@ export function EmailInput(props: EmailInputProps): JSX.Element;
 // @public (undocumented)
 export type EmailInputProps = Omit<InputBoxProps<HTMLInputElement>, 'type'>;
 
-// @public (undocumented)
-export type Falsy = false | 0 | '' | null | undefined;
-
 // @public
 export function Field(props: FieldProps): JSX.Element;
 
@@ -2660,13 +2657,6 @@ export function UrlInput(props: UrlInputProps): JSX.Element;
 export type UrlInputProps = Omit<InputBoxProps<HTMLInputElement>, 'type'>;
 
 // @public (undocumented)
-export const useArrayLikeClassNameProp: <T extends {
-    className?: string | cssFn | (string | cssFn | Falsy)[];
-}>(props: T) => T & {
-    className: string;
-};
-
-// @public (undocumented)
 export const useCursor: <T extends readonly [value: unknown, label: unknown, selected?: unknown, disabled?: unknown, type?: OptionType[4], url?: string] = OptionType>(initial: number, options: Array<T>, onChange: (option: T, visibilityHandler: VisibilityHandler) => void) => [cursor: number, handleKeyDown: (e: KeyboardEvent_2) => void, handleKeyUp: (e: KeyboardEvent_2) => void, reset: () => void, visibilityHandler: VisibilityHandler];
 
 // @public (undocumented)
@@ -2692,6 +2682,10 @@ show: () => void
 
 // @public (undocumented)
 export type VisibilityType = 'hidden' | 'visible' | 'hiding' | 'unhiding' | undefined;
+
+// Warnings were encountered during analysis:
+//
+// src/components/Box/Box.tsx:32:5 - (ae-forgotten-export) The symbol "Falsy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/fuselage/src/index.ts
+++ b/packages/fuselage/src/index.ts
@@ -5,5 +5,3 @@ export * from './styleTokens';
 export * from './contexts';
 
 export { Palette, __setThrowErrorOnInvalidToken__, Var } from './Theme';
-export { useArrayLikeClassNameProp } from './hooks/useArrayLikeClassNameProp';
-export type { Falsy } from './types/Falsy';


### PR DESCRIPTION
## Proposed changes

Removes `useArrayLikeClassNameProp` and the `Falsy` type from the `@rocket.chat/fuselage` public entry point. Both are internal helpers, used only by `Box` and `StylingBox`; the modules themselves are untouched and keep working internally.

Follow-up to #2167.

### Note

The API report now carries an api-extractor warning:

```
src/components/Box/Box.tsx:32:5 - (ae-forgotten-export) The symbol "Falsy" needs to be exported by the entry point index.d.ts
```

`Falsy` is still referenced by `Box`'s public `className` prop type, so un-exporting it leaves a dangling reference in the generated declarations. If that warning shouldn't stand, the alternatives are inlining the union in `Box`'s prop type or keeping `Falsy` exported.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change): two previously public exports are gone.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/fuselage/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)