### PR TITLE
a11y(fuselage): make PasswordInput visibility toggle keyboard accessible

### DIFF
--- a/packages/fuselage/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/fuselage/src/components/PasswordInput/PasswordInput.tsx
@@ -1,9 +1,7 @@
 import { useToggle } from '@rocket.chat/fuselage-hooks';
 
-import { Icon } from '../Icon';
+import { IconButton } from '../Button';
 import { InputBox, type InputBoxProps } from '../InputBox';
-
-// TODO: fix a11y issues
 
 export type PasswordInputProps = Omit<InputBoxProps<HTMLInputElement>, 'type'>;
 
@@ -17,9 +15,9 @@ function PasswordInput(props: PasswordInputProps) {
     <InputBox
       type={hidden ? 'password' : 'text'}
       endAddon={
-        <Icon
-          name={hidden ? 'eye-off' : 'eye'}
-          size={20}
+        <IconButton
+          icon={hidden ? 'eye-off' : 'eye'}
+          aria-label={hidden ? 'Show password' : 'Hide password'}
           onClick={handleAddonClick}
         />
       }


### PR DESCRIPTION
Fixes #2170

- replace the non-interactive icon with an accessible IconButton
- add an accessible label that changes between Show/Hide password
- preserve the existing password/text toggle behavior