### PR TITLE
fix(layout): Adapt `HorizontalWizardLayoutTitle` to smaller breakpoints

### DIFF
--- a/.changeset/horizontal-wizard-title-breakpoints.md
+++ b/.changeset/horizontal-wizard-title-breakpoints.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/layout': patch
+---
+
+fix(layout): Adapt `HorizontalWizardLayoutTitle` to viewports below the `md` breakpoint

--- a/packages/layout/src/components/FormPageLayout/FormPageLayout.styles.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormPageLayout.styles.tsx
@@ -98,16 +98,17 @@ export const TitleHighlight = styled(
   display: inline-block;
 `;
 
-const SubTitleFormPageProps = ({
-  fontColor: _fontColor,
-  fontWeight: _fontWeight,
-  ...props
-}: {
-  fontColor?: string;
-  fontWeight?: string;
-}) => props;
-
-export const Subtitle = styled('h2', SubTitleFormPageProps)`
+export const Subtitle = styled(
+  'h2',
+  ({
+    fontColor: _fontColor,
+    fontWeight: _fontWeight,
+    ...props
+  }: {
+    fontColor?: string;
+    fontWeight?: string;
+  }) => props,
+)`
   font-size: ${String(16 / 16)}rem;
   line-height: ${String(22 / 16)}rem;
   font-family: ${sans};

--- a/packages/layout/src/components/FormPageLayout/FormPageLayout.styles.tsx
+++ b/packages/layout/src/components/FormPageLayout/FormPageLayout.styles.tsx
@@ -1,5 +1,6 @@
 import styled from '@rocket.chat/styled';
 
+import { below } from '../../helpers/tokenBreakpoints';
 import { sans } from '../../helpers/tokenFontFamilies';
 
 export const Wrapper = styled('div')`
@@ -70,6 +71,12 @@ export const Title = styled('h1')`
   font-weight: 800;
   line-height: ${String(64 / 16)}rem;
   text-align: center;
+
+  @media ${below('md')} {
+    padding-block-end: 16px;
+    font-size: ${String(24 / 16)}rem;
+    line-height: ${String(32 / 16)}rem;
+  }
 
   @media (min-width: 1440px) {
     text-align: start;

--- a/packages/layout/src/helpers/tokenBreakpoints.ts
+++ b/packages/layout/src/helpers/tokenBreakpoints.ts
@@ -1,0 +1,12 @@
+import breakpoints from '@rocket.chat/fuselage-tokens/dist/breakpoints.json';
+
+type BreakpointName = keyof typeof breakpoints;
+
+const getMinViewportWidth = (name: BreakpointName): number =>
+  breakpoints[name].minViewportWidth ?? 0;
+
+export const from = (name: BreakpointName): string =>
+  `(min-width: ${getMinViewportWidth(name)}px)`;
+
+export const below = (name: BreakpointName): string =>
+  `(max-width: ${getMinViewportWidth(name) - 0.02}px)`;

--- a/packages/layout/src/layouts/HorizontalWizardLayout/__snapshots__/HorizontalWizardLayout.spec.tsx.snap
+++ b/packages/layout/src/layouts/HorizontalWizardLayout/__snapshots__/HorizontalWizardLayout.spec.tsx.snap
@@ -80,7 +80,7 @@ exports[`renders Default without crashing 1`] = `
             </div>
           </div>
           <h1
-            class="rcx-css-3fow2g"
+            class="rcx-css-qd3h7t"
           >
             Title
              
@@ -265,7 +265,7 @@ exports[`renders WithScroll without crashing 1`] = `
             </div>
           </div>
           <h1
-            class="rcx-css-3fow2g"
+            class="rcx-css-qd3h7t"
           >
             Title
           </h1>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->

`HorizontalWizardLayoutTitle` renders at `48px/64px` regardless of viewport, which dominates a phone screen on the login and registration pages.

The styled component under it — `FormPageLayout.Title` — now scales down below the `md` breakpoint:

| Property | `>= md` | `< md` |
| --- | --- | --- |
| `padding-block-end` | `32px` | `16px` |
| `font-size` | `3rem` (48px) | `1.5rem` (24px) |
| `line-height` | `4rem` (64px) | `2rem` (32px) |

The breakpoint bound is read from `@rocket.chat/fuselage-tokens` rather than hardcoded, via a new `tokenBreakpoints` helper that mirrors the existing `tokenFontFamilies` one:

```ts
import breakpoints from '@rocket.chat/fuselage-tokens/dist/breakpoints.json';

export const below = (name: BreakpointName): string =>
  `(max-width: ${getMinViewportWidth(name) - 0.02}px)`;
```

`md.minViewportWidth` is `768`, so the rule resolves to `@media (max-width: 767.98px)`. The `0.02px` offset closes the fractional-viewport gap between a `max-width` bound and the next `min-width` one.

<!-- END CHANGELOG -->

## Issue(s)

Motivated by RocketChat/Rocket.Chat#41127, which worked around this app-side by overriding the heading to `1.5rem/2rem` under `max-width: 767px`, targeted through the existing `#welcomeTitle` id. Fixing it here in the design system means that override can be dropped downstream, and every consumer of `HorizontalWizardLayout` gets the responsive title instead of just the login page.

## Further comments

- `FormPageLayout.Title` is shared with `VerticalWizardLayout` and `FormPageLayout`, so their titles scale down too. That is the intended reach — the 48px heading is oversized on a phone in every one of those layouts — but it is worth a reviewer's attention, since scoping it to the horizontal wizard alone would need a separate styled component.
- The helper also exports a `from()` counterpart for symmetry. It is currently unused; happy to drop it if you would rather not ship an unused export.
- The pre-existing `@media (min-width: 1440px)` blocks in this file are left untouched. `1440px` is not a token breakpoint (`xxl` is `1600`), so migrating those is a separate change.
- Two `HorizontalWizardLayout` snapshots were regenerated for the changed emitted class hash. The second commit is an unrelated no-op refactor inlining the `Subtitle` prop filter to match how `TitleHighlight` declares its own.

Lint, typecheck, and `packages/layout` tests (24 tests, 12 snapshots) pass locally. No visual regression run — this package has no VRT suite.
