### PR TITLE
fix(PasswordInput): improve visibility toggle accessibility

### DIFF
--- a/.changeset/fruity-snails-look.md
+++ b/.changeset/fruity-snails-look.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/fuselage': patch
+---
+
+Make PasswordInput visibility toggle keyboard accessible

--- a/packages/fuselage/src/components/PasswordInput/PasswordInput.spec.tsx
+++ b/packages/fuselage/src/components/PasswordInput/PasswordInput.spec.tsx
@@ -1,4 +1,6 @@
 import { composeStories } from '@storybook/react-webpack5';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import { render } from '../../testing';
@@ -18,5 +20,51 @@ describe('[PasswordInput Component]', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should toggle password visibility', async () => {
+    const user = userEvent.setup();
+
+    render(<Default />);
+
+    const button = screen.getByRole('button', { name: 'Show password' });
+
+    await user.click(button);
+
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should toggle password visibility with keyboard', async () => {
+    const user = userEvent.setup();
+
+    render(<Default />);
+
+    const button = screen.getByRole('button', { name: 'Show password' });
+
+    button.focus();
+
+    await user.keyboard('{Enter}');
+
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should toggle password visibility with Space', async () => {
+    const user = userEvent.setup();
+
+    render(<Default />);
+
+    const button = screen.getByRole('button', { name: 'Show password' });
+
+    button.focus();
+
+    await user.keyboard('{Space}');
+
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/fuselage/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/fuselage/src/components/PasswordInput/PasswordInput.tsx
@@ -1,9 +1,7 @@
 import { useToggle } from '@rocket.chat/fuselage-hooks';
 
-import { Icon } from '../Icon';
+import { IconButton } from '../Button';
 import { InputBox, type InputBoxProps } from '../InputBox';
-
-// TODO: fix a11y issues
 
 export type PasswordInputProps = Omit<InputBoxProps<HTMLInputElement>, 'type'>;
 
@@ -17,9 +15,10 @@ function PasswordInput(props: PasswordInputProps) {
     <InputBox
       type={hidden ? 'password' : 'text'}
       endAddon={
-        <Icon
-          name={hidden ? 'eye-off' : 'eye'}
-          size={20}
+        <IconButton
+          icon={hidden ? 'eye-off' : 'eye'}
+          small
+          aria-label={hidden ? 'Show password' : 'Hide password'}
           onClick={handleAddonClick}
         />
       }


### PR DESCRIPTION
## Summary

Fixes the accessibility of the `PasswordInput` visibility toggle.

* Replaces the non-interactive `Icon` with an `IconButton`
* Adds an accessible name that changes between `Show password` and `Hide password`
* Preserves the existing toggle behavior and sizing
* Adds regression tests for mouse, Enter, and Space keyboard activation
* Adds a patch changeset for `@rocket.chat/fuselage`

## Testing

* Prettier: passed
* `git diff --check`: passed
* Jest: unable to run because the repository currently resolves Jest 30 with `ts-jest` 29, resulting in a `ts-jest` preset validation error
* Lint: unable to run because the repository lint tooling fails with a `zx` error under Node.js 24.19.0

The test and lint failures appear to be repository/tooling compatibility issues rather than failures in the changed code.

Fixes #2170
